### PR TITLE
Autoscroll to Validation Content

### DIFF
--- a/src/_scss/common.scss
+++ b/src/_scss/common.scss
@@ -436,11 +436,25 @@ a.list-group-item {
 	& .usa-da-top-head{
 		background: $color-base;
 		height: $top-header-height;
-			& li{
-				float: right;
+			ul.usa-da-top-head-menu {
 				list-style: none;
-				line-height: $top-header-height;
+				padding: 0;
+				margin: 0;
+				display: block;
+				float: right;
+				height: $top-header-height;
+			}
+			li.usa-da-top-head-menu-item {
+				list-style: none;
 				font-size: 1.2rem;
+				display: inline-block;
+				padding-left: 25px;
+				margin-top: 0.4rem;
+				margin-bottom: 0.4rem;
+
+				&:before {
+					content: '';
+				}
 				& a{
 					color:$color-gray;
 						&:hover, &:active, &:focus{
@@ -471,6 +485,7 @@ a.list-group-item {
 							padding: 0 10px;
 							& a {
 								color: $color-white;
+								font-size: 1.2rem;
 							}
 							&::before {
 								display: none;

--- a/src/js/components/SharedComponents/navigation/AdminButton.jsx
+++ b/src/js/components/SharedComponents/navigation/AdminButton.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import * as Icons from '../icons/Icons.jsx';
+
+export default class AdminButton extends React.Component {
+	constructor(props) {
+        super(props);
+    }
+	render() {
+
+
+		return (
+
+			<li className="usa-da-top-head-menu-item">
+	            <a className="logout usa-da-header-link usa-da-user-info" href="#/admin">Admin</a>
+	        </li>
+
+		);
+	}
+}

--- a/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
+++ b/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
 import { kGlobalConstants } from '../../../GlobalConstants.js';
 import NavbarTab from './NavbarTab.jsx';
 import UserButton from './UserButton.jsx';
+import AdminButton from './AdminButton.jsx';
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -42,17 +43,16 @@ export class Navbar extends React.Component {
         const context = this;
         const userText = this.props.session.user === '' ? '' : this.props.session.user.name;
 
-        if (this.props.session.admin) {
-            tabNames['Admin'] = 'admin';
-        }
-
-        let userButton = "";
+        let userButton = null;
         if (this.props.session.login == "loggedIn") {
             userButton = <UserButton buttonText={userText} logout={this.logout.bind(this)} />;
         }
 
+        let adminButton = null;
+        if (this.props.session.admin) {
+            adminButton = <AdminButton />
+        }
 
-        // TODO: Remove admin once redux is in place
         Object.keys(tabNames).map((key) => {
             headerTabs.push(<NavbarTab key={tabNames[key]} name={key} class={tabNames[key]} activeTabClassName={context.props.activeTab} />);
         });
@@ -68,7 +68,10 @@ export class Navbar extends React.Component {
                     <div className="row">
                         <div className="col-md-12 usa-da-top-head">
                             <div className="container">
-                                {userButton}
+                                <ul className="usa-da-top-head-menu">
+                                    {adminButton}
+                                    {userButton}
+                                </ul>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/SharedComponents/navigation/UserButton.jsx
+++ b/src/js/components/SharedComponents/navigation/UserButton.jsx
@@ -32,7 +32,7 @@ export default class UserButton extends React.Component {
 
 		return (
 
-			<li>
+			<li className="usa-da-top-head-menu-item">
 	            <a href="#" onClick={this.toggleDropdown.bind(this)} className="usa-da-header-link usa-da-user-info dropdown-toggle usa-da-icon"><Icons.User />{this.props.buttonText}</a>
 	            <ul className={"header-dropdown" + hideDropdown}>
 	                <li>

--- a/src/js/components/addData/AddDataContent.jsx
+++ b/src/js/components/addData/AddDataContent.jsx
@@ -54,7 +54,7 @@ export default class AddDataContent extends React.Component {
 
         return (
             <div>
-                <div className="usa-da-content-step-block">
+                <div className="usa-da-content-step-block" name="content-top">
                     <div className="container center-block">
                         <div className="row">
                             <Progress totalSteps={3} currentStep={this.state.progressStep} />

--- a/src/js/components/addData/AddDataPage.jsx
+++ b/src/js/components/addData/AddDataPage.jsx
@@ -4,6 +4,7 @@
 **/
 
 import React from 'react';
+import $ from 'jquery';
 import Navbar from '../SharedComponents/navigation/NavigationComponent.jsx';
 import AddDataHeader from './AddDataHeader.jsx';
 import AddDataMeta from './AddDataMeta.jsx';
@@ -14,6 +15,18 @@ import Footer from '../SharedComponents/FooterComponent.jsx';
 export default class AddDataPage extends React.Component {
     constructor(props) {
         super(props);
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.submission.meta.agency != this.props.submission.meta.agency) {
+            this.scrollToUpload();
+        }
+    }
+
+    scrollToUpload() {
+        $('body').animate({
+            scrollTop: $('[name=content-top]').offset().top
+        }, 500);
     }
 
     render() {

--- a/src/js/components/reviewData/ReviewDataButton.jsx
+++ b/src/js/components/reviewData/ReviewDataButton.jsx
@@ -4,10 +4,11 @@
  **/
 
 import React, { PropTypes } from 'react';
+import BaseIcon from '../SharedComponents/icons/BaseIcon.jsx';
 import * as Icons from '../SharedComponents/icons/Icons.jsx';
 
 const propTypes = {
-    icon: PropTypes.string,
+    icon: PropTypes.element,
     label: PropTypes.string
 };
 

--- a/src/js/components/reviewData/ReviewDataContent.jsx
+++ b/src/js/components/reviewData/ReviewDataContent.jsx
@@ -4,6 +4,7 @@
  **/
 
 import React, { PropTypes } from 'react';
+import $ from 'jquery';
 import { kGlobalConstants } from '../../GlobalConstants.js';
 import SubmitButton from '../SharedComponents/SubmitButton.jsx';
 import ReviewDataContentRow from './ReviewDataContentRow.jsx';
@@ -37,7 +38,9 @@ export default class ReviewDataContent extends React.Component {
         ReviewHelper.fetchStatus(this.props.submissionID)
             .then((data) => {
                 data.ready = true;
-                this.setState(data);
+                this.setState(data, () => {
+                    this.scrollToContent();
+                });
             })
             .catch((error) => {
                 console.log(error);
@@ -46,6 +49,12 @@ export default class ReviewDataContent extends React.Component {
 
     componentDidMount() {
         this.getSubmissionData();
+    }
+
+    scrollToContent() {
+        $('body').animate({
+            scrollTop: $('[name=content-top]').offset().top
+        }, 500);
     }
 
     render() {

--- a/src/js/components/reviewData/ReviewDataPage.jsx
+++ b/src/js/components/reviewData/ReviewDataPage.jsx
@@ -48,7 +48,7 @@ export default class ReviewDataPage extends React.Component {
                 <div className="usa-da-page-content">
                     <Navbar activeTab="addData"/>
                     <AddDataHeader />
-                    <div className="usa-da-content-step-block">
+                    <div className="usa-da-content-step-block" name="content-top">
                         <div className="container center-block">
                             <div className="row">
                                 <Progress totalSteps={3} currentStep={3} />

--- a/src/js/components/validateData/ValidateDataContent.jsx
+++ b/src/js/components/validateData/ValidateDataContent.jsx
@@ -4,6 +4,7 @@
  **/
 
 import React, { PropTypes } from 'react';
+import $ from 'jquery';
 import { kGlobalConstants } from '../../GlobalConstants.js';
 import ValidateDataFileComponent from './ValidateDataFileComponent.jsx';
 import SubmitButton from '../SharedComponents/SubmitButton.jsx';
@@ -23,6 +24,15 @@ export default class ValidateDataContent extends React.Component {
         super(props);
     }
 
+    componentDidMount() {
+        this.scrollToContent();
+    }
+
+    scrollToContent() {
+        $('body').animate({
+            scrollTop: $('[name=content-top]').offset().top
+        }, 500);
+    }
 
     render() {
         

--- a/src/js/components/validateData/ValidateDataContent.jsx
+++ b/src/js/components/validateData/ValidateDataContent.jsx
@@ -28,6 +28,12 @@ export default class ValidateDataContent extends React.Component {
         this.scrollToContent();
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.submission.state != "review" && this.props.submission.state == "review") {
+            this.scrollToContent();
+        }
+    }
+
     scrollToContent() {
         $('body').animate({
             scrollTop: $('[name=content-top]').offset().top

--- a/src/js/components/validateData/ValidateDataPage.jsx
+++ b/src/js/components/validateData/ValidateDataPage.jsx
@@ -146,7 +146,7 @@ export default class ValidateDataPage extends React.Component {
             <div>
                 <Navbar activeTab="addData"/>
                 <AddDataHeader />
-                <div className="usa-da-content-step-block">
+                <div className="usa-da-content-step-block" name="content-top">
                     <div className="container center-block">
                         <div className="row">
                             <Progress totalSteps={3} currentStep={2} />

--- a/src/js/components/validateData/validateValues/ValidateValuesContent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesContent.jsx
@@ -4,6 +4,7 @@
  **/
 
 import React, { PropTypes } from 'react';
+import $ from 'jquery';
 import { kGlobalConstants } from '../../../GlobalConstants.js';
 
 import { fileTypes } from '../../../containers/addData/fileTypes.js';
@@ -20,6 +21,15 @@ export default class ValidateValuesContent extends React.Component {
         super(props);
     }
 
+    componentDidMount() {
+        this.scrollToContent();
+    }
+
+    scrollToContent() {
+        $('body').animate({
+            scrollTop: $('[name=content-top]').offset().top
+        }, 500);
+    }
 
     render() {
 

--- a/src/js/components/validateData/validateValues/ValidateValuesContent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesContent.jsx
@@ -25,6 +25,12 @@ export default class ValidateValuesContent extends React.Component {
         this.scrollToContent();
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.submission.state != "review" && this.props.submission.state == "review") {
+            this.scrollToContent();
+        }
+    }
+
     scrollToContent() {
         $('body').animate({
             scrollTop: $('[name=content-top]').offset().top

--- a/src/js/components/validateData/validateValues/ValidateValuesOverlay.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesOverlay.jsx
@@ -42,17 +42,6 @@ export default class ValidateValuesOverlay extends React.Component {
 			uploadButtonClass = '';
 		}
 
-		let buttonText = 'Upload Corrected CSV Files';
-		if (this.props.submission.state == 'uploading') {
-			uploadButtonDisabled = true;
-			uploadButtonClass = '-disabled';
-			buttonText = 'Uploading files...';
-		}
-		else if (this.props.submission.state == 'prepare') {
-			uploadButtonDisabled = true;
-			uploadButtonDisabled = '-disabled';
-			buttonText = 'Gathering data...';
-		}
 
 		let message = 'You must fix the Critical Errors found in ' + this.props.errors.length + ' of the .CSV files before moving on to the next step. View and download individual reports above.';
 
@@ -69,6 +58,19 @@ export default class ValidateValuesOverlay extends React.Component {
 				uploadButtonClass = '';
 			}
 
+
+		}
+
+		let buttonText = 'Upload Corrected CSV Files';
+		if (this.props.submission.state == 'uploading') {
+			uploadButtonDisabled = true;
+			uploadButtonClass = '-disabled';
+			buttonText = 'Uploading files...';
+		}
+		else if (this.props.submission.state == 'prepare') {
+			uploadButtonDisabled = true;
+			uploadButtonDisabled = '-disabled';
+			buttonText = 'Gathering data...';
 		}
 
 

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -16,7 +16,6 @@ export const generateRSSUrl = () => {
 	const deferred = Q.defer();
 
 	Request.get(kGlobalConstants.API + 'get_rss/')
-		.withCredentials()
 		.send()
 		.end((err, res) => {
 			if (err) {


### PR DESCRIPTION
* After the initial Add Metadata page, page transitions to the upload, validate, and review data screens are accompanied by an automatic scroll down past the top header
* Autoscroll also occurs when the user stays on the same validation page, but uploads a new set of files
* Admin button was moved from the navbar to the top black bar next to the user name, per new designs
* Fixed a bug where the Upload Corrected CSVs button did not correctly disable during upload/`check_status` pending period if the user was uploading files after everything passed validation