### PR TITLE
Handle Validation Errors

### DIFF
--- a/src/js/components/validateData/ValidateDataContent.jsx
+++ b/src/js/components/validateData/ValidateDataContent.jsx
@@ -29,7 +29,6 @@ export default class ValidateDataContent extends React.Component {
     render() {
         
         let allValid = true;
-        let allDone = true;
         let errors = [];
         let items = fileTypes.map((type, index) => {
             const validationStatus = this.props.submission.validation[type.requestName];
@@ -40,19 +39,15 @@ export default class ValidateDataContent extends React.Component {
                     errors.push(type.requestName);
                 }
 
-                if (validationStatus.job_status != 'finished' && validationStatus.job_status != 'invalid') {
-                    allDone = false;
-                }
-
                 return <ValidateDataFileContainer key={index} type={type} data={this.props.submission.validation} />;
             }
         });
 
         let overlay = '';
         let displayOverlay = '';
-        if (!allDone) {
+        if (!this.props.hasFinished || this.props.hasFailed) {
             // still loading or validating
-            overlay = <ValidateDataInProgressOverlay />;
+            overlay = <ValidateDataInProgressOverlay hasFailed={this.props.hasFailed} />;
         }
         else {
             overlay = <ValidateDataOverlayContainer errors={errors} />;

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -31,7 +31,8 @@ export default class ValidateDataFileComponent extends React.Component {
             headerTitle: 'Validating...',
             errorReports: [],
             hasErrorReport: false,
-            isError: false
+            isError: false,
+            hasFailed: false
         };
     }
 
@@ -82,6 +83,7 @@ export default class ValidateDataFileComponent extends React.Component {
         let isError = false;
         const errorKeys = [];
         let errorData = [];
+        let hasFailed = false;
 
         if (item.missing_headers.length > 0) {
             errorKeys.push('missing_headers');
@@ -137,11 +139,20 @@ export default class ValidateDataFileComponent extends React.Component {
             isError = false;
         }
 
+        if (item.job_status == 'failed') {
+            headerTitle = 'An error occurred while validating this file. Contact an administrator for assistance.';
+            errorData = [];
+            hasErrorReport = false;
+            isError = false;
+            hasFailed = true;
+        }
+
         this.setState({
             headerTitle: headerTitle,
             errorReports: errorData,
             hasErrorReport: hasErrorReport,
-            isError: isError
+            isError: isError,
+            hasFailed: hasFailed
         });
     }
 

--- a/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
+++ b/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
@@ -6,6 +6,10 @@
 import React from 'react';
 import * as Icons from '../SharedComponents/icons/Icons.jsx';
 
+const defaultProps = {
+	hasFailed: false
+};
+
 export default class ValidateDataInProgressOverlay extends React.Component {
 
 	constructor(props) {
@@ -14,13 +18,19 @@ export default class ValidateDataInProgressOverlay extends React.Component {
 	
 	render() {
 
+		let title = 'Your files are being validated.';
+		if (this.props.hasFailed) {
+			title = 'An error has occurred while validating your files.';
+		}
+
+
 		return (
 			<div className="center-block usa-da-validation-overlay">
 				<div className="container">
 					<div className="row">
 						<div className="col-md-12 usa-da-overlay-content-wrap">
 							<div className="overlay-loading">
-								<h6>Your files are being validated.</h6>
+								<h6>{title}</h6>
 								<div className="overlay-help-text">
 									You can return to this page at any time to check the validation status by using this link:<br />
 									<a href={window.location.href}>{window.location.href}</a>
@@ -33,3 +43,5 @@ export default class ValidateDataInProgressOverlay extends React.Component {
 		);
 	}
 }
+
+ValidateDataInProgressOverlay.defaultProps = defaultProps;

--- a/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
+++ b/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
@@ -19,8 +19,11 @@ export default class ValidateDataInProgressOverlay extends React.Component {
 	render() {
 
 		let title = 'Your files are being validated.';
+		let description = 'You can return to this page at any time to check the validation status by using this link:';
+
 		if (this.props.hasFailed) {
 			title = 'An error has occurred while validating your files.';
+			description = 'Contact an administrator for assistance. Provide this URL when describing the issue:';
 		}
 
 
@@ -32,7 +35,8 @@ export default class ValidateDataInProgressOverlay extends React.Component {
 							<div className="overlay-loading">
 								<h6>{title}</h6>
 								<div className="overlay-help-text">
-									You can return to this page at any time to check the validation status by using this link:<br />
+									{description}
+									<br />
 									<a href={window.location.href}>{window.location.href}</a>
 								</div>
 							</div>

--- a/src/js/containers/validateData/ValidateDataContainer.jsx
+++ b/src/js/containers/validateData/ValidateDataContainer.jsx
@@ -34,16 +34,20 @@ class ValidateDataContainer extends React.Component {
 			initialLoad: moment(),
 			notYours: false
 		};
+
+		this.isCancelled = false;
 	}
 
 
 	componentDidMount() {
+		this.isCancelled = false;
 		this.validateSubmission();
 		
 	}
 
 	componentWillUnmount() {
 		// remove any timers
+		this.isCancelled = true;
 		if (statusTimer) {
 			clearTimeout(statusTimer);
 			statusTimer = null;
@@ -102,6 +106,12 @@ class ValidateDataContainer extends React.Component {
 
 		ReviewHelper.validateSubmission(this.props.submissionID)
 			.then((data) => {
+
+				if (this.isCancelled) {
+					// the component has been unmounted, so don't bother with updating the state (it doesn't exist anymore anyway)
+					return;
+				}
+
 				this.setState({
 					finishedLoad: true
 				});

--- a/src/js/containers/validateData/ValidateDataContainer.jsx
+++ b/src/js/containers/validateData/ValidateDataContainer.jsx
@@ -33,7 +33,8 @@ class ValidateDataContainer extends React.Component {
 			headerErrors: true,
 			validationFailed: false,
 			validationFinished: false,
-			notYours: false
+			notYours: false,
+			serverError: null
 		};
 
 		this.isCancelled = false;
@@ -71,7 +72,8 @@ class ValidateDataContainer extends React.Component {
 				headerErrors: true,
 				validationFailed: false,
 				validationFinished: false,
-				notYours: false
+				notYours: false,
+				serverError: null
 			}, () => {
 				this.validateSubmission();
 			});
@@ -146,6 +148,11 @@ class ValidateDataContainer extends React.Component {
 						notYours: true
 					});
 				}
+				else if (err.detail != '') {
+					this.setState({
+						serverError: err.detail
+					});
+				}
 				else {
 					statusTimer = setTimeout(() => {
 						this.validateSubmission();
@@ -170,8 +177,10 @@ class ValidateDataContainer extends React.Component {
 		}
 
 		if (this.state.notYours) {
-			validationContent = '';
-			cancel = <ValidateNotYours message="You cannot view or modify this submission because you are not the original submitter." />;
+			validationContent = <ValidateNotYours message="You cannot view or modify this submission because you are not the original submitter." />;
+		}
+		if(this.state.serverError) {
+			validationContent = <ValidateNotYours message="This is not a valid submission. Check your validation URL and try again." />;
 		}
 
 		return (

--- a/src/js/containers/validateData/ValidateDataContainer.jsx
+++ b/src/js/containers/validateData/ValidateDataContainer.jsx
@@ -33,7 +33,6 @@ class ValidateDataContainer extends React.Component {
 			headerErrors: true,
 			validationFailed: false,
 			validationFinished: false,
-			initialLoad: moment(),
 			notYours: false
 		};
 
@@ -60,13 +59,22 @@ class ValidateDataContainer extends React.Component {
 		// check if the submission state changed, indicating a re-upload
 		if (prevProps.submission.state != this.props.submission.state) {
 			if (this.props.submission.state == "prepare") {
-				// uploads are done, reset the cancellation timer
-				this.setState({
-					initialLoad: moment()
-				}, () => {
-					this.validateSubmission();
-				});
+				this.validateSubmission();
 			}
+		}
+
+		// additionally, restart the process if the submission ID changes
+		if (prevProps.submissionID != this.props.submissionID) {
+			this.props.resetSubmission();
+			this.setState({
+				finishedPageLoad: false,
+				headerErrors: true,
+				validationFailed: false,
+				validationFinished: false,
+				notYours: false
+			}, () => {
+				this.validateSubmission();
+			});
 		}
 	}
 
@@ -129,19 +137,13 @@ class ValidateDataContainer extends React.Component {
 							this.validateSubmission();
 						}, 5*1000);
 					}
-					else {
-						this.setState({
-							initialLoad: moment()
-						});
-					}
 				});
 
 			})
 			.catch((err) => {
 				if (err.reason == 400) {
 					this.setState({
-						notYours: true,
-						initialLoad: moment()
+						notYours: true
 					});
 				}
 				else {

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -66,9 +66,15 @@ export const fetchStatus = (submissionId) => {
 	        .end((errFile, res) => {
 
 	        	if (errFile) {
+	        		let detail = '';
+	        		if (res.body != null && res.body.hasOwnProperty('message')) {
+	        			detail = res.body.message;
+	        		}
+
 	        		deferred.reject({
 	        			reason: res.statusCode,
-	        			error: errFile
+	        			error: errFile,
+	        			detail: detail
 	        		});
 	        	}
 	        	else {


### PR DESCRIPTION
* Display an error message when a validation job fails
* Display an error message when an invalid submission ID is provided
* Allow the page to reload when the submission ID in the URL changes
* Fixes a bug where unmounting the validation Redux container while a `check_status` API call was in-flight and the previous API call had not resulted in a fully complete set of validation jobs would cause the Redux submission object to be reset every 5 seconds
* Fixes a bug where "not yours" error message would never show up
* Page no longer constantly reloads `check_status` when validation job failures occur
* Refactored `check_status` response code to use fewer for loops