### PR TITLE
Add eslintrc rules consistent w/ codebase + Travis

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/js/vendor

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
         "comma-spacing": 0,
         "dot-notation": 0,
         "eol-last": 0,
-        "eqeqeq": 0,
+        "eqeqeq": 0,    // ASAP
         "guard-for-in": 0,
         "indent": 0,
         "key-spacing": 0,
@@ -21,16 +21,15 @@
         "no-multi-spaces": 0,
         "no-param-reassign": 0,
         "no-trailing-spaces": 0,
-        "no-undef": 0,
+        "no-undef": 0,    // ASAP
         "no-unused-vars": 0,
-        "no-use-before-define": 0,
+        "no-use-before-define": 0,  // ASAP
         "object-curly-spacing": 0,
         "object-shorthand": 0,
         "padded-blocks": 0,
         "prefer-const": 0,
         "quote-props": 0,
         "quotes": 0,
-        "radix": 0,
         "semi": 0,
         "space-infix-ops": 0,
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,6 @@
         "no-multi-spaces": 0,
         "no-param-reassign": 0,
         "no-trailing-spaces": 0,
-        "no-undef": 0,    // ASAP
         "no-unused-vars": 0,
         "no-use-before-define": 0,  // ASAP
         "object-curly-spacing": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,36 @@
     "extends": "airbnb",
     "rules": {
         // Override any settings from the airbnb configuration
-        "indent": [2, 4],
-        "comma-dangle": 0
+        // "indent": [2, 4],
+        "comma-dangle": 0,
+        // To fix
+        "brace-style": 0,
+        "camelcase": 0,
+        "comma-spacing": 0,
+        "dot-notation": 0,
+        "eol-last": 0,
+        "eqeqeq": 0,
+        "guard-for-in": 0,
+        "indent": 0,
+        "key-spacing": 0,
+        "max-len": 0,
+        "no-console": 0,
+        "no-mixed-spaces-and-tabs": 0,
+        "no-multiple-empty-lines": 0,
+        "no-multi-spaces": 0,
+        "no-param-reassign": 0,
+        "no-trailing-spaces": 0,
+        "no-undef": 0,
+        "no-unused-vars": 0,
+        "no-use-before-define": 0,
+        "object-curly-spacing": 0,
+        "object-shorthand": 0,
+        "padded-blocks": 0,
+        "prefer-const": 0,
+        "quote-props": 0,
+        "quotes": 0,
+        "radix": 0,
+        "semi": 0,
+        "space-infix-ops": 0,
     }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ before_script:
   - cp sampleGlobalConstants_local.js GlobalConstants_local.js
 script:
   - gulp buildLocal
+  - eslint src/js

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -172,7 +172,7 @@ const getFileStates = (status) => {
 		else {
 			let count = 0;
 			item.error_data.forEach((error) => {
-				count += parseInt(error.occurrences);
+				count += parseInt(error.occurrences, 10);
 			});
 
 			output[item.file_type].error_count = count;
@@ -185,7 +185,7 @@ const getFileStates = (status) => {
 		else {
 			let count = 0;
 			item.warning_data.forEach((warning) => {
-				count += parseInt(warning.occurrences);
+				count += parseInt(warning.occurrences, 10);
 			});
 			output[item.file_type].warning_count = count;
 		}

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -346,9 +346,9 @@ export const validateSubmission  = (submissionId) => {
 			});
 		})
 		.catch((err) => {
-			const response = Object.assign({}, res.body);
-            response.httpStatus = res.status;
-            deferred.reject(response);
+			const response = Object.assign({}, err.body);
+			response.httpStatus = err.status;
+			deferred.reject(response);
 		});
 
 	return deferred.promise;

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -66,7 +66,7 @@ export const rssFileKey = () => {
 
 export const currentQuarter = (type) => {
 
-	const month = parseInt(moment().format("M"));
+	const month = parseInt(moment().format("M"), 10);
     let year = moment().format('YYYY');
 
 	let quarter = 4;
@@ -88,7 +88,7 @@ export const currentQuarter = (type) => {
 
 export const fyStartDate = () => {
 
-	const month = parseInt(moment().format("M"));
+	const month = parseInt(moment().format("M"), 10);
     let year = moment().format('YYYY');
 
     if (month >= 10) {
@@ -109,10 +109,10 @@ export const quarterToMonth = (quarter, quarterYear, type) => {
         month = endMonth[quarter - 1];
     }
 
-    let year = parseInt(quarterYear);
+    let year = parseInt(quarterYear, 10);
     if (quarter == 1) {
         // decrement the year by one for the first quarter of the fiscal year
-        year = parseInt(quarterYear) - 1;
+        year -= 1;
     }
 
     return month + '/' + year;


### PR DESCRIPTION
Rather than go without a linter (our current strategy), let's draw a line in
the sand and prevent future issues by adding a linter that matches our current
code base. We're breaking some pretty important rules (e.g. no-undef), so we
should revisit these to fix things ASAP.