### PR TITLE
Hotfix to remove link

### DIFF
--- a/src/js/components/help/helpContent.jsx
+++ b/src/js/components/help/helpContent.jsx
@@ -102,9 +102,6 @@ export default class HelpContent extends React.Component {
                         Domain Values resource &nbsp;&nbsp;
                         <a href={this.state.domainValuesUrl} target="_blank">Download file</a>
                     </li>
-                    <li>
-                        <a href="/#/practices?section=top" target="_self">Practices and Procedures</a>
-                    </li>
                 </ul>
 
                 <h2 className="mt-50">Getting More Help</h2>


### PR DESCRIPTION
- Removing practices & procedures link from help page temporarily