### PR TITLE
db-1761 - force to revalidate/re-certify submission

### DIFF
--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -124,6 +124,11 @@ class GenerateFilesContainer extends React.Component {
 						// no request has been made yet
 						allRequested = false;
 					}
+					// certified submission files have been updated, hide prepopulate D1/D2
+					// ask to regenerate D1/D2 and forced to revalidate
+					if (this.props.submission.publishStatus == "updated") {
+						allRequested = false;
+					}
 					else {
 						combinedData.push(response.value);
 					}


### PR DESCRIPTION
As an agency user, if I change files in a published submission I have to revalidate everything

Acceptance Criteria:
User is forced to revalidate (cross-file especially) and re-certify submission