### PR TITLE
copy some setup directions from core

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,48 @@ The DATA Act broker website is the front-end to the [DATA Act broker API](https:
 
 ## Development Set Up
 
-Make sure you have the latest version of gulp to ensure it can run the babel version of the `gulpfile`:
+To stand up a local copy of the DATA Act broker website, follow the directions below.
 
-```bash
-    $ npm install gulp && npm install gulp -g
-```
+Assumptions:
 
-Install dependencies:
+* You're able to install software on your machine.
+* You have git installed on your machine and are able to clone code repositories from GitHub. If this isn't the case, the easiest way to get started is to install [GitHub Desktop](https://desktop.github.com/ "GitHub desktop"), available for Windows or Mac.
+* You're familiar with opening a terminal on your machine and using the command line as needed.
 
-```bash
-    $ npm install
-```
+### Install Prerequisites and Code
 
-#### Configuration
+1. If you're not already running Node.js, download and run the installer for your operating system: [https://nodejs.org/en/](https://nodejs.org/en/ "Node.js installer").
 
-Three sample `GlobalConstants` files are provided: `sampleGlobalConstants_dev.js`, `sampleGlobalConstants_local.js`, and `sampleGlobalConstants_prod.js`. These sample files should be used as the basis of files named `GlobalConstants_dev.js`, `GlobalConstants_local.js`, and `GlobalConstants_prod.js` respectively.
+2. Use *npm* (Node's package manager, which is part of the Node.js install) to install the latest version of gulp. This is necessary for runing the babel version of the `gulpfile`):
+
+    ```bash
+        $ npm install gulp && npm install gulp -g
+    ```
+
+3. From the command line, clone the DATA Act web app repository from GitHub to your local machine:
+
+        $ git clone git@github.com:fedspendingtransparency/data-act-broker-web-app.git
+
+4. Switch to the alpha release version of the code:
+
+        $ git checkout v0.1.0-alpha
+
+5. Change to the `data-act-broker-web-app` directory that was created when you cloned the DATA Act web repository.
+
+6. Install the web application's package dependencies:
+
+        $ npm install
+
+
+### Create Configurations
+
+The `data-act-broker-web-app` folder provides three sample `GlobalConstants` files:
+
+ * `sampleGlobalConstants_dev.js`
+ * `sampleGlobalConstants_local.js`
+ * `sampleGlobalConstants_prod.js`.
+
+Use these sample files to create files named `GlobalConstants_dev.js`, `GlobalConstants_local.js`, and `GlobalConstants_prod.js` respectively.
 
 The sample files require you to provide values for:
 
@@ -34,6 +61,8 @@ The sample files require you to provide values for:
 Other fields, such as `LOCAL` and `DEV` should be left based on their sample values.
 
 ### Run gulp tasks:
+
+To start the DATA Act broker website, run the appropriate gulp task as specified below.
 
 For production:
 
@@ -61,7 +90,6 @@ This will start a development environment using Browserify to hot reload when ch
 
 In the top level directory, you will find `GlobalConstants_prod.js` and `GlobalConstants_dev.js` that you may use for any conditional, global constants, such as the API endpoint you'd like to point to in either given scenario.
 
-
 ## Full DATA Act Broker Setup
 
-For complete instructions on contributing to this project or running your own copy DATA Act broker, please refer to the [documentation in the DATA Act core responsitory](https://github.com/fedspendingtransparency/data-act-core/blob/master/doc/INSTALL.md "DATA Act broker installation guide").
+For instructions on contributing to this project or installing the DATA Act broker backend, please refer to the [documentation in the DATA Act core responsitory](https://github.com/fedspendingtransparency/data-act-core/blob/master/doc/INSTALL.md "DATA Act broker installation guide").


### PR DESCRIPTION
For your consideration, adding some text from the install docs over on the data act core repo. I'd added this text before we decided to keep the web app directions in this repo. If you think it works, would like to get it merged in before we strike it from core.

Mostly just added some clarifying info about installing node and cloning the repo.