### PR TITLE
Help Page Markdown

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -177,6 +177,13 @@ gulp.task('copyAssets', ['copyConstants'], () => {
                 gutil.log('CSS copied');
             }),
 
+        // copy markdown files
+        gulp.src(dir.SRC + '/help/**/*.md')
+            .pipe(gulp.dest(dir.PUBLIC + '/help'))
+            .on('end', () => {
+                gutil.log('Markdown copied');
+            }),
+
         // copy the main index file
         gulp.src('./index.html')
             .pipe(gulp.dest(dir.PUBLIC))

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -307,17 +307,27 @@ gulp.task('minify', ['build'], () => {
 // after minifying, change the HTML script tag to point to the minified file
 gulp.task('modifyHtml', ['minify'], () => {
     return gulp.src(dir.PUBLIC + '/index.html')
-        .pipe(replace(path.OUT, path.MINIFIED_OUT))
+        // replace the app.js script reference with one that points to the minified file
+        // add in a ?v=[git hash] param to override browser caches when a new version is deployed
+        .pipe(replace(path.OUT, path.MINIFIED_OUT + '?v=' + commitHash))
+        // now do the same thing (without minification) for the CSS file
+        .pipe(replace('main.css', 'main.css?v=' + commitHash))
         .pipe(gulp.dest(dir.PUBLIC));
 });
 
 
 // serve the frontend locally
 gulp.task('serve', serverDeps, () => {
+
+    let reload = true;
+    if (environment == environmentTypes.LOCAL) {
+        reload = false;
+    }
+
     connect.server({
         root: dir.PUBLIC,
         port: 3000,
-        livereload: true
+        livereload: reload
     });
 });
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "js-cookie": "^2.1.0",
     "jsdom": "^8.1.0",
     "lodash": "^4.6.1",
+    "markdown": "^0.5.0",
     "merge-stream": "^1.0.0",
     "mocha": "^2.4.5",
     "mocha-junit-reporter": "^1.10.0",

--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -1,0 +1,38 @@
+In this version of the broker, we have made a change if you are logging in with Internet Explorer, added funtionality for the Broker to recognize files with the pipe symbol as a delimiter, and updated some of the validations.
+
+* [Logging into the Broker with Internet Explorer](#/help?section=brokerIE)
+* [Submit Files with Pipe Symbol](#/help?section=pipe)
+* [File Validations per RSS v1.0](#/help?section=fileValv1)
+* [Cross File Validations](#/help?section=crossFileValv1)
+* [Browser Requirements & Known Issues](#/help?section=browser)
+
+#### Logging into the Broker with Internet Explorer{section=brokerIE}
+During user testing, some Internet Explorer users were unable to log into the Broker and upload files. We implemented a workaround so users with Internet Explorer on __medium security settings__ can log in and upload files. See Known Issues below.
+
+#### Submit File with Pipe Symbol{section=pipe}
+Based on user feedback, we changed the Broker to automatically detect whether a file is using a comma or pipe symbol as a delimiter, based on the format of the header row.
+
+#### File Validations per RSS v1.0{section=fileValv1}
+Submitted files will be validated per RSS v1.0. Specifically:
+
+* Field names match the RSS v1.0
+* Maximum field length does not exceed the value in RSS v1.0
+* Required fields are present per RSS v1.0
+* Records in File C have a PIID, FAIN, or URI
+
+#### Cross File Validations{section=crossFileValv1}
+We started work on cross file validations, beginning with cross validation of the FAIN, URI or PIID between sample files for Files C and D2.
+
+#### Browser Requirements & Known Issues{section=browser}
+The Broker is currently tested with the following browsers:
+
+* Internet Explorer version 10 and higher
+* Firefox (current version)
+* Chrome (current version)
+* Safari (current version)
+
+Although you may use any browser/version combination you wish, we cannot support browsers and versions other than the ones stated above.
+
+Known Issues
+
+* The Broker will not work when using Internet Explorer under medium privacy settings or high security settings.

--- a/src/js/components/help/helpContent.jsx
+++ b/src/js/components/help/helpContent.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import $ from 'jquery';
 import { generateRSSUrl } from '../../helpers/util.js';
 
+
 let gifSrc = 'graphics/reportabug.gif';
 
 export default class HelpContent extends React.Component {
@@ -22,7 +23,6 @@ export default class HelpContent extends React.Component {
     }
 
     componentDidMount() {
-        this.scrollToSection();
         this.rssPromise = generateRSSUrl();
         this.rssPromise.promise
             .then((url) => {
@@ -58,69 +58,9 @@ export default class HelpContent extends React.Component {
                 <p>Welcome to the DATA Act Broker – Alpha Release. This release is a <a href="https://en.wikipedia.org/wiki/Minimum_viable_product" target="_blank">Minimum Viable Product</a> and represents just enough functionality so that we can gather critical user feedback to determine the direction and implementation of future features. This version of the Broker aligns with <a href={this.state.rssUrl} target="_blank">Reporting Submission Specification (RSS v1.0)</a>.</p>
 
                 <h2>What's New in This Release</h2>
-        
-                <p>In this version of the broker, we have made a change if you are logging in with Internet Explorer, added funtionality for the Broker to recognize files with the pipe symbol as a delimiter, and updated some of the validations.</p>
                 
-                <ul>
-                    <li>
-                        <a href="/#/help?section=brokerIE">Logging into the Broker with Internet Explorer</a>
-                    </li>
-                    <li>
-                        <a href="/#/help?section=pipe">Submit Files with Pipe Symbol</a>
-                    </li>
-                    <li>
-                        <a href="/#/help?section=fileValv1">File Validations per RSS v1.0</a>
-                    </li>
-                     <li>
-                        <a href="/#/help?section=crossFileValv1">Cross File Validations</a>
-                    </li>
-              
-                    <li>
-                        <a href="/#/help?section=browser">Browser Requirements &amp; Known Issues</a>
-                    </li>
-                </ul>
-
-                <h4 name="brokerIE">Logging into the Broker with Internet Explorer</h4>
-                <p>During user testing, some Internet Explorer users were unable to log into the Broker and upload files. We implemented a workaround so users with Internet Explorer on <b>medium security settings</b> can log in and upload files. See Known Issues below.</p>
-
-                <h4 name="pipe">Submit File with Pipe Symbol</h4>
-                <p>Based on user feedback, we changed the Broker to automatically detect whether a file is using a comma or pipe symbol as a delimiter, based on the format of the header row.</p>
-
-                <h4 name="fileValv1">File Validations per RSS v1.0</h4>
-                <p>Submitted files will be validated per RSS v1.0. Specifically:
-                <ul>
-                <li>Field names match the RSS v1.0
-                </li>
-                <li>Maximum field length does not exceed the value in RSS v1.0
-                </li>
-                <li>Required fields are present per RSS v1.0
-                </li>
-                <li>Records in File C have a PIID, FAIN, or URI
-                </li>
-                </ul>
-                </p>
+                <div dangerouslySetInnerHTML={{__html:this.props.changelog}} />
                 
-                <h4 name="crossFileValv1">Cross File Validations</h4>
-                <p>We started work on cross file validations, beginning with cross validation of the FAIN, URI or PIID between sample files for Files C and D2.</p>
-
-                <h4 name="browser">Browser Requirements &amp; Known Issues</h4>
-
-                <p>The Broker is currently tested with the following browsers:</p>
-
-                <ul>
-                    <li>Internet Explorer version 10 and higher</li>
-                    <li>Firefox (current version)</li>
-                    <li>Chrome (current version)</li>
-                    <li>Safari (current version)</li>
-                </ul>
-
-                <p>Although you may use any browser/version combination you wish, we cannot support browsers and versions other than the ones stated above.</p>
-                <p>Known Issues
-                <ul>
-                <li>The Broker will not work when using Internet Explorer under medium privacy settings or high security settings.
-                </li>
-                </ul>
-                </p>
                 <h2>Getting More Help</h2>
 
                 <h4 name="filingIssue">Filing an Issue</h4>

--- a/src/js/components/help/helpPage.jsx
+++ b/src/js/components/help/helpPage.jsx
@@ -9,7 +9,35 @@ import HelpSidebar from './helpSidebar.jsx';
 import HelpContent from './helpContent.jsx';
 import Footer from '../SharedComponents/FooterComponent.jsx';
 
+import * as HelpHelper from '../../helpers/helpHelper.js';
+
 export default class HelpPage extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            changelog: '',
+            sections: []
+        };
+    }
+
+    componentDidMount() {
+        this.loadChangelog();
+    }
+
+    loadChangelog() {
+        HelpHelper.loadChangelog()
+            .then((output) => {
+                console.log(output);
+                this.setState({
+                    changelog: output.html,
+                    sections: output.sections
+                });
+            })
+            .catch((err) => {
+                console.log(err);
+            });
+    }
 
     render() {
         return (
@@ -28,10 +56,10 @@ export default class HelpPage extends React.Component {
                     <div className="container">
                         <div className="row usa-da-help-page">
                             <div className="col-md-4">
-                                <HelpSidebar />
+                                <HelpSidebar sections={this.state.sections} />
                             </div>
                             <div className="col-md-8">
-                                <HelpContent section={this.props.location.query.section} />
+                                <HelpContent section={this.props.location.query.section} changelog={this.state.changelog} />
                             </div>
                         </div>
                     </div>

--- a/src/js/components/help/helpPage.jsx
+++ b/src/js/components/help/helpPage.jsx
@@ -28,7 +28,6 @@ export default class HelpPage extends React.Component {
     loadChangelog() {
         HelpHelper.loadChangelog()
             .then((output) => {
-                console.log(output);
                 this.setState({
                     changelog: output.html,
                     sections: output.sections

--- a/src/js/components/help/helpSidebar.jsx
+++ b/src/js/components/help/helpSidebar.jsx
@@ -4,28 +4,19 @@
  **/
 
 import React from 'react';
+import HelpSidebarItem from './helpSidebarItem.jsx';
 
 export default class HelpSidebar extends React.Component {
     render() {
+        const sectionList = this.props.sections.map((section, index) => {
+            return <HelpSidebarItem key={index} sectionName={section.name} sectionId={section.link} />
+        });
+
         return (
             <div className="usa-da-help-sidebar">
                 <h6>What’s New in This Release</h6>
                 <ul>
-                    <li>
-                        <a href="/#/help?section=brokerIE">Logging into the Broker with Internet Explorer</a>
-                    </li>
-                    <li>
-                        <a href="/#/help?section=pipe">Submit Files with Pipe Symbol</a>
-                    </li>
-                    <li>
-                        <a href="/#/help?section=fileValv1">File Validations per RSS v1.0</a>
-                    </li>
-                    <li>
-                        <a href="/#/help?section=crossFileValv1">Cross File Validations</a>
-                    </li>
-                    <li>
-                        <a href="/#/help?section=browser">Browser Requirements &amp; Known Issues</a>
-                    </li>
+                    {sectionList}
                 </ul>
                 <h6>Getting More Help</h6>
                 <ul>

--- a/src/js/components/help/helpSidebarItem.jsx
+++ b/src/js/components/help/helpSidebarItem.jsx
@@ -1,0 +1,18 @@
+/**
+  * helpSidebarItem.jsx
+  * Created by Kevin li 5/26/16
+  **/
+
+import React from 'react';
+
+export default class HelpSidebarItem extends React.Component {
+	render() {
+		return (
+			<li>
+                <a href={"/#/help?section=" + this.props.sectionId}>
+                	{this.props.sectionName}
+                </a>
+            </li>
+		)
+	}
+}

--- a/src/js/helpers/helpHelper.js
+++ b/src/js/helpers/helpHelper.js
@@ -1,0 +1,73 @@
+import Request from './sessionSuperagent.js';
+import Q from 'q';
+import Markdown from 'markdown';
+
+const parseMarkdown = (rawText) => {
+	const md = Markdown.markdown;
+
+	// generate a tree of the incoming markdown
+	const tree = md.parse(rawText);
+
+	const sectionList = [];
+
+	// look for section headers
+	tree.forEach((element) => {
+		if (Array.isArray(element)) {
+			const type = element[0];
+			const attributes = element[1];
+			const value = element[2];
+			if (type == "header") {
+
+				// found a header, look for the section markdown attribute
+				const regex = /{section=[a-zA-Z0-9]+}/;
+
+				const results = regex.exec(value);
+				if (results.length > 0) {
+					// get the section URL name by substringing the section markdown
+					const nameValue = results[0].substring(9, results[0].length - 1);
+
+					// save it as an HTML attribute
+					attributes.name = nameValue;
+					element[1] = attributes;
+
+					// replace the section link markdown with an empty string
+					element[2] = value.replace(regex, '');
+
+					// also add it as a sidebar item
+					sectionList.push({
+						link: nameValue,
+						name: element[2]
+					});
+				}
+
+			}
+		}
+	});
+
+	const output = {
+		html: md.renderJsonML(md.toHTMLTree(tree)),
+		sections: sectionList
+	};
+
+	return output;
+}
+
+export const loadChangelog = () => {
+
+	const deferred = Q.defer();
+
+	Request.get('/help/changelog.md')
+	        .send()
+	        .end((err, res) => {
+	        	if (err) {
+	        		deferred.reject(err);
+	        	}
+	        	else {
+	        		const output = parseMarkdown(res.text);
+	        		deferred.resolve(output);
+	        	}
+
+	        });
+
+	return deferred.promise;
+}


### PR DESCRIPTION
* Help page "What's New" section is now populated from a Markdown file
* Help page side bar "What's New" links are now dynamically generated based on section headers in the Markdown file
* Customized Markdown parser to handle special metadata in the section headers
* Changes to the Gulp task:
    * Local production mode no longer has live reloading (uses less memory, no more web sockets)
    * Production mode (local and hosted) now use appended `?v=[git hash]` CSS and app.js URLs in index.html file to invalidate browser caches when a new build is available