### PR TITLE
Display account expired/locked out error messages

### DIFF
--- a/src/js/components/login/LoginPanel.jsx
+++ b/src/js/components/login/LoginPanel.jsx
@@ -49,11 +49,7 @@ export default class LoginPanel extends React.Component {
         let errorMessageComponent = null;
 
         if (this.props.session.login == "failed") {
-            errorMessageComponent = <ErrorMessage message={"Username or password is incorrect"} />;
-
-            if (this.props.cookieError) {
-                errorMessageComponent = <ErrorMessage message={"Browser cookie support is required to access this site. Enable cookies on your browser to continue."} />;
-            }
+            errorMessageComponent = <ErrorMessage message={this.props.errorMessage} />;
         }
 
 

--- a/src/js/containers/login/LoginContainer.jsx
+++ b/src/js/containers/login/LoginContainer.jsx
@@ -20,7 +20,7 @@ class LoginContainer extends React.Component {
 
 		this.state = {
 			loading: false,
-			cookieError: false
+			errorMessage: ""
 		};
 	}
 	performLogin(username, password) {
@@ -33,12 +33,13 @@ class LoginContainer extends React.Component {
 				if (err == "cookie") {
 					this.setState({
 						loading: false,
-						cookieError: true
+						errorMessage: 'Browser cookie support is required to access this site. Enable cookies on your browser to continue.'
 					});
 				}
 				else {
 					this.setState({
-						loading: false
+						loading: false,
+						errorMessage: err
 					});
 				}
 			})
@@ -46,7 +47,7 @@ class LoginContainer extends React.Component {
 	render() {
 
 		return (
-			<LoginPanel {...this.props} performLogin={this.performLogin.bind(this)} loading={this.state.loading} cookieError={this.state.cookieError} />
+			<LoginPanel {...this.props} performLogin={this.performLogin.bind(this)} loading={this.state.loading} errorMessage={this.state.errorMessage} />
 		);
 	}
 }

--- a/src/js/helpers/loginHelper.js
+++ b/src/js/helpers/loginHelper.js
@@ -72,7 +72,14 @@ export const performLogin = (username, password) => {
 
 					// unset the login state cookie
 	                Cookies.remove('brokerLogin');
-					deferred.reject(err);
+
+	                // if a message is available, display that
+	                if (res.body && res.body.hasOwnProperty('message')) {
+						deferred.reject(res.body.message);
+					}
+					else {
+						deferred.reject(err);
+					}
 				} else {
 					// set the login state cookie that expires in 15 minutes
 					Cookies.set('brokerLogin', Date.now(), {expires: (1/(24*4))});


### PR DESCRIPTION
* Display login error messages using the server's `message` value, when available
* Continue to display an error message if the browser doesn't write the session cookie