### PR TITLE
Hotfix updates

### DIFF
--- a/src/js/components/generateEF/GenerateEFContent.jsx
+++ b/src/js/components/generateEF/GenerateEFContent.jsx
@@ -12,7 +12,7 @@ import GenerateEFItem from './generateItem/GenerateEFItem.jsx';
 
 export default class GenerateFilesContent extends React.Component {
 
-    
+
 	render() {
 		return (
 			<div>
@@ -25,9 +25,9 @@ export default class GenerateFilesContent extends React.Component {
 
 					 <div className="alert alert-warning">
                             <span className="usa-da-icon"><Icons.ExclamationCircle /></span>
-                            <p>Functionality related to <b>Files E and F</b> are not yet available.</p>
+                            <p>Download functionality related to <b>Files E and F</b> are not yet available.</p>
                     </div>
-				
+
 					<GenerateEFItem {...this.props}
 						comingSoon={true}
 						type="E"

--- a/src/js/components/help/helpContent.jsx
+++ b/src/js/components/help/helpContent.jsx
@@ -102,9 +102,6 @@ export default class HelpContent extends React.Component {
                         Domain Values resource &nbsp;&nbsp;
                         <a href={this.state.domainValuesUrl} target="_blank">Download file</a>
                     </li>
-                    <li>
-                        <a href="/#/practices?section=top" target="_self">Practices and Procedures</a>
-                    </li>
                 </ul>
 
                 <h2 className="mt-50">Getting More Help</h2>


### PR DESCRIPTION
- Removing Practices & Procedures link on help page
- Updating text for E & F to read “Download functionality related to
Files E and F are not yet available.”