### PR TITLE
Remove original_label from treemap

### DIFF
--- a/src/js/components/validateData/treemap/Treemap.jsx
+++ b/src/js/components/validateData/treemap/Treemap.jsx
@@ -22,7 +22,27 @@ const defaultProps = {
 
 
 export default class Treemap extends React.Component {
+	constructor(props) {
+		super(props);
 
+		this.state = {
+			chart: null
+		};
+	}
+
+	componentDidMount() {
+		this.setState({
+			chart: this.drawChart()
+		});
+	}
+
+	componentDidUpdate(prevProps, prevState) {
+		if (!_.isEqual(prevProps.formattedData.data, this.props.formattedData.data)) {
+			this.setState({
+				chart: this.drawChart()
+			});
+		}
+	}
 
 	drawChart() {
 		const layout = d3.layout.treemap()
@@ -47,8 +67,7 @@ export default class Treemap extends React.Component {
 			}
 
 			const color = tinycolor(baseColor).lighten(tint).toString();
-
-			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} color={color} rule={node.rule} count={node.value} field={node.field} detail={node.detail} description={node.description} clickedItem={this.props.clickedItem} />
+			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} color={color} rule={node.rule} count={node.value} field={node.field} detail={node.detail} description={node.description} clickedItem={this.props.clickedItem} />;
 		});
 
 	}
@@ -56,7 +75,7 @@ export default class Treemap extends React.Component {
 	render() {
 		return (
 			<div className="usa-da-treemap">
-				{this.drawChart()}
+				{this.state.chart}
 			</div>
 		);
 	}

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
@@ -59,7 +59,7 @@ class ValidateValuesTreemap extends React.Component {
 
 
 			data.push({
-				rule: item.original_label,
+				rule: item.field_name,
 				value: item.occurrences,
 				field: item.field_name,
 				description: item.error_description,

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
@@ -22,7 +22,7 @@ export default class ValidateValuesTreemapHelp extends React.Component {
 		return (
 			<div className="usa-da-treemap-help-wrap">
 				<div className="treemap-help-title">
-					Rule {this.props.rule}
+					
 				</div>
 				<div className="treemap-help-description">
 					<b>Field:</b> {this.props.field}<br />

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
@@ -21,8 +21,8 @@ export default class ValidateValuesTreemapHelp extends React.Component {
 		}
 		return (
 			<div className="usa-da-treemap-help-wrap">
-				<div className="treemap-help-title">
-					
+				<div className="treemap-help-title hide">
+					Rule {this.props.rule}
 				</div>
 				<div className="treemap-help-description">
 					<b>Field:</b> {this.props.field}<br />


### PR DESCRIPTION
* Replaces `original_label` with `field_name`
* Hides Rule XXX header in sidebar
* Fixes a bug where treemap cells of the same value could reshuffle between render cycles by caching the treemap in the component's state