### PR TITLE
Db 1766 prevent monthly certification

### DIFF
--- a/src/_scss/pages/reviewData/_content.scss
+++ b/src/_scss/pages/reviewData/_content.scss
@@ -8,4 +8,9 @@
     @import "./rightSide/rightSide";
     @import "./bottomSide/bottomSide";
     @import "./narrative/narrative";
+
+    .monthly-submission-error {
+        margin-left: 15px;
+        margin-top: 10px;
+    }
 }

--- a/src/_scss/pages/reviewData/_content.scss
+++ b/src/_scss/pages/reviewData/_content.scss
@@ -12,5 +12,9 @@
     .monthly-submission-error {
         margin-left: 15px;
         margin-top: 10px;
+
+        @media(max-width: $medium-screen) {
+            margin-left: 0;
+        }
     }
 }

--- a/src/js/components/reviewData/ReviewDataContent.jsx
+++ b/src/js/components/reviewData/ReviewDataContent.jsx
@@ -177,8 +177,8 @@ export default class ReviewDataContent extends React.Component {
             buttonAction = "";
             notifyButtonText = "Notify Another User that the Submission is Ready";
             monthlySubmissionError = <div className="alert alert-danger text-center monthly-submission-error" role="alert">
-				Monthly submissions cannot be certified
-			</div>
+                                        Monthly submissions cannot be certified
+                                    </div>
         }
 
         return (

--- a/src/js/components/reviewData/ReviewDataContent.jsx
+++ b/src/js/components/reviewData/ReviewDataContent.jsx
@@ -162,12 +162,23 @@ export default class ReviewDataContent extends React.Component {
         }
 
         let certifyButtonText = "Certify & Publish the Submission to USAspending.gov";
+        let notifyButtonText = "Notify Another User that the Submission is Ready for Certification";
         let buttonClass = "";
         let buttonAction = this.openModal.bind(this, modalToOpen);
+        let monthlySubmissionError = null;
         if (this.props.data.publish_status == "published") {
             certifyButtonText = "Submission has already been certified";
             buttonClass = " btn-disabled";
             buttonAction = "";
+        }
+        if (!this.props.data.quarterly_submission) {
+            certifyButtonText = "Monthly submissions cannot be certified";
+            buttonClass = " btn-disabled";
+            buttonAction = "";
+            notifyButtonText = "Notify Another User that the Submission is Ready";
+            monthlySubmissionError = <div className="alert alert-danger text-center monthly-submission-error" role="alert">
+				Monthly submissions cannot be certified
+			</div>
         }
 
         return (
@@ -227,12 +238,13 @@ export default class ReviewDataContent extends React.Component {
                                             <Icons.Bell />
                                         </div>
                                         <div className="button-content">
-                                            Notify Another User that the Submission is Ready for Certification
+                                            {notifyButtonText}
                                         </div>
                                     </div>
                                 </button>
                             </div>
                         </div>
+                        {monthlySubmissionError}
                     </div>
 
                     <div id="reviewDataNotifyModalHolder">


### PR DESCRIPTION
Prevents user from certifying monthly submissions and shows a banner explaining why beneath the buttons.

- [x] Merged after or concurrently with https://github.com/fedspendingtransparency/data-act-broker-backend/pull/610
- [x] Reviewed by frontend