### PR TITLE
Switching check detached generation status to pass job_id instead of file_type

### DIFF
--- a/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
+++ b/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
@@ -204,9 +204,9 @@ export default class GenerateDetachedFilesPage extends React.Component {
             });
     }
 
-    checkFileStatus(file) {
+    checkFileStatus(job_id) {
         // callback to check file status
-        GenerateFilesHelper.fetchDetachedFile(file)
+        GenerateFilesHelper.fetchDetachedFile(job_id)
             .then((response) => {
                 if (this.isUnmounted) {
 					return;
@@ -272,7 +272,7 @@ export default class GenerateDetachedFilesPage extends React.Component {
         if (runCheck && !this.isUnmounted) {
             // wait 5 seconds and check the file status again
 			window.setTimeout(() => {
-				this.checkFileStatus(data.file_type);
+				this.checkFileStatus(data.job_id);
 			}, timerDuration * 1000);
         }
     }

--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -103,12 +103,12 @@ export const generateDetachedFile = (type, start, end, cgac_code) => {
     return deferred.promise;
 }
 
-export const fetchDetachedFile = (type) => {
+export const fetchDetachedFile = (job_id) => {
     const deferred = Q.defer();
 
     Request.post(kGlobalConstants.API + 'check_detached_generation_status/')
             .send({
-                'file_type': type
+                'job_id': job_id
             })
             .end((errFile, res) => {
 


### PR DESCRIPTION
- Using `job_id` to look up generation status (which is returned as part of the response for `generate_detached_file`)

- [x] tested on sandbox with https://github.com/fedspendingtransparency/data-act-broker-backend/pull/454