### PR TITLE
Include submission context in UI

### DIFF
--- a/src/js/components/addData/AddDataHeader.jsx
+++ b/src/js/components/addData/AddDataHeader.jsx
@@ -8,15 +8,15 @@ import moment from 'moment';
 
 import * as ReviewHelper from '../../helpers/reviewHelper.js';
 
-class LastUpdated extends React.Component {
-    constructor(props){
-        super(props);
-    }
-    
+class SubmissionContext extends React.Component {
     render() {
         return (
             <div className="last-updated">
-                Last Saved: {this.props.last_updated}
+                Last Saved: {this.props.formattedTime}
+                <br />
+                {this.props.agencyName}
+                <br />
+                {this.props.submissionTime}
             </div>
         );
     }
@@ -60,10 +60,14 @@ export default class AddDataHeader extends React.Component {
     }
 
     render() {
-        let lastUpdated = null;
-        if (this.state.ready && this.state.last_updated){
+        let submissionContext = null;
+        if (this.state.ready) {
             let formattedTime = moment.utc(this.state.last_updated).local().format('h:mm a');
-            lastUpdated = <LastUpdated last_updated={formattedTime} />
+            submissionContext = <SubmissionContext
+              formattedTime={formattedTime}
+              agencyName={this.state.agency_name}
+              submissionTime={this.state.reporting_period_start_date}
+            />
         }
 
         return (
@@ -74,7 +78,7 @@ export default class AddDataHeader extends React.Component {
                             <div className="display-2" data-contentstart="start" tabIndex={-1}>{this.props.title}</div>
                         </div>
                         <div className="col-md-2">
-                            {lastUpdated}
+                            {submissionContext}
                         </div>
                         
                     </div>

--- a/src/js/components/addData/AddDataHeader.jsx
+++ b/src/js/components/addData/AddDataHeader.jsx
@@ -16,7 +16,7 @@ class SubmissionContext extends React.Component {
                 <br />
                 {this.props.agencyName}
                 <br />
-                {this.props.submissionTime}
+                {this.props.timePeriodLabel}
             </div>
         );
     }
@@ -66,7 +66,7 @@ export default class AddDataHeader extends React.Component {
             submissionContext = <SubmissionContext
               formattedTime={formattedTime}
               agencyName={this.state.agency_name}
-              submissionTime={this.state.reporting_period_start_date}
+              timePeriodLabel={this.state.reporting_period_start_date}
             />
         }
 

--- a/src/js/components/crossFile/components/ErrorBox.jsx
+++ b/src/js/components/crossFile/components/ErrorBox.jsx
@@ -132,9 +132,8 @@ export default class ErrorBox extends React.Component {
         window.location = this.state.signedUrl;
     }
 
-    signReport(type) {
-        const fileName = `submission_${this.props.submission.id}_cross${type}${this.props.meta.firstKey}_${this.props.meta.secondKey}`;
-        ReviewHelper.signErrorWarningReport(this.props.submission.id, fileName)
+    signReport(warning) {
+        ReviewHelper.submissionReport(this.props.submission.id, warning, this.props.meta.firstKey, this.props.meta.secondKey)
             .then((data) => {
                 this.setState({
                     signInProgress: false,
@@ -151,7 +150,7 @@ export default class ErrorBox extends React.Component {
             });
     }
 
-    clickedReport(type, e) {
+    clickedReport(warning, e) {
         e.preventDefault();
         // check if the link is already signed
         if (this.state.signInProgress) {
@@ -167,7 +166,7 @@ export default class ErrorBox extends React.Component {
             this.setState({
                 signInProgress: true
             }, () => {
-                this.signReport(type);
+                this.signReport(warning);
             });
         }
     }
@@ -187,7 +186,7 @@ export default class ErrorBox extends React.Component {
 
 		let tableKey = this.state.activeTab;
 		let reportName = "Error Report";
-        let reportFileNameType = "_";
+		let reportWarning = false;
 
 		if (this.state.activeTab == 'errors' && this.props.status == 'warning') {
 			// in the case of a warning only pair, the state won't have time to change to warnings on initial load
@@ -196,7 +195,7 @@ export default class ErrorBox extends React.Component {
 
 		if (tableKey == 'warnings') {
 			reportName = "Warning Report";
-            reportFileNameType = "_warning_";
+			reportWarning = true;
 		}
 
         let downloadLabel = `Download ${reportName}`;
@@ -219,7 +218,7 @@ export default class ErrorBox extends React.Component {
 								<div className="button-list">
 									<div className="row">
 										<div className="col-md-12">
-                                            <a href="#" onClick={this.clickedReport.bind(this, reportFileNameType)} className="usa-da-button btn-full btn-primary">
+                                            <a href="#" onClick={this.clickedReport.bind(this, reportWarning)} className="usa-da-button btn-full btn-primary">
 				            	            	{downloadLabel}
 				            	            </a>
 				            	            <div className="upload-title">

--- a/src/js/components/validateData/ValidateDataErrorReport.jsx
+++ b/src/js/components/validateData/ValidateDataErrorReport.jsx
@@ -39,8 +39,7 @@ export default class ValidateDataErrorReport extends React.Component {
     }
 
     signReport() {
-        const fileName = `submission_${this.props.submission}_${this.props.type}_error_report`;
-        ReviewHelper.signErrorWarningReport(this.props.submission, fileName)
+        ReviewHelper.submissionReport(this.props.submission, false, this.props.type)
             .then((data) => {
                 this.setState({
                     signInProgress: false,

--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -113,8 +113,7 @@ export default class ValidateValuesErrorReport extends React.Component {
     }
 
     signReport() {
-        const fileName = `submission_${this.props.submission}_${this.props.fileType}_${this.props.reportType}_report`;
-        ReviewHelper.signErrorWarningReport(this.props.submission, fileName)
+        ReviewHelper.submissionReport(this.props.submission, this.props.reportType === 'warning', this.props.fileType)
             .then((data) => {
                 this.setState({
                     signInProgress: false,

--- a/src/js/containers/review/ReviewDataContainer.jsx
+++ b/src/js/containers/review/ReviewDataContainer.jsx
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import * as ReviewHelper from '../../helpers/reviewHelper.js';
-import * as AgencyHelper from '../../helpers/agencyHelper.js';
 
 import ReviewDataPage from '../../components/reviewData/ReviewDataPage.jsx';
 
@@ -53,10 +52,6 @@ class ReviewDataContainer extends React.Component {
                 data.ready = true;
                 submission = data;
 
-                return AgencyHelper.fetchAgencyName(data.cgac_code);
-            })
-            .then((name) => {
-                submission.agency_name = name;
                 return ReviewHelper.fetchSubmissionNarrative(this.props.params.submissionID);
             })
             .then((narrative) => {

--- a/src/js/helpers/agencyHelper.js
+++ b/src/js/helpers/agencyHelper.js
@@ -23,21 +23,3 @@ export const fetchAgencies = () => {
 
     return deferred.promise;
 }
-
-export const fetchAgencyName = (cgac) => {
-    const deferred = Q.defer();
-
-
-    fetchAgencies()
-        .then((agencies) => {
-            const index = _.findIndex(agencies, {cgac_code: cgac});
-            if (index > -1) {
-                deferred.resolve(agencies[index].agency_name);
-            }
-            else {
-                deferred.resolve("UNKNOWN");
-            }
-        });
-
-    return deferred.promise;
-}

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -415,13 +415,14 @@ export const fetchObligations = (submissionId) => {
 	return deferred.promise;
 }
 
-export const signErrorWarningReport = (submissionId, fileName) => {
+export const submissionReport = (submissionId, warning, fileType, crossType) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'sign_submission_file')
+    Request.post(kGlobalConstants.API + 'submission/' + submissionId + '/report_url')
         .send({
-            'submission': submissionId,
-            'file': fileName
+            'warning': warning,
+            'file_type': fileType,
+            'cross_type': crossType
         })
         .end((errFile, res) => {
             if (errFile) {


### PR DESCRIPTION
~~Depends on fedspendingtransparency/data-act-broker-backend#484~~. Adds the agency name and submission date to the floating submission context:

<img width="553" alt="screen shot 2016-12-30 at 12 02 54 pm" src="https://cloud.githubusercontent.com/assets/326918/21570108/7b088aee-ce88-11e6-913b-878bba90c979.png">
