### PR TITLE
EF autofile generation disabled

### DIFF
--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -18,6 +18,8 @@ import ValidateDataErrorReport from './ValidateDataErrorReport.jsx';
 import ValidateDataUploadButton from './ValidateDataUploadButton.jsx';
 import * as Icons from '../SharedComponents/icons/Icons.jsx';
 
+import * as GenerateFilesHelper from '../../helpers/generateFilesHelper.js';
+
 const propTypes = {
 
 };
@@ -25,6 +27,13 @@ const propTypes = {
 export default class ValidateDataFileComponent extends React.Component {
     constructor(props) {
         super(props);
+
+        console.log(this.props)
+
+        GenerateFilesHelper.fetchFile('A', this.props.submission.id)
+            .then((response)=>{
+                console.log(response);
+            })
 
         this.state = {
             showError: false,

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -18,8 +18,6 @@ import ValidateDataErrorReport from './ValidateDataErrorReport.jsx';
 import ValidateDataUploadButton from './ValidateDataUploadButton.jsx';
 import * as Icons from '../SharedComponents/icons/Icons.jsx';
 
-import * as GenerateFilesHelper from '../../helpers/generateFilesHelper.js';
-
 const propTypes = {
 
 };
@@ -27,13 +25,6 @@ const propTypes = {
 export default class ValidateDataFileComponent extends React.Component {
     constructor(props) {
         super(props);
-
-        console.log(this.props)
-
-        GenerateFilesHelper.fetchFile('A', this.props.submission.id)
-            .then((response)=>{
-                console.log(response);
-            })
 
         this.state = {
             showError: false,

--- a/src/js/containers/generateEF/GenerateEFContainer.jsx
+++ b/src/js/containers/generateEF/GenerateEFContainer.jsx
@@ -31,14 +31,15 @@ class GenerateEFContainer extends React.Component {
 			isReady: false,
 			hasErrors: false,
 			e: {},
-			f: {}
+			f: {},
+			generated: false
 		};
 
 	}
 
 	componentDidMount() {
 		this.isUnmounted = false;
-		this.generateFiles();
+		this.checkFileStatus();
 	}
 
 	componentWillUnmount() {
@@ -59,7 +60,13 @@ class GenerateEFContainer extends React.Component {
 				data = response.value;
 
 				if (data.status == 'invalid') {
-					data.message = 'Prerequisites required to generate this file are incomplete.';
+					if(!this.state.generated){
+						this.setState({'generated': true});
+						this.generateFiles();
+						return;
+					}else{
+						data.message = 'Prerequisites required to generate this file are incomplete.';
+					}
 				}
 			}
 			else {


### PR DESCRIPTION
Adding a flag to the state so that we can identify if it has not been generated (queuing the generation) or if it is an error. Instead of generating on componentDidMount, do fileStatusCheck instead.