### PR TITLE
replace ssh w/ https in git clone directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Assumptions:
 
 3. From the command line, clone the DATA Act web app repository from GitHub to your local machine:
 
-        $ git clone git@github.com:fedspendingtransparency/data-act-broker-web-app.git
+        $ git clone https://github.com/fedspendingtransparency/data-act-broker-web-app.git
 
 4. Switch to the alpha release version of the code. This is the latest stable release.
 


### PR DESCRIPTION
Based on feedback from a local install tester, better to instruct people to git clone using https.