### PR TITLE
Validation Page Transitions

### DIFF
--- a/src/_scss/pages/addData.scss
+++ b/src/_scss/pages/addData.scss
@@ -124,6 +124,9 @@ div.usa-da-validate-items {
         & .usa-da-validate-txt-wrap {
             margin: -35px 0 0 0;
         }
+        & .usa-da-validate-loading-message {
+            margin: -35px 0 0 0;
+        }
     }
     .usa-da-validate-icon {
         font-size: 0.7em;
@@ -349,6 +352,14 @@ div.usa-da-validate-items {
             margin: 0;
         }
     }
+
+    .overlay-loading {
+        width: 100%;
+        h6 {
+            width: 100%;
+            text-align: left;
+        }
+    }
 }
 
 div.usa-da-dropzone {
@@ -411,5 +422,32 @@ div.usa-da-dropzone {
     }
     .progress {
         margin-top: 10px;
+    }
+}
+
+.usa-da-validate-data-loading {
+    min-height: 800px;
+}
+
+.usa-da-validate-fade-appear {
+    opacity: 0.01;
+    &.usa-da-validate-fade-appear-active {
+        opacity: 1;
+        transition: opacity 500ms ease-in;
+    }
+}
+.usa-da-validate-fade-enter {
+    opacity: 0.01;
+    &.usa-da-validate-fade-enter-active {
+        opacity: 1;
+        transition: opacity 500ms ease-in;
+    }
+}
+
+.usa-da-validate-fade-leave {
+    opacity: 1;
+    &.usa-da-validate-fade-leave-active {
+        opacity: 0.01;
+        transition: opacity 500ms ease-in;
     }
 }

--- a/src/js/components/SharedComponents/ProgressComponent.jsx
+++ b/src/js/components/SharedComponents/ProgressComponent.jsx
@@ -13,8 +13,8 @@ const propTypes = {
 
 const defaultProps = {
     currentStep: 1,
-    totalSteps: 3,
-    stepNames: ['Upload .csv Files', 'Validate .csv Data', 'Review & Publish']
+    totalSteps: 4,
+    stepNames: ['Name Submission', 'Upload .CSV Files', 'Validate .CSV Data', 'Review & Publish']
 };
 
 export default class Progress extends React.Component {

--- a/src/js/components/addData/AddDataContent.jsx
+++ b/src/js/components/addData/AddDataContent.jsx
@@ -25,8 +25,7 @@ export default class AddDataContent extends React.Component {
         this.state = {
             fileHolder: [],
             submissionID: 0,
-            progress: 0,
-            progressStep: 1
+            progress: 0
         };
     }
 
@@ -57,7 +56,7 @@ export default class AddDataContent extends React.Component {
                 <div className="usa-da-content-step-block" name="content-top">
                     <div className="container center-block">
                         <div className="row">
-                            <Progress totalSteps={3} currentStep={this.state.progressStep} />
+                            <Progress totalSteps={4} currentStep={2} />
                         </div>
                     </div>
                 </div>

--- a/src/js/components/addData/AddDataHeader.jsx
+++ b/src/js/components/addData/AddDataHeader.jsx
@@ -15,7 +15,7 @@ class LastUpdated extends React.Component {
     
     render() {
         return (
-            <div className="col-md-5 mt-40 mb-50 last-updated">
+            <div className="col-md-4 mt-40 mb-50 last-updated">
                 <p>Last Saved: {this.props.last_updated}</p>
             </div>
         );
@@ -57,7 +57,7 @@ export default class AddDataHeader extends React.Component {
             <div className="usa-da-content-dark">
                 <div className="container">
                     <div className="row usa-da-content-add-data usa-da-page-title">
-                        <div className="col-md-10 mt-40 mb-20">
+                        <div className="col-md-8 mt-40 mb-20">
                             <div className="display-2">Upload & Validate a New Submission</div>
                             <p>The current DATA Act Broker allows agencies to upload and test their data as it is required under the DATA Act. It is not connected to USAspending.</p>
                         </div>

--- a/src/js/components/addData/AddDataMeta.jsx
+++ b/src/js/components/addData/AddDataMeta.jsx
@@ -11,6 +11,8 @@ import moment from 'moment';
 import AgencyListContainer from '../../containers/SharedContainers/AgencyListContainer.jsx';
 import * as Icons from '../SharedComponents/icons/Icons.jsx';
 
+import Progress from '../SharedComponents/ProgressComponent.jsx';
+
 import DateTypeField from './metadata/DateTypeField.jsx';
 import DateRangeField from './metadata/DateRangeField.jsx';
 
@@ -175,6 +177,13 @@ export default class AddDataMeta extends React.Component {
 
         return (
                 <div>
+                    <div className="usa-da-content-step-block" name="content-top">
+                        <div className="container center-block">
+                            <div className="row">
+                                <Progress totalSteps={4} currentStep={1} />
+                            </div>
+                        </div>
+                    </div>
                     <div className="container center-block">
                         <div className="row text-center usa-da-add-data-meta">
                             <div className="col-md-offset-2 col-md-8 mt-60 mb-60">

--- a/src/js/components/reviewData/ReviewDataPage.jsx
+++ b/src/js/components/reviewData/ReviewDataPage.jsx
@@ -48,7 +48,7 @@ export default class ReviewDataPage extends React.Component {
                     <div className="usa-da-content-step-block" name="content-top">
                         <div className="container center-block">
                             <div className="row">
-                                <Progress totalSteps={3} currentStep={3} />
+                                <Progress totalSteps={4} currentStep={4} />
                             </div>
                         </div>
                     </div>

--- a/src/js/components/validateData/ValidateDataContent.jsx
+++ b/src/js/components/validateData/ValidateDataContent.jsx
@@ -5,6 +5,7 @@
 
 import React, { PropTypes } from 'react';
 import $ from 'jquery';
+
 import { kGlobalConstants } from '../../GlobalConstants.js';
 import ValidateDataFileComponent from './ValidateDataFileComponent.jsx';
 import SubmitButton from '../SharedComponents/SubmitButton.jsx';
@@ -12,6 +13,7 @@ import MetaData from '../addData/AddDataMetaDisplay.jsx';
 import FileComponent from '../addData/FileComponent.jsx';
 import ValidateDataOverlayContainer from '../../containers/validateData/ValidateDataOverlayContainer.jsx';
 import ValidateDataFileContainer from '../../containers/validateData/ValidateDataFileContainer.jsx';
+import ValidateDataInProgressOverlay from './ValidateDataInProgressOverlay.jsx';
 
 import { fileTypes } from '../../containers/addData/fileTypes.js';
 
@@ -22,22 +24,6 @@ const propTypes = {
 export default class ValidateDataContent extends React.Component {
     constructor(props) {
         super(props);
-    }
-
-    componentDidMount() {
-        this.scrollToContent();
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        if (prevProps.submission.state != "review" && this.props.submission.state == "review") {
-            this.scrollToContent();
-        }
-    }
-
-    scrollToContent() {
-        $('html, body').animate({
-            scrollTop: $('[name=content-top]').offset().top
-        }, 500);
     }
 
     render() {
@@ -64,15 +50,17 @@ export default class ValidateDataContent extends React.Component {
 
         let overlay = '';
         let displayOverlay = '';
-        if (!allValid && allDone) {
-            // we'll need extra padding at the bottom of the page if the overlay is present
-            displayOverlay = ' with-overlay';
+        if (!allDone) {
+            // still loading or validating
+            overlay = <ValidateDataInProgressOverlay />;
+        }
+        else {
             overlay = <ValidateDataOverlayContainer errors={errors} />;
         }
 
         return (
             <div className="container">
-                <div className={"row center-block usa-da-submission-items" + displayOverlay}>
+                <div className="row center-block usa-da-submission-items with-overlay">
                     <div className="usa-da-validate-items">
                         {items}
                     </div>

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -191,12 +191,14 @@ export default class ValidateDataFileComponent extends React.Component {
         
         let successfulFade = '';
         let disabledCorrect = '';
+        let messageClass = ' usa-da-validate-item-message';
         if (!this.state.isError && this.isFileReady()) {
             successfulFade = ' successful';
             disabledCorrect = ' hide';
         }
         else if (!this.isFileReady()) {
             successfulFade = '';
+            messageClass = '';
             disabledCorrect = ' hide';
         }
 
@@ -245,7 +247,7 @@ export default class ValidateDataFileComponent extends React.Component {
                                 </div>
                             </div>
                             <div className="row usa-da-validate-item-body">
-                                <div className="col-md-12 usa-da-validate-item-message usa-da-validate-txt-wrap" data-testid="validate-message">{this.state.headerTitle}</div>
+                                <div className={"col-md-12 usa-da-validate-txt-wrap" + messageClass} data-testid="validate-message">{this.state.headerTitle}</div>
                             </div>
                             <div className="row usa-da-validate-item-footer-wrapper">
                                 <div className={"usa-da-validate-item-footer usa-da-header-error" + showFooter +" "+footerStatus} onClick={this.toggleErrorReport.bind(this)}>

--- a/src/js/components/validateData/ValidateDataFilePlaceholder.jsx
+++ b/src/js/components/validateData/ValidateDataFilePlaceholder.jsx
@@ -1,0 +1,54 @@
+/**
+ * ValidateDataContent.jsx
+ * Created by Mike Bray 3/28/16
+ **/
+
+import React, { PropTypes } from 'react';
+import { kGlobalConstants } from '../../GlobalConstants.js';
+import * as Icons from '../SharedComponents/icons/Icons.jsx';
+
+const defaultProps = {
+    fileTitle: ''
+};
+
+export default class ValidateDataFilePlaceholder extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <div className="row center-block usa-da-validate-item successful">
+                <div className="col-md-12">
+                    <div className="row usa-da-validate-item-top-section">
+                        <div className="col-md-9 usa-da-validate-item-status-section">
+                            <div className="row usa-da-validate-item-header">
+                                <div className="col-md-8">
+                                    <h4>{this.props.fileTitle}</h4>
+                                </div>
+                                <div className="col-md-4" />
+                            </div>
+                            <div className="row usa-da-validate-item-body">
+                                <div className="col-md-12 usa-da-validate-txt-wrap usa-da-validate-loading-message" data-testid="validate-message">
+                                    Gathering data...
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="col-md-3">
+                            <div className="usa-da-validate-item-file-section">
+                                <div className="usa-da-validate-item-file-section-result">
+                                    <div className="usa-da-icon" data-testid="validate-icon">
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+ValidateDataFilePlaceholder.defaultProps = defaultProps;

--- a/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
+++ b/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
@@ -1,0 +1,31 @@
+/**
+ * ValidateDataInProgressOverlay.jsx
+ * Created by Kevin Li 3/31/2016
+ */
+
+import React from 'react';
+import * as Icons from '../SharedComponents/icons/Icons.jsx';
+
+export default class ValidateDataInProgressOverlay extends React.Component {
+
+	constructor(props) {
+		super(props);
+	}
+
+	render() {
+
+		return (
+			<div className="center-block usa-da-validation-overlay">
+				<div className="container">
+					<div className="row">
+						<div className="col-md-12 usa-da-overlay-content-wrap">
+							<div className="overlay-loading">
+								<h6>Validation in progress...</h6>
+							</div>
+						</div>
+					</div>
+            	</div>
+            </div>
+		);
+	}
+}

--- a/src/js/components/validateData/ValidateDataPage.jsx
+++ b/src/js/components/validateData/ValidateDataPage.jsx
@@ -149,7 +149,7 @@ export default class ValidateDataPage extends React.Component {
                 <div className="usa-da-content-step-block" name="content-top">
                     <div className="container center-block">
                         <div className="row">
-                            <Progress totalSteps={3} currentStep={2} />
+                            <Progress totalSteps={4} currentStep={3} />
                         </div>
                     </div>
                 </div>

--- a/src/js/components/validateData/ValidateLoadingScreen.jsx
+++ b/src/js/components/validateData/ValidateLoadingScreen.jsx
@@ -4,12 +4,41 @@
   */
 
 import React from 'react';
+import ValidateDataFilePlaceholder from './ValidateDataFilePlaceholder.jsx';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 export default class ValidateLoadingScreen extends React.Component {
 	render() {
+		const placeholders = [];
+
+		for (let i = 0; i < 3; i++) {
+			placeholders.push(<ValidateDataFilePlaceholder key={i} />);
+		}
+
 		return (
 			<div className="container">
-				<h4 className="usa-da-gathering-data">Gathering data...</h4>
+				<div className="row center-block usa-da-submission-items with-overlay">
+                    <div className="usa-da-validate-items">
+	                    <ReactCSSTransitionGroup transitionName="usa-da-validate-fade" transitionAppear={true} transitionAppearTimeout={500} transitionEnterTimeout={500} transitionLeaveTimeout={500}>
+		                	<div>
+		                		{placeholders}
+		                	</div>
+                    	</ReactCSSTransitionGroup>
+                    </div>
+                </div>
+                <ReactCSSTransitionGroup transitionName="usa-da-validate-fade" transitionAppear={true} transitionAppearTimeout={500} transitionEnterTimeout={500} transitionLeaveTimeout={500}>
+					<div className="center-block usa-da-validation-overlay" data-testid="validate-value-overlay">
+						<div className="container">
+							<div className="row">
+								<div className="col-md-12 usa-da-overlay-content-wrap">
+									<div className="overlay-loading">
+										<h6>Gathering data...</h6>
+									</div>
+								</div>
+							</div>
+						</div>
+		            </div>
+	            </ReactCSSTransitionGroup>
 			</div>
 		);
 	}

--- a/src/js/components/validateData/validateValues/ValidateValuesContent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesContent.jsx
@@ -5,6 +5,7 @@
 
 import React, { PropTypes } from 'react';
 import $ from 'jquery';
+
 import { kGlobalConstants } from '../../../GlobalConstants.js';
 
 import { fileTypes } from '../../../containers/addData/fileTypes.js';
@@ -21,22 +22,6 @@ export default class ValidateValuesContent extends React.Component {
         super(props);
     }
 
-    componentDidMount() {
-        this.scrollToContent();
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        if (prevProps.submission.state != "review" && this.props.submission.state == "review") {
-            this.scrollToContent();
-        }
-    }
-
-    scrollToContent() {
-        $('html, body').animate({
-            scrollTop: $('[name=content-top]').offset().top
-        }, 500);
-    }
-
     render() {
 
         const errors = [];
@@ -49,7 +34,7 @@ export default class ValidateValuesContent extends React.Component {
                     errors.push(type.requestName);
                 }
 
-                return <ValidateValuesFileContainer data={validation} type={type} key={index} />;
+                return <ValidateValuesFileContainer key={index} data={validation} type={type}  />;
             }
 
         });

--- a/src/js/components/validateData/validateValues/ValidateValuesOverlay.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesOverlay.jsx
@@ -75,7 +75,7 @@ export default class ValidateValuesOverlay extends React.Component {
 
 
 		return (
-			<div className="center-block usa-da-validation-overlay" data-testid="validate-value-overlay">
+			<div className="center-block usa-da-validation-overlay">
 				<div className="container">
 					<div className="row">
 						<div className="col-md-8 usa-da-overlay-content-wrap">

--- a/src/js/containers/validateData/ValidateDataContainer.jsx
+++ b/src/js/containers/validateData/ValidateDataContainer.jsx
@@ -55,8 +55,12 @@ class ValidateDataContainer extends React.Component {
 		// check if the submission state changed, indicating a re-upload
 		if (prevProps.submission.state != this.props.submission.state) {
 			if (this.props.submission.state == "prepare") {
-				// uploads are done
-				this.validateSubmission();
+				// uploads are done, reset the cancellation timer
+				this.setState({
+					initialLoad: moment()
+				}, () => {
+					this.validateSubmission();
+				});
 			}
 		}
 	}
@@ -98,7 +102,7 @@ class ValidateDataContainer extends React.Component {
 	validateSubmission() {
 
 		// check how long it's been since the initial validation check
-		if (!this.state.offerCancellation) {
+		if (!this.state.offerCancellation && !this.state.notYours) {
 			const secondsPassed = moment().unix() - this.state.initialLoad.unix();
 			if (secondsPassed >= 5 * 60) {
 				this.setState({
@@ -123,8 +127,10 @@ class ValidateDataContainer extends React.Component {
 				}
 				else {
 					// all the files have returned something, hide the cancellation banner if necessary
+					// reset the initial load time to reset how long until the cancellation banner appears
 					this.setState({
-						offerCancellation: false
+						offerCancellation: false,
+						initialLoad: moment()
 					});
 				}
 
@@ -133,7 +139,9 @@ class ValidateDataContainer extends React.Component {
 			.catch((err) => {
 				if (err.reason == 400) {
 					this.setState({
-						notYours: true
+						notYours: true,
+						offerCancellation: false,
+						initialLoad: moment()
 					});
 				}
 				else {


### PR DESCRIPTION
* Validation boxes now fade in and allow for a smooth transition from the upload screen
* Autoscroll behavior has been removed. During the "gathering data" phase, placeholder boxes approximate the validation layout.
* Bottom bar now appears throughout the entire validation process and now has new messages to indicate "gathering data" and "validation in progress" stages
* "Validating..." message inside file boxes now appears in black text instead of red
* Top bar updated to reflect four submission steps instead of three
* Fixed a bug where, if more than 5 minutes passed between validation completing and the start of either the next validation cycle or file upload, the "stuck in validation" message would erroneously appear