### PR TITLE
Handle unparseable header rows

### DIFF
--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -131,6 +131,15 @@ export default class ValidateDataFileComponent extends React.Component {
             });
         }
 
+        else if (item.missing_headers.length == 0 && item.duplicated_headers.length == 0 && item.error_type == 'header_errors') {
+            // special case where the header rows could not be read
+            headerTitle = 'Critical Error: The header row could not be parsed.';
+            errorData = [];
+            hasErrorReport = false;
+            hasFailed = true;
+            isError = true;
+        } 
+
 
         if (item.file_status == 'incomplete' || !this.isFileReady()) {
             headerTitle = 'Validating...';


### PR DESCRIPTION
* Displays an error message when the header rows cannot be parsed rather than becoming stuck in validation