### PR TITLE
Hotfix: Incorrect adjustment for zero-indexed months

### DIFF
--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -97,7 +97,7 @@ class GenerateFilesContainer extends React.Component {
 			day = '01';
 		}
 		else if (type == 'end') {
-			const date = moment().month(parseInt(month) + 1).year(year);
+			const date = moment().month(parseInt(month) - 1).year(year);
 			day = date.endOf('month').format('DD');
 		}
 


### PR DESCRIPTION
* Resulted in JS errors when month lengths differed from expected