### PR TITLE
Hide hashed URLs

### DIFF
--- a/src/js/components/generateFiles/components/GenerateFileBox.jsx
+++ b/src/js/components/generateFiles/components/GenerateFileBox.jsx
@@ -27,7 +27,7 @@ export default class GenerateFileBox extends React.Component {
 		}
 
 		let showDownload = ' hide';
-		if (this.props.download.show) {
+		if (this.props.download.show && this.props.download.url != '#') {
 			showDownload = '';
 		}
 


### PR DESCRIPTION
* If D1/D2 generation routes return a URL of `#`, do not show the download link.

- [x]  Code review
- [x]  @jworcestBAH sign off