### PR TITLE
File Warnings

### DIFF
--- a/src/js/components/validateData/treemap/Treemap.jsx
+++ b/src/js/components/validateData/treemap/Treemap.jsx
@@ -17,7 +17,8 @@ const defaultProps = {
 		data: [],
 		max: 0,
 		min: 0
-	}
+	},
+	color: '#5d87bb'
 }
 
 
@@ -55,7 +56,7 @@ export default class Treemap extends React.Component {
 
 		const treemap = layout(this.props.formattedData.data);
 
-		const baseColor = '#5d87bb';
+		const baseColor = this.props.color;
 		return treemap.map((node, index) => {
 			const max = this.props.formattedData.max;
 			const min = this.props.formattedData.min;

--- a/src/js/components/validateData/treemap/Treemap.jsx
+++ b/src/js/components/validateData/treemap/Treemap.jsx
@@ -68,7 +68,7 @@ export default class Treemap extends React.Component {
 			}
 
 			const color = tinycolor(baseColor).lighten(tint).toString();
-			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} color={color} rule={node.rule} count={node.value} field={node.field} detail={node.detail} description={node.description} clickedItem={this.props.clickedItem} />;
+			return <TreemapCell key={index} width={node.dx} height={node.dy} x={node.x} y={node.y} color={color} title={node.title} count={node.value} field={node.field} detail={node.detail} description={node.description} clickedItem={this.props.clickedItem} />;
 		});
 
 	}

--- a/src/js/components/validateData/treemap/TreemapCell.jsx
+++ b/src/js/components/validateData/treemap/TreemapCell.jsx
@@ -53,7 +53,7 @@ export default class TreemapCell extends React.Component {
 
 		return (
 			<div className="usa-da-treemap-cell" style={style} onMouseOver={this.mouseOver.bind(this)} onMouseOut={this.mouseOut.bind(this)} onClick={this.clickEvent.bind(this)}>
-				<div className="treemap-rule">{this.props.rule}</div>
+				<div className="treemap-rule">{this.props.title}</div>
 			</div>
 		);
 	}

--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -99,14 +99,14 @@ export default class ValidateValuesErrorReport extends React.Component {
                 <div className="usa-da-validate-error-report">
                     <div className="row center-block">
                         <div className="col-md-9">
-                            <h6>Invididual {this.props.name}s</h6>
+                            <h6>Individual {this.props.name}s</h6>
                         </div>
                         <div className="col-md-3">
                             <button className="usa-da-button btn-primary pull-right" onClick={this.openWindow.bind(this)}>Download {this.props.name}s Report</button>
                         </div>
                         <div className="col-md-12">
                             {tables}
-                            <ValidateValuesTreemap data={this.props.data.error_data} type="error" />
+                            <ValidateValuesTreemap data={this.props.data.error_data} type="error" color={this.props.color} />
                         </div>
                     </div>
                 </div>

--- a/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
@@ -185,7 +185,7 @@ export default class ValidateDataFileComponent extends React.Component {
                                 </div>
                             </div>
                             <div className="row">
-                                <FileDetailBox styleClass="usa-da-validate-item-warning" label="Warnings" count={1} expandedReport={this.state.showWarning} onClick={this.toggleWarningReport.bind(this)} />
+                                <FileDetailBox styleClass="usa-da-validate-item-warning" label="Warnings" count={0} expandedReport={this.state.showWarning} onClick={this.toggleWarningReport.bind(this)} />
                                 <FileDetailBox styleClass="usa-da-validate-item-critical" label="Critical Errors" count={this.props.item.error_count} expandedReport={this.state.showError} onClick={this.toggleErrorReport.bind(this)} />
                             </div>
                         </div>

--- a/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
@@ -16,6 +16,7 @@ import MetaData from '../../addData/AddDataMetaDisplay.jsx';
 import FileComponent from '../../addData/FileComponent.jsx';
 import ValidateDataUploadButton from './../ValidateDataUploadButton.jsx';
 import ValidateValuesErrorReport from './ValidateValuesErrorReport.jsx';
+import FileDetailBox from './ValidateValuesFileDetailBox.jsx';
 import CorrectButtonOverlay from '../CorrectButtonOverlay.jsx';
 import * as Icons from '../../SharedComponents/icons/Icons.jsx';
 
@@ -30,7 +31,8 @@ export default class ValidateDataFileComponent extends React.Component {
         this.state = {
             showWarning: false,
             showError: false,
-            hasErrors: false
+            hasErrors: false,
+            hasWarnings: false
         };
     }
 
@@ -53,11 +55,17 @@ export default class ValidateDataFileComponent extends React.Component {
     }
 
     toggleWarningReport(){
-        this.setState({ showWarning: !this.state.showWarning });
+        this.setState({ 
+            showWarning: !this.state.showWarning,
+            showError: false
+        });
     }
 
     toggleErrorReport(){
-        this.setState({ showError: !this.state.showError });
+        this.setState({ 
+            showError: !this.state.showError,
+            showWarning: false
+        });
     }
 
     isFileReady() {
@@ -87,7 +95,8 @@ export default class ValidateDataFileComponent extends React.Component {
         }
         
         this.setState({
-            hasErrors: hasErrors
+            hasErrors: hasErrors,
+            hasWarnings: true
         });
     
     }
@@ -130,22 +139,9 @@ export default class ValidateDataFileComponent extends React.Component {
 
     render() {
         let correctButtonOverlay = '';
-        let warningDirection = <Icons.AngleDown />;
-        let showError = '';
-        let errorDirection = <Icons.AngleDown />;
-        let footerStatus = '';
 
-        if (this.state.showError) {
-            errorDirection = <Icons.AngleUp />;
-            footerStatus = 'active';
-        }
-
-        let warningCount = '--';
-        let noWarnings = ' none';
-        let noErrors = ' none';
         let optionalUpload = false;
         let uploadText = 'Choose Corrected File';
-        let showWarning = ' hide';
         let validationElement = '';
 
         // override this data if a new file is dropped in
@@ -162,13 +158,11 @@ export default class ValidateDataFileComponent extends React.Component {
         }
 
         if (!this.state.hasErrors) {
-            showError = ' hide';
             optionalUpload = true;
             uploadText = 'Overwrite File';
             correctButtonOverlay = <CorrectButtonOverlay isReplacingFile={this.isReplacingFile()} fileKey={this.props.type.requestName} onDrop={this.props.onFileChange} fileName={fileName}/>
             validationElement = <p>File successfully validated</p>;
         } else {
-            noErrors = '';
             validationElement = <div className="row usa-da-validate-item-file-section-correct-button" data-testid="validate-upload">
                 <ValidateDataUploadButton optional={optionalUpload} onDrop={this.props.onFileChange} text={uploadText} />
             </div>;
@@ -191,33 +185,8 @@ export default class ValidateDataFileComponent extends React.Component {
                                 </div>
                             </div>
                             <div className="row">
-                                <div className="col-md-6 usa-da-validate-item-warning">
-                                    <div className="row usa-da-validate-item-body">
-                                        <div className='usa-da-validate-txt-wrap'>
-                                            <span className="usa-da-validate-item-message-label">Warnings:</span>
-                                            <span className={"usa-da-validate-item-message-count" + noWarnings}>&nbsp;{warningCount}</span>
-                                        </div>
-                                    </div>
-                                    <div className="row usa-da-validate-item-footer-wrapper">
-                                        <div className={"usa-da-validate-item-footer usa-da-header-error" + showWarning +" "+footerStatus} onClick={this.toggleWarningReport.bind(this)}>
-                                            <div>View &amp; Download Warnings Report <span className={"usa-da-icon"}>{warningDirection}</span></div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div className="col-md-6 usa-da-validate-item-critical">
-                                    <div className="row usa-da-validate-item-body">
-                                        <div className='usa-da-validate-txt-wrap'>
-                                            <span className="usa-da-validate-item-message-label">Critical Errors:</span>
-                                            <span className={"usa-da-validate-item-message-count" + noErrors}>&nbsp;{this.props.item.error_count}</span>
-                                        </div>
-                                    </div>
-                                    <div className="row usa-da-validate-item-footer-wrapper">
-                                        <div className={"usa-da-validate-item-footer usa-da-header-error" + showError +" "+footerStatus} onClick={this.toggleErrorReport.bind(this)}>
-                                            <div>View &amp; Download Critical Errors Report <span className={"usa-da-icon"}>{errorDirection}</span></div>
-                                        </div>
-                                    </div>
-                                </div>
+                                <FileDetailBox styleClass="usa-da-validate-item-warning" label="Warnings" count={1} expandedReport={this.state.showWarning} onClick={this.toggleWarningReport.bind(this)} />
+                                <FileDetailBox styleClass="usa-da-validate-item-critical" label="Critical Errors" count={this.props.item.error_count} expandedReport={this.state.showError} onClick={this.toggleErrorReport.bind(this)} />
                             </div>
                         </div>
 
@@ -233,8 +202,8 @@ export default class ValidateDataFileComponent extends React.Component {
                             {validationElement}
                         </div>
                     </div>
-                    {this.state.showWarning ? <ValidateValuesErrorReport link={this.props.item.report} data={this.props.item} name="Warning" /> : null}
-                    {this.state.showError ? <ValidateValuesErrorReport link={this.props.item.report} data={this.props.item} name="Critical Error" /> : null}
+                    {this.state.showWarning ? <ValidateValuesErrorReport link={this.props.item.report} data={this.props.item} name="Warning" color="#fdb81e" /> : null}
+                    {this.state.showError ? <ValidateValuesErrorReport link={this.props.item.report} data={this.props.item} name="Critical Error" color="#5d87bb" /> : null}
                 </div>
             </div>
         );

--- a/src/js/components/validateData/validateValues/ValidateValuesFileDetailBox.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesFileDetailBox.jsx
@@ -1,0 +1,60 @@
+/**
+  * ValidateValuesFileDetailBox.jsx
+  * Created by Kevin Li 6/27/16
+  **/
+
+import React from 'react';
+import * as Icons from '../../SharedComponents/icons/Icons.jsx';
+
+const defaultProps = {
+	styleClass: '',
+	label: '',
+	count: 0,
+	expandedReport: false,
+	onClick: null
+}
+
+export default class ValidateValuesFileDetailBox extends React.Component {
+	render() {
+
+		// handle CSS class for determining if the error/warning count should be color text or black
+		let labelClass = 'usa-da-validate-item-message-count';
+		if (this.props.count == 0) {
+			labelClass += ' none';
+		}
+
+		// handle CSS for displaying the error/warning report button only when there are errors/warnings
+		let showButton = ' hide';
+		if (this.props.count > 0) {
+			showButton = '';
+		}
+
+		// handle CSS class for expanding/collapsing the error/warning report
+		let footerStatus = '';
+		if (this.props.expandedReport) {
+			footerStatus = ' active';
+		}
+
+		// toggle report button icon for open/close state
+		let buttonIcon = <Icons.AngleDown />;
+		if (this.props.expandedReport) {
+			buttonIcon = <Icons.AngleUp />;
+		}
+
+		return (
+			<div className={"col-md-6 " + this.props.styleClass}>
+		        <div className="row usa-da-validate-item-body">
+		            <div className='usa-da-validate-txt-wrap'>
+		                <span className="usa-da-validate-item-message-label">{this.props.label}:&nbsp;</span>
+		                <span className={labelClass}>{this.props.count}</span>
+		            </div>
+		        </div>
+		        <div className="row usa-da-validate-item-footer-wrapper">
+		            <div className={"usa-da-validate-item-footer usa-da-header-error" + showButton + footerStatus} onClick={this.props.onClick}>
+		                <div>View &amp; Download {this.props.label} Report <span className={"usa-da-icon"}>{buttonIcon}</span></div>
+		            </div>
+		        </div>
+		    </div>
+		)
+	}
+}

--- a/src/js/components/validateData/validateValues/ValidateValuesOverlay.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesOverlay.jsx
@@ -68,11 +68,21 @@ export default class ValidateValuesOverlay extends React.Component {
 			uploadButtonDisabled = true;
 			uploadButtonClass = '-disabled';
 			buttonText = 'Uploading files...';
+
+			if (this.props.errors.length == 0) {
+				nextButtonClass = '-disabled';
+				nextButtonDisabled = true;
+			}
 		}
 		else if (this.props.submission.state == 'prepare') {
 			uploadButtonDisabled = true;
 			uploadButtonDisabled = '-disabled';
 			buttonText = 'Gathering data...';
+			
+			if (this.props.errors.length == 0) {
+				nextButtonClass = '-disabled';
+				nextButtonDisabled = true;
+			}
 		}
 
 

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
@@ -44,33 +44,41 @@ class ValidateValuesTreemap extends React.Component {
 		this.props.data.forEach((item) => {
 
 			let detail = null;
+
+			let title = item.field_name;
 			if (item.error_name == 'rule_failed') {
 				detail = item.rule_failed;
+				title = 'Rule ' + item.original_label;
+				if (item.original_label == '') {
+					title = 'Unknown Rule';
+				}
 			}
 
 
 			// calculate the max and min occurrences, this will be used by the treemap to determine the color/shade
-			if (!maxCount || maxCount < item.occurrences) {
-				maxCount = item.occurrences;
+			const occurrences = parseInt(item.occurrences);
+			if (!maxCount || maxCount < occurrences) {
+				maxCount = occurrences;
 			}
-			if (!minCount || minCount > item.occurrences) {
-				minCount = item.occurrences;
+			if (!minCount || minCount > occurrences) {
+				minCount = occurrences;
 			}
 
+			let ruleLabel = item.original_label;
 
 			data.push({
-				rule: item.field_name,
+				title: title,
 				value: item.occurrences,
 				field: item.field_name,
 				description: item.error_description,
 				detail: detail
 			});
 		});
-
+		
 		// sort by descending value
 		this.setState({
 			formattedData: {
-				data: _.orderBy(data, ['value', 'rule'], 'desc'),
+				data: _.orderBy(data, ['value', 'title'], 'desc'),
 				min: minCount,
 				max: maxCount
 			}

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemap.jsx
@@ -93,7 +93,7 @@ class ValidateValuesTreemap extends React.Component {
 		return (
 			<div className="row">
 				<div className="col-md-9">
-					<Treemap formattedData={this.state.formattedData} width={this.props.containerWidth * 0.75} clickedItem={this.clickedItem.bind(this)} />
+					<Treemap formattedData={this.state.formattedData} width={this.props.containerWidth * 0.75} clickedItem={this.clickedItem.bind(this)} color={this.props.color} />
 				</div>
 				<div className="col-md-3">
 					{help}

--- a/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesTreemapHelp.jsx
@@ -21,8 +21,8 @@ export default class ValidateValuesTreemapHelp extends React.Component {
 		}
 		return (
 			<div className="usa-da-treemap-help-wrap">
-				<div className="treemap-help-title hide">
-					Rule {this.props.rule}
+				<div className="treemap-help-title">
+					{this.props.title}
 				</div>
 				<div className="treemap-help-description">
 					<b>Field:</b> {this.props.field}<br />


### PR DESCRIPTION
* UI implementation only, no API integration
* Will currently always display 0 warnings until API is ready
* Refactors warnings/critical errors sections into a smaller, shared React component
* Restores `original_label` behavior in treemaps
* Fixes a bug where if the number of occurrences exceeds 9, strange treemap cell coloring occurs