### PR TITLE
Hotfix: Saner Gulp output

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
 		<meta charset="UTF-8" />
 		<meta http-equiv="X-Frame-Options" content="SAMEORIGIN" />
 		<title>DATA Act Broker</title>
-		<link rel="stylesheet" href="dev/css/main.css">
+		<link rel="stylesheet" href="css/main.css">
 	</head>
 	<body>
 		<div id="app"></div>
-		<script type="text/javascript" src="dev/app.js"></script>
-		<script type="text/javascript" src="dev/newrelic.js"></script>
+		<script type="text/javascript" src="app.js"></script>
+		<script type="text/javascript" src="newrelic.js"></script>
 	</body>
 </html>

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -5,9 +5,6 @@ import Request from './sessionSuperagent.js';
 
 export const fetchStaticAssetPath = () => {
 	let imgSrc = '';
-	if (kGlobalConstants.DEV) {
-    	imgSrc = 'dev/';
-	}
 	return imgSrc;
 };
 


### PR DESCRIPTION
* Gulp will now always output to `public/` and use the same folder structure, even in local dev environments
* This time merging into dev instead of master