### PR TITLE
Hotfix: Cross-file D1/D2 regeneration

### DIFF
--- a/src/js/components/crossFile/components/GeneratedErrorButton.jsx
+++ b/src/js/components/crossFile/components/GeneratedErrorButton.jsx
@@ -51,7 +51,7 @@ export default class GeneratedErrorButton extends React.Component {
 				<div className={"usa-da-button btn-full " + buttonClass} onClick={this.showModal.bind(this)}>
 					File {this.props.file.letter}: {this.props.file.name}
 				</div>
-				<GeneratedFileModal showModal={this.state.showModal} closeModal={this.closeModal.bind(this)} file={this.props.file} finishedGenerating={this.finishedGenerating.bind(this)} />
+				<GeneratedFileModal showModal={this.state.showModal} closeModal={this.closeModal.bind(this)} file={this.props.file} finishedGenerating={this.finishedGenerating.bind(this)} submissionID={this.props.submissionID} />
 			</div>
 
 		)

--- a/src/js/components/crossFile/components/GeneratedFileModal.jsx
+++ b/src/js/components/crossFile/components/GeneratedFileModal.jsx
@@ -12,7 +12,7 @@ export default class GeneratedFileModal extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			disabledButton: false,
+			disabledButton: true,
 			buttonText: 'Generate File',
 			message: ''
 		};

--- a/src/js/containers/crossFile/CrossFileGenerateModalContainer.jsx
+++ b/src/js/containers/crossFile/CrossFileGenerateModalContainer.jsx
@@ -49,6 +49,10 @@ export default class CrossFileGenerateModalContainer extends React.Component {
 	}
 
 	componentDidMount() {
+		// disable the submit button while we load the initial data
+		this.props.setMessage('Gathering data...');
+		this.props.disableButton();
+
 		this.checkForPreviousFiles();
 	}
 


### PR DESCRIPTION
* Fixes a bug where submission ID was not passed to the regeneration modal
* Disabled Generate button in regeneration modal while initial `check_dX_file` request is in flight