### PR TITLE
Db mk 1667 fabs reupload

### DIFF
--- a/src/_scss/pages/uploadDetachedFiles/uploadDetachedFiles.scss
+++ b/src/_scss/pages/uploadDetachedFiles/uploadDetachedFiles.scss
@@ -109,6 +109,13 @@
 	.usa-da-validate-item {
         @import "../validateData/fileItem/fileItem";
         @include fileItem;
+        .usa-da-validate-item-file-section {
+        	.usa-da-validate-corrected-file-holder.full-width{
+        		.full-overlay{
+        			height: 107%;
+        		}
+        	}
+        }
     }
 
     .header-box{

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -213,7 +213,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 		submission.meta['endDate'] = this.state.rep_end;
 		submission.meta['subTierAgency'] = this.state.agency;
 
-		this.uploadFileHelper(kGlobalConstants.LOCAL === true, submission)
+		this.uploadFileHelper(kGlobalConstants.LOCAL, submission)
 			.then((submissionID) => {
 				this.setState({
 					validationFinished: false

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -45,6 +45,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 				valid: false,
 				status: ""
 			},
+			cgac_code:'',
 			jobResults: {detached_award: {}},
 			headerErrors: false,
 			validationFinished: false,
@@ -80,6 +81,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 				if (this.isUnmounted) {
 					return;
 				}
+				console.log(response)
 				var submission = true;
 				if(response.publish_status==='published'){
 					submission = false;
@@ -91,7 +93,8 @@ export default class UploadDetachedFileValidation extends React.Component {
 					agency: response.agency_name,
 					rep_start: response.reporting_period_start_date,
 					rep_end: response.reporting_period_end_date,
-					submit: submission
+					submit: submission,
+					cgac_code: response.cgac_code
 				}, () => {
 					this.parseJobStates(response);
 				});			
@@ -188,11 +191,6 @@ export default class UploadDetachedFileValidation extends React.Component {
 	// 2: Fetching file metadata failed
 	// 3: File already has been submitted in another submission
 
-	testBind(item){
-		console.log('testing 123', item)
-		console.log(this.props.submission)
-	}
-
 	uploadFileHelper(local, submission){
 		if(local){
 			return UploadHelper.performDetachedLocalUpload(submission);
@@ -204,10 +202,11 @@ export default class UploadDetachedFileValidation extends React.Component {
 		// upload specified file
 		this.props.setSubmissionState('uploading');
 		let submission = this.props.submission;
-		console.log(submission)
+		submission.files.detached_award = this.state.detachedAward;
 		submission.files.detached_award.file = item;
-		submission.meta['startDate'] = this.state.detachedAward.startDate.format('DD/MM/YYYY');
-		submission.meta['endDate'] = this.state.detachedAward.endDate.format('DD/MM/YYYY');
+		submission.sub = this.state.submissionID;
+		submission.meta['startDate'] = this.state.rep_start;
+		submission.meta['endDate'] = this.state.rep_end;
 		submission.meta['subTierAgency'] = this.state.agency;
 
 		this.uploadFileHelper(kGlobalConstants.LOCAL === true && !this.isUnmounted, submission)

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -178,6 +178,11 @@ export default class UploadDetachedFileValidation extends React.Component {
 	// 2: Fetching file metadata failed
 	// 3: File already has been submitted in another submission
 
+	testBind(item){
+		console.log('testing 123', item)
+		console.log(this.props.submission)
+	}
+
 	render() {
 		let validationButton = null;
 		let validationBox = null;
@@ -206,7 +211,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 		
 		validationBox = <ValidateDataFileContainer type={type} data={this.state.jobResults}/>;
 		if(!this.state.headerErrors && this.state.validationFinished) {
-			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} />;
+			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} setUploadItem={this.testBind.bind(this)} updateItem={this.testBind.bind(this)} />;
 			if(this.state.jobResults.detached_award.error_type === "none" && this.state.error === 0) {
 				validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.submitFabs.bind(this)}>Publish</button>;
 				if(this.state.published === 'published'){

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -81,14 +81,12 @@ export default class UploadDetachedFileValidation extends React.Component {
 				if (this.isUnmounted) {
 					return;
 				}
-				console.log(response)
 				var submission = true;
 				if(response.publish_status==='published'){
 					submission = false;
 				}
 				const job = Object.assign({}, this.state.jobResults);
 				job.detached_award = response.jobs[0];
-				console.log(job)
 				this.setState({
 					jobResults: job,
 					agency: response.agency_name,
@@ -117,7 +115,6 @@ export default class UploadDetachedFileValidation extends React.Component {
 						jobResults: response,
 						published: publishDate
 					});
-					console.log('post validate', this.state)
 				});
 	}
 
@@ -125,7 +122,6 @@ export default class UploadDetachedFileValidation extends React.Component {
 		let runCheck = true;
 
 		if (data.jobs[0].job_status === 'failed' || data.jobs[0].job_status === 'invalid') {
-			console.log('failed/invalid')
 			// don't run the check again if it failed
 			runCheck = false;
 
@@ -151,7 +147,6 @@ export default class UploadDetachedFileValidation extends React.Component {
 			}
 		}
 		else if (data.jobs[0].job_status === 'finished') {
-			console.log('finished')
 			// don't run the check again if it's done
 			runCheck = false;
 
@@ -159,7 +154,6 @@ export default class UploadDetachedFileValidation extends React.Component {
 			// make a clone of the file's react state
 			const item = Object.assign({}, this.state.detachedAward);
 			item.status = "done";
-			console.log('prevalidate', this.state)
 			this.validateSubmission(item, data.publish_status);
 		}
 

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -213,7 +213,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 		submission.meta['endDate'] = this.state.rep_end;
 		submission.meta['subTierAgency'] = this.state.agency;
 
-		this.uploadFileHelper(kGlobalConstants.LOCAL === true && !this.isUnmounted, submission)
+		this.uploadFileHelper(kGlobalConstants.LOCAL === true, submission)
 			.then((submissionID) => {
 				this.setState({
 					validationFinished: false

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -93,7 +93,8 @@ export default class UploadDetachedFileValidation extends React.Component {
 					rep_start: response.reporting_period_start_date,
 					rep_end: response.reporting_period_end_date,
 					submit: submission,
-					cgac_code: response.cgac_code
+					cgac_code: response.cgac_code,
+					published: (response.publish_status === 'published' ? true : false)
 				}, () => {
 					this.parseJobStates(response);
 				});			
@@ -105,15 +106,14 @@ export default class UploadDetachedFileValidation extends React.Component {
 			});
 	}
 
-	validateSubmission(item, publishDate=undefined){
+	validateSubmission(item){
 		ReviewHelper.validateDetachedSubmission(this.props.params.submissionID)
 				.then((response) => {
 					this.setState({
 						detachedAward: item,
 						validationFinished: true,
 						headerErrors: false,
-						jobResults: response,
-						published: publishDate
+						jobResults: response
 					});
 				});
 	}
@@ -154,7 +154,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			// make a clone of the file's react state
 			const item = Object.assign({}, this.state.detachedAward);
 			item.status = "done";
-			this.validateSubmission(item, data.publish_status);
+			this.validateSubmission(item);
 		}
 
 		if (this.isUnmounted) {
@@ -174,7 +174,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 	submitFabs(){
 		UploadHelper.submitFabs({'submission_id': this.props.submission.id})
 			.then((response)=>{
-				this.setState({submit: false})
+				this.setState({submit: false, published: true})
 			})
 			.catch((error)=>{
 				if(error.httpStatus === 400){
@@ -258,7 +258,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} setUploadItem={this.uploadFile.bind(this)} updateItem={this.uploadFile.bind(this)} />;
 			if(this.state.jobResults.detached_award.error_type === "none" && this.state.error === 0) {
 				validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.submitFabs.bind(this)}>Publish</button>;
-				if(this.state.published === 'published'){
+				if(this.state.published){
 					validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' onClick={this.submitFabs.bind(this)} disabled>File Already Published</button>;
 				}
 			}

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -161,7 +161,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			return;
 		}
 
-		if ((runCheck || forceCheck) && !this.isUnmounted) {
+		if (runCheck && !this.isUnmounted) {
 			// wait 5 seconds and check the file status again
 			window.setTimeout(() => {
 				if(this.props.params.submissionID){
@@ -198,6 +198,11 @@ export default class UploadDetachedFileValidation extends React.Component {
 	}
 
 	uploadFile(item) {
+
+		if(this.isUnmounted){
+			return;
+		}
+
 		// upload specified file
 		this.props.setSubmissionState('uploading');
 		let submission = this.props.submission;
@@ -210,14 +215,13 @@ export default class UploadDetachedFileValidation extends React.Component {
 
 		this.uploadFileHelper(kGlobalConstants.LOCAL === true && !this.isUnmounted, submission)
 			.then((submissionID) => {
-                this.setState({
+				this.setState({
 					validationFinished: false
 				})
 				setTimeout(()=>{
 					this.checkFileStatus(submissionID);
 				}, 2000);
-				
-            })
+			})
 			.catch((err) => {
 				this.setState({
 					validationFinished: false,
@@ -234,16 +238,16 @@ export default class UploadDetachedFileValidation extends React.Component {
 		
 		if(this.state.agency !== '' && this.state.rep_start !== '' && this.state.rep_end !== ''){
 			headerDate = <div className="col-md-2 ">
-										<div className = 'header-box'>
-												<span>
-												Agency: {this.state.agency}
-												</span>
-												<br/>
-												<span>
-												Date: {this.state.rep_start} - {this.state.rep_end}
-												</span>
-											</div>
-									</div>;
+							<div className = 'header-box'>
+									<span>
+									Agency: {this.state.agency}
+									</span>
+									<br/>
+									<span>
+									Date: {this.state.rep_start} - {this.state.rep_end}
+									</span>
+								</div>
+						</div>;
 		}
 
 		const type = {
@@ -258,7 +262,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} setUploadItem={this.uploadFile.bind(this)} updateItem={this.uploadFile.bind(this)} published={this.state.published}/>;
 			validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.submitFabs.bind(this)}>Publish</button>;
 			if(this.state.published){
-				validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' onClick={this.submitFabs.bind(this)} disabled>File Already Published</button>;
+				validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' disabled>File Already Published</button>;
 			}
 		}
 

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -255,12 +255,10 @@ export default class UploadDetachedFileValidation extends React.Component {
 
 		validationBox = <ValidateDataFileContainer type={type} data={this.state.jobResults}/>;
 		if(!this.state.headerErrors && this.state.validationFinished) {
-			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} setUploadItem={this.uploadFile.bind(this)} updateItem={this.uploadFile.bind(this)} />;
-			if(this.state.jobResults.detached_award.error_type === "none" && this.state.error === 0) {
-				validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.submitFabs.bind(this)}>Publish</button>;
-				if(this.state.published){
-					validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' onClick={this.submitFabs.bind(this)} disabled>File Already Published</button>;
-				}
+			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} setUploadItem={this.uploadFile.bind(this)} updateItem={this.uploadFile.bind(this)} published={this.state.published}/>;
+			validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.submitFabs.bind(this)}>Publish</button>;
+			if(this.state.published){
+				validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' onClick={this.submitFabs.bind(this)} disabled>File Already Published</button>;
 			}
 		}
 

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -74,7 +74,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 		this.isUnmounted = true;
 	}
 
-	checkFileStatus(submissionID, forceCheck=false) {
+	checkFileStatus(submissionID) {
 		// callback to check file status
 		GenerateFilesHelper.fetchSubmissionMetadata(submissionID)
 			.then((response) => {
@@ -97,7 +97,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 					submit: submission,
 					cgac_code: response.cgac_code
 				}, () => {
-					this.parseJobStates(response, forceCheck);
+					this.parseJobStates(response);
 				});			
 			})
 			.catch((err)=>{
@@ -121,7 +121,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 				});
 	}
 
-	parseJobStates(data, forceCheck) {
+	parseJobStates(data) {
 		let runCheck = true;
 
 		if (data.jobs[0].job_status === 'failed' || data.jobs[0].job_status === 'invalid') {
@@ -220,7 +220,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 					validationFinished: false
 				})
 				setTimeout(()=>{
-					this.checkFileStatus(submissionID, true);
+					this.checkFileStatus(submissionID);
 				}, 2000);
 				
             })

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -81,12 +81,14 @@ export default class UploadDetachedFileValidation extends React.Component {
 				if (this.isUnmounted) {
 					return;
 				}
+				console.log(response)
 				var submission = true;
 				if(response.publish_status==='published'){
 					submission = false;
 				}
 				const job = Object.assign({}, this.state.jobResults);
 				job.detached_award = response.jobs[0];
+				console.log(job)
 				this.setState({
 					jobResults: job,
 					agency: response.agency_name,
@@ -115,6 +117,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 						jobResults: response,
 						published: publishDate
 					});
+					console.log('post validate', this.state)
 				});
 	}
 
@@ -122,6 +125,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 		let runCheck = true;
 
 		if (data.jobs[0].job_status === 'failed' || data.jobs[0].job_status === 'invalid') {
+			console.log('failed/invalid')
 			// don't run the check again if it failed
 			runCheck = false;
 
@@ -147,6 +151,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			}
 		}
 		else if (data.jobs[0].job_status === 'finished') {
+			console.log('finished')
 			// don't run the check again if it's done
 			runCheck = false;
 
@@ -154,6 +159,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			// make a clone of the file's react state
 			const item = Object.assign({}, this.state.detachedAward);
 			item.status = "done";
+			console.log('prevalidate', this.state)
 			this.validateSubmission(item, data.publish_status);
 		}
 
@@ -210,11 +216,13 @@ export default class UploadDetachedFileValidation extends React.Component {
 
 		this.uploadFileHelper(kGlobalConstants.LOCAL === true && !this.isUnmounted, submission)
 			.then((submissionID) => {
-                this.props.setSubmissionId(submissionID);
-				this.checkFileStatus(submissionID, true);
-				this.setState({
+                this.setState({
 					validationFinished: false
 				})
+				setTimeout(()=>{
+					this.checkFileStatus(submissionID, true);
+				}, 2000);
+				
             })
 			.catch((err) => {
 				this.setState({
@@ -250,7 +258,7 @@ export default class UploadDetachedFileValidation extends React.Component {
 			requestName: 'detached_award',
 			progress: '0'
 		}
-		 
+
 		validationBox = <ValidateDataFileContainer type={type} data={this.state.jobResults}/>;
 		if(!this.state.headerErrors && this.state.validationFinished) {
 			validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults} setUploadItem={this.uploadFile.bind(this)} updateItem={this.uploadFile.bind(this)} />;

--- a/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesFileComponent.jsx
@@ -230,19 +230,19 @@ export default class ValidateDataFileComponent extends React.Component {
             }
         }
 
-        if (!this.state.hasErrors && !this.state.hasWarnings) {
+        if (!this.state.hasErrors && !this.state.hasWarnings && !this.props.published) {
             optionalUpload = true;
             uploadText = 'Overwrite File';
             correctButtonOverlay = <CorrectButtonOverlay isReplacingFile={this.isReplacingFile()} fileKey={this.props.type.requestName} onDrop={this.props.onFileChange} fileName={fileName}/>
             validationElement = <p className='usa-da-success-txt'>File successfully validated</p>;
         }
-        else if (!this.state.hasErrors && this.state.hasWarnings) {
+        else if (!this.state.hasErrors && this.state.hasWarnings && !this.props.published) {
             optionalUpload = true;
             uploadText = 'Overwrite File';
             correctButtonOverlay = <CorrectButtonOverlay isReplacingFile={this.isReplacingFile()} fileKey={this.props.type.requestName} onDrop={this.props.onFileChange} fileName={fileName}/>
             validationElement = <p className='usa-da-warning-txt'>File validated with warnings</p>;
         }
-        else {
+        else if(!this.props.published){
             validationElement = <div className="row usa-da-validate-item-file-section-correct-button" data-testid="validate-upload"><div className="col-md-12">
                 <ValidateDataUploadButton optional={optionalUpload} onDrop={this.props.onFileChange} text={uploadText} />
                 </div>

--- a/src/js/containers/validateData/ValidateValuesFileContainer.jsx
+++ b/src/js/containers/validateData/ValidateValuesFileContainer.jsx
@@ -15,6 +15,9 @@ import { fileTypes } from '../addData/fileTypes.js';
 import { kGlobalConstants } from '../../GlobalConstants.js';
 
 class ValidateValuesFileContainer extends React.Component {
+	constructor(props){
+		super(props);
+	}
 
 	selectedFile(file) {
 		this.props.setUploadItem({
@@ -22,6 +25,9 @@ class ValidateValuesFileContainer extends React.Component {
 			state: 'ready',
 			file: file
 		});
+		if(this.props.updateItem){
+			this.props.updateItem(file);
+		}
 	}
 
 	render() {

--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -52,6 +52,7 @@ export const performLocalUpload = (submission) => {
     for (let fileType in submission.files) {
 		const file = submission.files[fileType].file;
         uploadOperations.push(uploadLocalFile(file, fileType));
+        console.log(fileType)
         types.push(fileType);
     }
 
@@ -459,6 +460,9 @@ export const performDetachedLocalUpload = (submission) => {
 
     prepareMetadata(submission.meta, request);
     request.agency_code = submission.meta.subTierAgency
+    if(submission.sub){
+        request.submission_id = submission.sub
+    }
 
     let i = 0;
 

--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -52,7 +52,6 @@ export const performLocalUpload = (submission) => {
     for (let fileType in submission.files) {
 		const file = submission.files[fileType].file;
         uploadOperations.push(uploadLocalFile(file, fileType));
-        console.log(fileType)
         types.push(fileType);
     }
 
@@ -329,7 +328,6 @@ export const performRemoteCorrectedUpload = (submission) => {
         request[fileType] = file.name;
     }
 
-
     prepareFiles(request)
         .then((res) => {
             // now do the actual uploading
@@ -448,23 +446,57 @@ export const performDetachedFileUpload = (submission) => {
     return deferred.promise;
 }
 
+export const performDetachedFileCorrectedUpload = (submission) => {
+    const deferred = Q.defer();
+
+    const store = new StoreSingleton().store;
+    store.dispatch(uploadActions.setSubmissionState('uploading'));
+
+    let request = {
+        existing_submission_id: submission.id
+    };
+
+    for (let fileType in submission.files) {
+        const file = submission.files[fileType].file;
+        request[fileType] = file.name;
+    }   
+
+    // submit it to the API to set up S3
+    let submissionID;
+    
+    prepareDetachedFiles(request)
+        .then((res) => {
+            // now do the actual uploading
+            submissionID = res.body.submission_id;
+            return uploadMultipleFiles(submission, res.body);
+        })
+        .then((fileIds) => {
+            // upload complete, finalize with the API
+            return finalizeMultipleUploads(fileIds);
+        })
+        .then(() => {
+            store.dispatch(uploadActions.setSubmissionState('prepare'));
+            deferred.resolve(submissionID);
+        })
+        .catch((err) => {
+            store.dispatch(uploadActions.setSubmissionState('failed'));
+            deferred.reject(err);
+        });
+
+    return deferred.promise;
+}
+
 export const performDetachedLocalUpload = (submission) => {
 
 	const deferred = Q.defer();
 
 	const request = {};
-    let successfulUploads = {};
 
     const store = new StoreSingleton().store;
 	store.dispatch(uploadActions.setSubmissionState('uploading'));
 
     prepareMetadata(submission.meta, request);
     request.agency_code = submission.meta.subTierAgency
-    if(submission.sub){
-        request.submission_id = submission.sub
-    }
-
-    let i = 0;
 
     const uploadOperations = [];
     const types = [];
@@ -472,6 +504,63 @@ export const performDetachedLocalUpload = (submission) => {
 
     for (let fileType in submission.files) {
 		const file = submission.files[fileType].file;
+        uploadOperations.push(uploadLocalFile(file, fileType));
+        types.push(fileType);
+    }
+
+    Q.all(uploadOperations)
+        .then((uploads) => {
+            
+            // prepare the request
+            uploads.forEach((upload) => {
+                request[upload[0]] = upload[1];
+            });
+
+            // submit the files
+            return prepareDetachedFiles(request);
+        })
+        .then((res) => {
+            submissionID = res.body.submission_id;
+
+            // get all the file IDs
+            const fileIds = [];
+            types.forEach((type) => {
+                const key = type + '_id';
+                fileIds.push(res.body[key]);
+            });
+
+            // finalize all the files
+            return finalizeMultipleUploads(fileIds);
+        })
+        .then(() => {
+            store.dispatch(uploadActions.setSubmissionState('prepare'));
+            deferred.resolve(submissionID);
+        })
+        .catch((err) => {
+            store.dispatch(uploadActions.setSubmissionState('failed'));
+            deferred.reject(err);
+        });
+
+    return deferred.promise;
+}
+
+export const performDetachedLocalCorrectedUpload = (submission) => {
+
+    const deferred = Q.defer();
+
+    const request = {
+        existing_submission_id: submission.id
+    };
+
+    const store = new StoreSingleton().store;
+    store.dispatch(uploadActions.setSubmissionState('uploading'));
+
+    const uploadOperations = [];
+    const types = [];
+    let submissionID = null;
+
+    for (let fileType in submission.files) {
+        const file = submission.files[fileType].file;
         uploadOperations.push(uploadLocalFile(file, fileType));
         types.push(fileType);
     }


### PR DESCRIPTION
- [x] Need to merge backend [update branch](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/617)
Allow users to reupload files on the `/uploadDetachedFiles` route when there are errors.
Acceptance Criteria
- Users can upload a replacement file in a FABS submission
