### PR TITLE
Css to read line breaks for formatting, and added agency column to th…

### DIFF
--- a/src/_scss/pages/landing/recentActivity/_table.scss
+++ b/src/_scss/pages/landing/recentActivity/_table.scss
@@ -7,5 +7,9 @@
         @include submissionTableLink;
     }
 
+    .white-space {
+    	white-space: pre;
+    }
+
     @import "../../../components/tables/_submissionTableProgress";
 }

--- a/src/js/components/landing/recentActivity/RecentActivityTable.jsx
+++ b/src/js/components/landing/recentActivity/RecentActivityTable.jsx
@@ -20,12 +20,13 @@ export default class RecentActivityTable extends React.Component {
 
 		this.tableHeaders = [
 			'View',
+			'Agency',
 			'Reporting Period',
 			'Submitted By',
 			'Last Modified Date',
 			'Size',
 			'Status',
-			'Errors'
+			// 'Errors'
 		];
 
 		this.state = {
@@ -78,7 +79,7 @@ export default class RecentActivityTable extends React.Component {
 		const output = [];
 		const rowClasses = [];
 
-		const classes = ['row-10 text-center', 'row-15 text-right', 'row-15 text-right', 'row-15 text-right','row-10 text-right', 'row-25 text-right progress-cell', 'row-10 text-right'];
+		const classes = ['row-10 text-center', 'row-20 text-center', 'row-15 text-right white-space', 'row-15 text-right', 'row-15 text-right','row-10 text-right', 'row-15 text-right progress-cell'];
 
 		// sort the array by object key
 		const orderKeys = ['sortableReportingDate', 'sortableName', 'sortableDate', 'sortableSize', 'sortableStatus', 'errors'];
@@ -87,7 +88,7 @@ export default class RecentActivityTable extends React.Component {
 		// iterate through each item returned from the API
 		data.forEach((item) => {
 
-			let reportingDateString = item.reporting_start_date + ' to ' + item.reporting_end_date;
+			let reportingDateString = "Start: "+item.reporting_start_date + "\nEnd: " + item.reporting_end_date;
 			if (!item.reporting_start_date || !item.reporting_end_date) {
 				reportingDateString = 'No reporting period specified';
 			}
@@ -100,12 +101,12 @@ export default class RecentActivityTable extends React.Component {
             // break the object out into an array for the table component
 			const row = [
 				<SubmissionLink submissionId={item.submission_id} />,
+				item.agency,
 				reportingDateString,
 				userName,
 				item.last_modified,
 				item.fileSize,
-				<Status.SubmissionStatus status={item.rowStatus} />,
-				item.errors
+				<Status.SubmissionStatus status={item.rowStatus} />
 			];
 
 			rowClasses.push(classes);

--- a/src/js/components/landing/recentActivity/RecentActivityTable.jsx
+++ b/src/js/components/landing/recentActivity/RecentActivityTable.jsx
@@ -25,8 +25,7 @@ export default class RecentActivityTable extends React.Component {
 			'Submitted By',
 			'Last Modified Date',
 			'Size',
-			'Status',
-			// 'Errors'
+			'Status'
 		];
 
 		this.state = {


### PR DESCRIPTION
…e recent activity table

- [ ] merge backend first https://github.com/fedspendingtransparency/data-act-broker-backend/pull/527
- [ ] Code Review

confirm table renders correctly.
Changed format of date from xx to yy -> start: xx \n end: yy
removed the number of errors column