### PR TITLE
Help update of items from sprint 14

### DIFF
--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -1,16 +1,12 @@
 #### June 15, 2016
 
-In this version of the Broker, we added an indicator of when your data was last saved, made it easier to select your agency, made it easier to submit your data without errors, updated some of the validations, and identified another issue. 
+In this version of the Broker, we made it easier to select your agency, made it easier to submit your data without errors, and updated some of the validations. 
 
-  - [Time Data Last Saved](#/help?section=lastSaved)
   - [Easier Agency Selection](#/help?section=agencyCGAC)
   - [Accidental Commas in Dollar Amounts](#/help?section=removeCommas)
   - [Header Row Capitalization Errors](#/help?section=elementCaps)
   - [Updated Validations](#/help?section=updatedValidations)
   - [Browser Requirements & Known Issues](#/help?section=browser)
-
-#### Time Data last Saved{section=lastSaved}
-The Broker automatically saves your files when you upload them and at each step of the validation process. The time the data was last saved is displayed at the top of the broker below the Help menu.
 
 #### Easier Agency Selection{section=agencyCGAC}
 When you register for an account or create a submission, you can enter your CGAC code to correctly select your agency.
@@ -154,5 +150,4 @@ Although you may use any browser/version combination you wish, we cannot support
 
 Known Issues
 
-* Proxy issue
 * The Broker will not work when using Internet Explorer under medium privacy settings or high security settings.

--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -1,28 +1,174 @@
-#### June 8, 2016
+#### June 15, 2016
+
+In this version of the Broker, we added an indicator of when your data was last saved, made it easier to select your agency, made it easier to submit your data without errors, updated some of the validations, and identified another issue. 
+
+  - [Time Data Last Saved](#/help?section=lastSaved)
+  - [Easier Agency Selection](#/help?section=agencyCGAC)
+  - [Accidental Commas in Dollar Amounts](#/help?section=removeCommas)
+  - [Header Row Capitalization Errors](#/help?section=elementCaps)
+  - [Updated Validations](#/help?section=updatedValidations)
+  - [Browser Requirements & Known Issues](#/help?section=browser)
+
+#### Time Data last Saved{section=lastSaved}
+The Broker automatically saves your files when you upload them and at each step of the validation process. The time the data was last saved is displayed at the top of the broker below the Help menu.
+
+#### Easier Agency Selection{section=agencyCGAC}
+When you register for an account or create a submission, you can enter your CGAC code to correctly select your agency.
+
+#### Accidental Commas in Dollar Amounts{section=removeCommas}
+The Practices and Procedures document specifies that dollar amounts should be submitted without commas. However, if you accidentally include commas in dollar amounts the Broker will remove them.
+
+#### Header Row Capitalization Errors{section=elementCaps}
+The Practices and Procedures document specifies that the element names in the header row should exactly match the RSS element names. However, to assist you the Broker will process files with incorrect element name capitalization.
+
+#### Updated Validations{section=updatedValidations}
+Below is a cumulative table of validations implemented to date.
+
+<table className="usa-da-table table-bordered">
+<thead>
+<tr>
+<th scope="col">Relates to Files</th>
+<th scope="col">Rule Name</th>
+<th scope="col">Rule Detail</th>
+<th scope="col">Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr><td>A/B/C</td>
+<td>A1</td>
+<td>TAS components: The combination of all the elements that make up the TAS must match the Treasury Central Accounting Reporting System (CARS). AgencyIdentifier, MainAccountCode, and SubAccountCode are always required. AllocationTransferAgencyIdentifier, BeginningPeriodOfAvailability, EndingPeriodOfAvailability and AvailabilityTypeCode are required if present in the CARS table.</td>
+<td>TAS must be valid</td>
+</tr>
+<tr><td>A</td>
+<td>A2</td>
+<td>BudgetAuthorityAvailableAmountTotal_CPE = BudgetAuthorityAppropriatedAmount_CPE + BudgetAuthorityUnobligatedBalanceBroughtForward_FYB + AdjustmentsToUnobligatedBalanceBroughtForward_CPE + OtherBudgetaryResourcesAmount_CPE</td>
+<td>Calculation</td>
+</tr>
+<tr><td>A</td>
+<td>A3</td>
+<td>OtherBudgetaryResourcesAmount_CPE = ContractAuthorityAmountTotal_CPE + BorrowingAuthorityAmountTotal_CPE + SpendingAuthorityfromOffsettingCollectionsAmountTotal_CPE</td>
+<td>Calculation</td>
+</tr>
+<tr><td>A</td>
+<td>A4</td>
+<td>StatusOfBudgetaryResourcesTotal_CPE= ObligationsIncurredTotalByTAS_CPE + UnobligatedBalance_CPE</td>
+<td>Calculation</td>
+</tr>
+<tr><td>A</td>
+<td>A21</td>
+<td>Only acceptable values are x and [blank]</td>
+<td>Requirement for availability type codes</td>
+</tr>
+<tr><td>A</td>
+<td>A24</td>
+<td>StatusOfBudgetaryResourcesTotal_CPE = BudgetAuthorityAvailableAmountTotal_CPE</td>
+<td>In File A, both of these elements must match, per TAS</td>
+</tr>
+<tr><td>B</td>
+<td>B3</td>
+<td>ObligationsUndeliveredOrdersUnpaidTotal (FYB or CPE) = USSGL(4801 + 4831 + 4871 + 4881). This applies to the program activity and object class level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>B</td>
+<td>B4</td>
+<td>ObligationsDeliveredOrdersUnpaidTotal (FYB or CPE) = USSGL(4901 + 4931 + 4971 + 4981). This applies to the program activity and object class level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>B</td>
+<td>B5</td>
+<td>GrossOutlayAmountByProgramObjectClass (FYB or CPE, File B) = GrossOutlaysUndeliveredOrdersPrepaidTotal (FYB or CPE, File B) + GrossOutlaysDeliveredOrdersPaidTotal (FYB or CPE, File B)</td>
+<td>Calculation</td>
+</tr>
+<tr><td>B</td>
+<td>B6</td>
+<td>GrossOutlaysUndeliveredOrdersPrepaidTotal (FYB or CPE) = USSGL(4802 + 4832 + 4872+ 4882). This applies to the program activity and object class level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>B</td>
+<td>B7</td>
+<td>GrossOutlaysDeliveredOrdersPaidTotal (FYB or CPE)= USSGL(4902 + 4908 + 4972 + 4982). This applies to the program activity and object class level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>B</td>
+<td>B13</td>
+<td>DeobligationsRecoveriesRefundsdOfPriorYearByProgramObjectClass_CPE = USSGL(4871+ 4872 + 4971 + 4972)</td>
+<td>Calculation</td>
+</tr>
+<tr><td>C</td>
+<td>C3</td>
+<td>ObligationsUndeliveredOrdersUnpaidTotal (FYB or CPE) = USSGL(4801 + 4831 + 4871 + 4881). This applies to the award level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>C</td>
+<td>C4</td>
+<td>ObligationsDeliveredOrdersUnpaidTotal (FYB or CPE) = USSGL(4901 + 4931 + 4971 + 4981). This applies to the award level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>C</td>
+<td>C5</td>
+<td>GrossOutlayAmountByAward (FYB or CPE, File C) = GrossOutlaysUndeliveredOrdersPrepaidTotal (FYB or CPE, File C) + GrossOutlaysDeliveredOrdersPaidTotal (FYB or CPE, File C)</td>
+<td>Calculation</td>
+</tr>
+<tr><td>C</td>
+<td>C6</td>
+<td>GrossOutlaysUndeliveredOrdersPrepaidTotal (FYB or CPE) = USSGL(4802 + 4832 + 4872+ 4882). This applies to the award level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>C</td>
+<td>C7</td>
+<td>GrossOutlaysDeliveredOrdersPaidTotal (FYB or CPE) = USSGL(4902 + 4908 + 4972 + 4982). This applies to the award level.</td>
+<td>Calculation</td>
+</tr>
+<tr><td>C</td>
+<td>C8</td>
+<td>Unique FAIN/URI from file C exists in file D2</td>
+<td>Linkage</td>
+</tr>
+<tr><td>C/D2</td>
+<td>C9</td>
+<td>Unique FAIN/URI from file D2 exists in file C, except D2 records with zero FederalActionObligation</td>
+<td>Linkage</td>
+</tr>
+<tr><td>C/D1</td>
+<td>C14</td>
+<td>If FAIN is not provided then provide URI </td>
+<td> </td>
+</tr>
+<tr><td>C</td>
+<td>C17</td>
+<td>Not Required on rows that include values for USSGL accounts balances or subtotals</td>
+<td>This is for transactions, not for USSGL amounts, from the financial systems.</td>
+</tr>
+</tbody>
+</table>
+
+#### What's New in This Release - June 1, 2016
+In this version of the broker, we have added some information on the screens to help you with your data submission, added some functionality to help you select the reporting period, and updated some of the validations. __Note:__ Validation details are included in the cumulative updated validations table.
+
+#### Step-by-Step Guide on the Broker Home Page
+When you log into the Broker, you will see three choices that guide you to _Upload and validate a new submission_, _Continue with an existing submission_, and _Review, certify, and publish a submission_.
+
+#### Submission Guide
+The Submission Guide provides details of the four steps to submit your agency's data. Once you have reviewed this page, you can check a box to hide this page the next time you log into the Broker.
+        
+#### Select Reporting Period
+Based on user feedback, the quarterly submission dates are displayed as the quarter number and the fiscal year. Example: Quarter 2 - 2016.
+
+#### What's New in This Release - May 17, 2016
 In this version of the broker, we have made a change if you are logging in with Internet Explorer, added funtionality for the Broker to recognize files with the pipe symbol as a delimiter, and updated some of the validations.
 
-* [Logging into the Broker with Internet Explorer](#/help?section=brokerIE)
-* [Submit Files with Pipe Symbol](#/help?section=pipe)
-* [File Validations per RSS v1.0](#/help?section=fileValv1)
-* [Cross File Validations](#/help?section=crossFileValv1)
-* [Browser Requirements & Known Issues](#/help?section=browser)
-
-#### Logging into the Broker with Internet Explorer{section=brokerIE}
+#### Logging into the Broker with Internet Explorer
 During user testing, some Internet Explorer users were unable to log into the Broker and upload files. We implemented a workaround so users with Internet Explorer on __medium security settings__ can log in and upload files. See Known Issues below.
 
-#### Submit File with Pipe Symbol{section=pipe}
+#### Submit File with Pipe Symbol
 Based on user feedback, we changed the Broker to automatically detect whether a file is using a comma or pipe symbol as a delimiter, based on the format of the header row.
 
-#### File Validations per RSS v1.0{section=fileValv1}
+#### File Validations per RSS v1.0
 Submitted files will be validated per RSS v1.0. Specifically:
-
 * Field names match the RSS v1.0
 * Maximum field length does not exceed the value in RSS v1.0
 * Required fields are present per RSS v1.0
-* Records in File C have a PIID, FAIN, or URI
-
-#### Cross File Validations{section=crossFileValv1}
-We started work on cross file validations, beginning with cross validation of the FAIN, URI or PIID between sample files for Files C and D2.
+* Records in File C have a PIID, FAIN, or URI    
 
 #### Browser Requirements & Known Issues{section=browser}
 The Broker is currently tested with the following browsers:
@@ -36,4 +182,5 @@ Although you may use any browser/version combination you wish, we cannot support
 
 Known Issues
 
+* Proxy issue
 * The Broker will not work when using Internet Explorer under medium privacy settings or high security settings.

--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -142,34 +142,6 @@ Below is a cumulative table of validations implemented to date.
 </tbody>
 </table>
 
-#### What's New in This Release - June 1, 2016
-In this version of the broker, we have added some information on the screens to help you with your data submission, added some functionality to help you select the reporting period, and updated some of the validations. __Note:__ Validation details are included in the cumulative updated validations table.
-
-#### Step-by-Step Guide on the Broker Home Page
-When you log into the Broker, you will see three choices that guide you to _Upload and validate a new submission_, _Continue with an existing submission_, and _Review, certify, and publish a submission_.
-
-#### Submission Guide
-The Submission Guide provides details of the four steps to submit your agency's data. Once you have reviewed this page, you can check a box to hide this page the next time you log into the Broker.
-        
-#### Select Reporting Period
-Based on user feedback, the quarterly submission dates are displayed as the quarter number and the fiscal year. Example: Quarter 2 - 2016.
-
-#### What's New in This Release - May 17, 2016
-In this version of the broker, we have made a change if you are logging in with Internet Explorer, added funtionality for the Broker to recognize files with the pipe symbol as a delimiter, and updated some of the validations.
-
-#### Logging into the Broker with Internet Explorer
-During user testing, some Internet Explorer users were unable to log into the Broker and upload files. We implemented a workaround so users with Internet Explorer on __medium security settings__ can log in and upload files. See Known Issues below.
-
-#### Submit File with Pipe Symbol
-Based on user feedback, we changed the Broker to automatically detect whether a file is using a comma or pipe symbol as a delimiter, based on the format of the header row.
-
-#### File Validations per RSS v1.0
-Submitted files will be validated per RSS v1.0. Specifically:
-* Field names match the RSS v1.0
-* Maximum field length does not exceed the value in RSS v1.0
-* Required fields are present per RSS v1.0
-* Records in File C have a PIID, FAIN, or URI    
-
 #### Browser Requirements & Known Issues{section=browser}
 The Broker is currently tested with the following browsers:
 

--- a/src/help/history.md
+++ b/src/help/history.md
@@ -1,39 +1,38 @@
 #### What's New in This Release - June 1, 2016
+In this version of the broker, we have added some information on the screens to help you with your data submission, added some functionality to help you select the reporting period, and updated some of the validations. __Note:__ Validation details are included in the cumulative updated validations table.
+* [Step-by-Step Guide on the Broker Home Page](#/help?section=stepby)
+* [Submission Guide](#/help?section=subguide)
+* [Selecting Reporting Period](#/help?section=dateselect)
+
+#### Step-by-Step Guide on the Broker Home Page{section=stepby}
+When you log into the Broker, you will see three choices that guide you to _Upload and validate a new submission_, _Continue with an existing submission_, and _Review, certify, and publish a submission_.
+
+#### Submission Guide{section=subguide}
+The Submission Guide provides details of the four steps to submit your agency's data. Once you have reviewed this page, you can check a box to hide this page the next time you log into the Broker.
+        
+#### Select Reporting Period{section=dateselect}
+Based on user feedback, the quarterly submission dates are displayed as the quarter number and the fiscal year. Example: Quarter 2 - 2016.
+
+#### What's New in This Release - May 17, 2016
 In this version of the broker, we have made a change if you are logging in with Internet Explorer, added funtionality for the Broker to recognize files with the pipe symbol as a delimiter, and updated some of the validations.
 
-* [(Sample Old) Logging into the Broker with Internet Explorer](#/help?section=oldBrokerIE)
-* [(Sample Old) Submit Files with Pipe Symbol](#/help?section=oldPipe)
-* [(Sample Old) File Validations per RSS v1.0](#/help?section=oldFileValv1)
-* [(Sample Old)Cross File Validations](#/help?section=oldCrossFileValv1)
-* [(Sample Old) Browser Requirements & Known Issues](#/help?section=oldBrowser)
+* [Logging into the Broker with Internet Explorer](#/help?section=brokerIE)
+* [Submit Files with Pipe Symbol](#/help?section=pipe)
+* [File Validations per RSS v1.0](#/help?section=fileValv1)
+* [Cross File Validations](#/help?section=crossFileValv1)
 
-#### (Sample Old) Logging into the Broker with Internet Explorer{section=oldBrokerIE}
+#### Logging into the Broker with Internet Explorer{section=brokerIE}
 During user testing, some Internet Explorer users were unable to log into the Broker and upload files. We implemented a workaround so users with Internet Explorer on __medium security settings__ can log in and upload files. See Known Issues below.
 
-#### (Sample Old) Submit File with Pipe Symbol{section=oldPipe}
+#### Submit File with Pipe Symbol{section=pipe}
 Based on user feedback, we changed the Broker to automatically detect whether a file is using a comma or pipe symbol as a delimiter, based on the format of the header row.
 
-#### (Sample Old) File Validations per RSS v1.0{section=oldFileValv1}
+#### File Validations per RSS v1.0{section=fileValv1}
 Submitted files will be validated per RSS v1.0. Specifically:
-
 * Field names match the RSS v1.0
 * Maximum field length does not exceed the value in RSS v1.0
 * Required fields are present per RSS v1.0
-* Records in File C have a PIID, FAIN, or URI
+* Records in File C have a PIID, FAIN, or URI 
 
-#### (Sample Old) Cross File Validations{section=oldCrossFileValv1}
+#### Cross File Validations{section=crossFileValv1}
 We started work on cross file validations, beginning with cross validation of the FAIN, URI or PIID between sample files for Files C and D2.
-
-#### (Sample Old) Browser Requirements & Known Issues{section=oldBrowser}
-The Broker is currently tested with the following browsers:
-
-* Internet Explorer version 10 and higher
-* Firefox (current version)
-* Chrome (current version)
-* Safari (current version)
-
-Although you may use any browser/version combination you wish, we cannot support browsers and versions other than the ones stated above.
-
-Known Issues
-
-* The Broker will not work when using Internet Explorer under medium privacy settings or high security settings.


### PR DESCRIPTION
Added information from Sprint 14 including DB-586, DB-557, DB-499, DB-575, DB-567, DB-568. 
Added rules  A1, A2, C8, C9 to rules table. @Kaitlin - you said to add B12 but that is not listed as implemented.
Included help content from prior two updates without jump or sidebar links.
@Kaitlin - remember your were going to add info about proxy issue