### PR TITLE
Updated Treemap

### DIFF
--- a/src/_scss/pages/addData.scss
+++ b/src/_scss/pages/addData.scss
@@ -357,6 +357,14 @@ div.usa-da-validate-items {
             width: 100%;
             text-align: left;
         }
+
+        .overlay-help-text {
+            font-family: "Source Sans Pro", "Helvetica", "Arial", sans-serif;
+
+            a {
+                color: $color-white;
+            }
+        }
     }
 }
 

--- a/src/_scss/pages/addMetaData.scss
+++ b/src/_scss/pages/addMetaData.scss
@@ -136,6 +136,10 @@
             font-size: 1.2rem;
             border-right: 1px solid $color-white;
             border-bottom: 1px solid $color-white;
+
+            .treemap-rule {
+                font-weight: bold;
+            }
         }
     }
     
@@ -146,9 +150,16 @@
         padding: 10px;
         word-wrap: break-word;
         font-size: 1.4rem;
-        line-height: 2.4rem;
-        color: #525252;
-        &.default {
-            color: $color-gray;
+        line-height: 2.4rem;    
+        color: $color-gray;
+
+        .treemap-help-title {
+            font-weight: bold;
+        }
+
+        .treemap-help-description {
+            b {
+                text-transform: capitalize;
+            }
         }
     }

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -42,7 +42,7 @@ export default class ValidateDataFileComponent extends React.Component {
     componentWillReceiveProps(nextProps) {
         this.determineErrors(nextProps.item);
 
-        if (this.props.submission.state == 'uploading' && nextProps.submission.state == 'review') {
+        if ((this.props.submission.state == 'uploading' || this.props.submission.state == 'prepare') && nextProps.submission.state == 'review') {
             // we've finished uploading files, close any open error reports
             if (this.state.showError) {
                 this.setState({

--- a/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
+++ b/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
@@ -11,7 +11,7 @@ export default class ValidateDataInProgressOverlay extends React.Component {
 	constructor(props) {
 		super(props);
 	}
-
+	
 	render() {
 
 		return (
@@ -20,7 +20,11 @@ export default class ValidateDataInProgressOverlay extends React.Component {
 					<div className="row">
 						<div className="col-md-12 usa-da-overlay-content-wrap">
 							<div className="overlay-loading">
-								<h6>Validation in progress...</h6>
+								<h6>Your files are being validated.</h6>
+								<div className="overlay-help-text">
+									You can return to this page at any time to check the validation status by using this link:<br />
+									<a href={window.location.href}>{window.location.href}</a>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/src/js/components/validateData/treemap/Treemap.jsx
+++ b/src/js/components/validateData/treemap/Treemap.jsx
@@ -37,7 +37,15 @@ export default class Treemap extends React.Component {
 
 		const baseColor = '#5d87bb';
 		return treemap.map((node, index) => {
-			const tint = (40 / (this.props.formattedData.max - this.props.formattedData.min)) * (this.props.formattedData.max - node.value);
+			const max = this.props.formattedData.max;
+			const min = this.props.formattedData.min;
+
+			let tint = 0;
+			if (max != min) {
+				// prevent divide by zero errors
+				tint = (40 / (this.props.formattedData.max - this.props.formattedData.min)) * (this.props.formattedData.max - node.value);
+			}
+
 			const color = tinycolor(baseColor).lighten(tint).toString();
 
 			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} color={color} rule={node.rule} count={node.value} field={node.field} detail={node.detail} description={node.description} clickedItem={this.props.clickedItem} />

--- a/src/js/components/validateData/treemap/Treemap.jsx
+++ b/src/js/components/validateData/treemap/Treemap.jsx
@@ -13,7 +13,11 @@ import TreemapCell from './TreemapCell.jsx';
 const defaultProps = {
 	width: 0,
 	height: 300,
-	data: []
+	formattedData: {
+		data: [],
+		max: 0,
+		min: 0
+	}
 }
 
 
@@ -29,15 +33,14 @@ export default class Treemap extends React.Component {
 			})
 			.sticky(true);
 
-		const treemap = _.drop(layout(this.props.data), 1);
+		const treemap = layout(this.props.formattedData.data);
 
-		const baseColor = '#e31c3d';
+		const baseColor = '#5d87bb';
 		return treemap.map((node, index) => {
-
-			const tint = (50 / treemap.length) * index;
+			const tint = (40 / (this.props.formattedData.max - this.props.formattedData.min)) * (this.props.formattedData.max - node.value);
 			const color = tinycolor(baseColor).lighten(tint).toString();
 
-			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} label={node.label} color={color} description={node.description} clickedItem={this.props.clickedItem} />
+			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} color={color} rule={node.rule} count={node.value} field={node.field} detail={node.detail} description={node.description} clickedItem={this.props.clickedItem} />
 		});
 
 	}

--- a/src/js/components/validateData/treemap/TreemapCell.jsx
+++ b/src/js/components/validateData/treemap/TreemapCell.jsx
@@ -7,6 +7,10 @@ import React from 'react';
 import d3 from 'd3';
 import tinycolor from 'tinycolor2';
 
+const defaultProps = {
+	rule: 'Unspecified'
+};
+
 export default class TreemapCell extends React.Component {
 
 	constructor(props) {
@@ -54,3 +58,5 @@ export default class TreemapCell extends React.Component {
 		);
 	}
 }
+
+TreemapCell.defaultProps = defaultProps;

--- a/src/js/components/validateData/treemap/TreemapCell.jsx
+++ b/src/js/components/validateData/treemap/TreemapCell.jsx
@@ -30,7 +30,7 @@ export default class TreemapCell extends React.Component {
 	}
 
 	clickEvent(e) {
-		this.props.clickedItem(this.props.description);
+		this.props.clickedItem(this.props);
 	}
 
 	render() {
@@ -49,7 +49,7 @@ export default class TreemapCell extends React.Component {
 
 		return (
 			<div className="usa-da-treemap-cell" style={style} onMouseOver={this.mouseOver.bind(this)} onMouseOut={this.mouseOut.bind(this)} onClick={this.clickEvent.bind(this)}>
-				<span dangerouslySetInnerHTML={{__html:this.props.label}} />
+				<div className="treemap-rule">{this.props.rule}</div>
 			</div>
 		);
 	}

--- a/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
@@ -40,7 +40,7 @@ export default class ValidateDataFileComponent extends React.Component {
     componentWillReceiveProps(nextProps) {
         this.determineErrors(nextProps.item);
 
-        if (this.props.submission.state == 'uploading' && nextProps.submission.state == 'review') {
+        if ((this.props.submission.state == 'uploading' || this.props.submission.state == 'prepare') && nextProps.submission.state == 'review') {
             // we've finished uploading files, close any open error reports
             if (this.state.showError) {
                 this.setState({

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
@@ -5,7 +5,10 @@
 
 import React from 'react';
 import Dimensions from 'react-dimensions';
+import _ from 'lodash';
 import Treemap from '../treemap/Treemap.jsx';
+import TreemapHelp from './ValidateValuesTreemapHelp.jsx'
+import TreemapHelpPlaceholder from './ValidateValuesTreemapHelpPlaceholder.jsx'
 
 class ValidateValuesTreemap extends React.Component {
 
@@ -13,70 +16,93 @@ class ValidateValuesTreemap extends React.Component {
 		super(props);
 
 		this.state = {
-			hoverText: ''
+			selected: null,
+			formattedData: {
+				data: [],
+				max: 0,
+				min: 0
+			}
 		};
+	}
+
+	componentDidMount() {
+		this.formatData();
+	}
+
+	componentDidUpdate(prevProps, prevState) {
+		if (!_.isEqual(prevProps.data, this.props.data)) {
+			this.formatData();
+		}
 	}
 
 	formatData() {
 		const data = [];
 
+		let maxCount = null;
+		let minCount = null;
+
 		this.props.data.forEach((item) => {
-			let value = '<b>' + item.field_name + '</b><br />';
-			let description = '';
-			if (item.error_name == 'type_error') {
-				value += 'type error (' + item.occurrences + ')';
-				description = 'There is a type error in the \"' + item.field_name + '\" field. ' + item.error_description;
-			}
-			else if (item.error_name == 'rule_failed') {
-				value += 'rule error (' + item.occurrences + ')';
-				description = 'There is a rule error in the \"' + item.field_name + '\" field. ' + item.rule_failed;
-			}
-			else if (item.error_name == 'required_error') {
-				value += 'missing required value (' + item.occurrences + ')';
-				description = 'Values are missing in the required \"' + item.field_name + '\" field. ' + item.error_description;
-			}
-			else {
-				value += '(' + item.occurrences + ')';
-				description = 'There are errors in the \"' + item.field_name + '\" field. ' + item.error_description;
+
+			let detail = null;
+			if (item.error_name == 'rule_failed') {
+				detail = item.rule_failed;
 			}
 
+
+			// calculate the max and min occurrences, this will be used by the treemap to determine the color/shade
+			if (maxCount && maxCount < item.occurrences) {
+				maxCount = item.occurrences;
+			}
+			else if (!maxCount) {
+				maxCount = item.occurrences;
+			}
+			if (minCount && minCount > item.occurrences) {
+				minCount = item.occurrences;
+			}
+			else if (!minCount) {
+				minCount = item.occurrences;
+			}
+
+
 			data.push({
-				label: value,
+				rule: 'A12',
 				value: item.occurrences,
-				description: description
+				field: item.field_name,
+				description: item.error_description,
+				detail: detail
 			});
 		});
 
 		// sort by descending value
-		return _.sortBy(data, (o) => {
-			return -1 * o.value;
+		this.setState({
+			formattedData: {
+				data: _.orderBy(data, ['value', 'rule'], 'desc'),
+				min: minCount,
+				max: maxCount
+			}
 		});
 	}
 
-	clickedItem(description) {
+	clickedItem(item) {
 		this.setState({
-			hoverText: description
+			selected: item
 		});
 	}
 
 	render() {
 
-		let hoverText = this.state.hoverText;
-		let hoverTextClass = '';
-		if (this.state.hoverText == '') {
-			hoverText = 'Click on a block for more information about the ' + this.props.type + '.';
-			hoverTextClass = ' default';
+		let help = <TreemapHelpPlaceholder type={this.props.type} />;
+		if (this.state.selected) {
+			help = <TreemapHelp {...this.state.selected} type={this.props.type} />;
 		}
 
 		return (
 			<div className="row">
 				<div className="col-md-9">
-					<Treemap data={this.formatData()} width={this.props.containerWidth * 0.75} clickedItem={this.clickedItem.bind(this)} />
+					<Treemap formattedData={this.state.formattedData} width={this.props.containerWidth * 0.75} clickedItem={this.clickedItem.bind(this)} />
 				</div>
 				<div className="col-md-3">
-					<div className={"usa-da-treemap-help-wrap" + hoverTextClass}>
-						{hoverText}
-					</div>
+					{help}
 				</div>
 			</div>
 		);

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
@@ -65,7 +65,7 @@ class ValidateValuesTreemap extends React.Component {
 
 
 			data.push({
-				rule: 'A12',
+				rule: item.original_label,
 				value: item.occurrences,
 				field: item.field_name,
 				description: item.error_description,

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
@@ -50,16 +50,10 @@ class ValidateValuesTreemap extends React.Component {
 
 
 			// calculate the max and min occurrences, this will be used by the treemap to determine the color/shade
-			if (maxCount && maxCount < item.occurrences) {
+			if (!maxCount || maxCount < item.occurrences) {
 				maxCount = item.occurrences;
 			}
-			else if (!maxCount) {
-				maxCount = item.occurrences;
-			}
-			if (minCount && minCount > item.occurrences) {
-				minCount = item.occurrences;
-			}
-			else if (!minCount) {
+			if (!minCount || minCount > item.occurrences) {
 				minCount = item.occurrences;
 			}
 

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
@@ -1,0 +1,41 @@
+/**
+  * ValidateValuesTreemapHelp.jsx
+  * Created by Kevin Li 6/20/16
+  **/
+
+import React from 'react';
+
+const defaultProps = {
+	rule: 'Unspecified',
+	description: '',
+	detail: null,
+	count: 0,
+	type: 'error'
+};
+
+export default class ValidateValuesTreemapHelp extends React.Component {
+	render() {
+		let detail = ' hide';
+		if (this.props.detail) {
+			detail = '';
+		}
+		return (
+			<div className="usa-da-treemap-help-wrap">
+				<div className="treemap-help-title">
+					Rule {this.props.rule}
+				</div>
+				<div className="treemap-help-description">
+					<b>Field:</b> {this.props.field}<br />
+					<b>{this.props.type}:</b> {this.props.description}<br />
+					<b>Occurrences: </b>{this.props.count}
+				</div>
+				<div className={"treemap-help-detail" + detail}>
+					<b>More information:</b><br />
+					{this.props.detail}
+				</div>
+			</div>
+		)
+	}
+}
+
+ValidateValuesTreemapHelp.defaultProps = defaultProps;

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemapHelpPlaceholder.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemapHelpPlaceholder.jsx
@@ -1,0 +1,22 @@
+/**
+  * ValidateValuesTreemapHelpPlaceholder.jsx
+  * Created by Kevin Li 6/20/16
+  **/
+
+import React from 'react';
+
+const defaultProps = {
+	type: 'error'
+};
+
+export default class ValidateValuesTreemapHelpPlaceholder extends React.Component {
+	render() {
+		return (
+			<div className="usa-da-treemap-help-wrap">
+				Click on a block for more information about the {this.props.type}.
+			</div>
+		)
+	}
+}
+
+ValidateValuesTreemapHelpPlaceholder.defaultProps = defaultProps;

--- a/src/js/containers/validateData/ValidateDataContainer.jsx
+++ b/src/js/containers/validateData/ValidateDataContainer.jsx
@@ -32,7 +32,6 @@ class ValidateDataContainer extends React.Component {
 			finishedLoad: false,
 			headerErrors: true,
 			initialLoad: moment(),
-			offerCancellation: false,
 			notYours: false
 		};
 	}
@@ -101,16 +100,6 @@ class ValidateDataContainer extends React.Component {
 
 	validateSubmission() {
 
-		// check how long it's been since the initial validation check
-		if (!this.state.offerCancellation && !this.state.notYours) {
-			const secondsPassed = moment().unix() - this.state.initialLoad.unix();
-			if (secondsPassed >= 5 * 60) {
-				this.setState({
-					offerCancellation: true
-				});
-			}
-		}
-
 		ReviewHelper.validateSubmission(this.props.submissionID)
 			.then((data) => {
 				this.setState({
@@ -126,10 +115,7 @@ class ValidateDataContainer extends React.Component {
 					}, 5*1000);
 				}
 				else {
-					// all the files have returned something, hide the cancellation banner if necessary
-					// reset the initial load time to reset how long until the cancellation banner appears
 					this.setState({
-						offerCancellation: false,
 						initialLoad: moment()
 					});
 				}
@@ -140,7 +126,6 @@ class ValidateDataContainer extends React.Component {
 				if (err.reason == 400) {
 					this.setState({
 						notYours: true,
-						offerCancellation: false,
 						initialLoad: moment()
 					});
 				}
@@ -167,11 +152,6 @@ class ValidateDataContainer extends React.Component {
 			validationContent = <ValidateLoadingScreen />;
 		}
 
-		let cancel = '';
-		if (this.state.offerCancellation && !checkingValues) {
-			cancel = <ValidateCancellation />;
-		}
-
 		if (this.state.notYours) {
 			validationContent = '';
 			cancel = <ValidateNotYours message="You cannot view or modify this submission because you are not the original submitter." />;
@@ -179,7 +159,6 @@ class ValidateDataContainer extends React.Component {
 
 		return (
 			<div>
-				{cancel}
 				{validationContent}
 			</div>
 		);


### PR DESCRIPTION
* New treemap color
* Treemap labels are now `original_label`, updated treemap sidebar text to show detailed rule failure information
* Fixes a bug where, if a file had header errors and was replaced with a file that did not _and_ the header error details were expanded, a half-populated header error details table would appear while the replacement file was in validation
* Removed "validation is stuck" message and replaced it with a new lower-third overlay that provides a URL that the user can use to return to the page at a later time