### PR TITLE
db-1700 Add the rule label for error and warning descriptions

### DIFF
--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -66,11 +66,7 @@ export default class ValidateValuesErrorReport extends React.Component {
 
             let description = item.error_description;
             if (item.error_name == 'rule_failed') {
-                // Remove "Failed rule:" label
-                let msg = item.rule_failed.split('Failed rule: ');
-                msg.shift();
-                msg = msg.join('Failed rule: ');
-                description = ['Rule ' + item.original_label + ': ' + msg];
+                description = ['Rule ' + item.original_label + ': ' + item.rule_failed];
             }
 
             const row = [item.field_name, description, parseInt(item.occurrences)];

--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -66,7 +66,7 @@ export default class ValidateValuesErrorReport extends React.Component {
 
             let description = item.error_description;
             if (item.error_name == 'rule_failed') {
-                description = ['Rule ' + item.original_label + ': ' + item.rule_failed];
+                description = 'Rule ' + item.original_label + ': ' + item.rule_failed;
             }
 
             const row = [item.field_name, description, parseInt(item.occurrences)];

--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -66,7 +66,11 @@ export default class ValidateValuesErrorReport extends React.Component {
 
             let description = item.error_description;
             if (item.error_name == 'rule_failed') {
-                description = ['Rule ' + item.original_label + ': ' + item.rule_failed];
+                // Remove "Failed rule:" label
+                let msg = item.rule_failed.split('Failed rule: ');
+                msg.shift();
+                msg = msg.join('Failed rule: ');
+                description = ['Rule ' + item.original_label + ': ' + msg];
             }
 
             const row = [item.field_name, description, parseInt(item.occurrences)];

--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -66,7 +66,7 @@ export default class ValidateValuesErrorReport extends React.Component {
 
             let description = item.error_description;
             if (item.error_name == 'rule_failed') {
-                description = item.rule_failed;
+                description = ['Rule ' + item.original_label + ': ' + item.rule_failed];
             }
 
             const row = [item.field_name, description, parseInt(item.occurrences)];


### PR DESCRIPTION
As an agency user, I want to see the rule label in all of the error and warning descriptions

**Acceptance Criteria:**

- Rule label (i.e. A9) is present in the error messages on all validation pages

**Checklist:**
- [ ] Backend changes: https://github.com/fedspendingtransparency/data-act-broker-backend/pull/699