### PR TITLE
DB-2155 file type error

### DIFF
--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -151,6 +151,9 @@ export default class ValidateDataFileComponent extends React.Component {
                 case 'row_count_error':
                     headerTitle = 'Critical Error: Raw file row count does not match the number of rows validated';
                     break;
+                case 'file_type_error':
+                    headerTitle = 'Critical Error: Invalid file type. Valid file types include .csv and .txt';
+                    break;
                 case 'unknown_error':
                     isError = false;
                     break;
@@ -330,6 +333,9 @@ export default class ValidateDataFileComponent extends React.Component {
         let uploadProgress = '';
         let fileName = this.props.item.filename;
 
+        let clickDownload = null;
+        let clickDownloadClass = '';
+
         if (this.isReplacingFile()) {
             // also display the new file name
             const newFile = this.props.submission.files[this.props.type.requestName];
@@ -338,6 +344,10 @@ export default class ValidateDataFileComponent extends React.Component {
             if (newFile.state == 'uploading') {
                 uploadProgress = <FileProgress fileStatus={newFile.progress} />;
             }
+        }
+        else {
+            clickDownload = this.state.canDownload ? this.clickedReport.bind(this, this.props.item) : null;
+            clickDownloadClass = this.state.canDownload ? 'file-download' : '';
         }
 
         if (this.props.type.requestName === 'detached_award') {
@@ -355,9 +365,6 @@ export default class ValidateDataFileComponent extends React.Component {
         if(this.state.error) {
             errorMessage = <UploadDetachedFilesError error={this.state.error} />
         }
-
-        let clickDownload = this.state.canDownload ? this.clickedReport.bind(this, this.props.item) : null;
-        let clickDownloadClass = this.state.canDownload ? 'file-download' : '';
 
         return (
             <div className="row center-block usa-da-validate-item" data-testid={"validate-wrapper-" + this.props.type.requestName}>

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -345,9 +345,10 @@ export default class ValidateDataFileComponent extends React.Component {
                 uploadProgress = <FileProgress fileStatus={newFile.progress} />;
             }
         }
-        else {
-            clickDownload = this.state.canDownload ? this.clickedReport.bind(this, this.props.item) : null;
-            clickDownloadClass = this.state.canDownload ? 'file-download' : '';
+        else if (this.state.canDownload) {
+            // no parsing errors and not a new file
+            clickDownload = this.clickedReport.bind(this, this.props.item);
+            clickDownloadClass = 'file-download';
         }
 
         if (this.props.type.requestName === 'detached_award') {


### PR DESCRIPTION
- [ ] Review back end PR https://github.com/fedspendingtransparency/data-act-broker-backend/pull/848

AC:
- Provide more accurate error code logic/text that fits the case of uploading a file with the wrong extension
- Make sure the submitted file is downloadable from this screen
- Remove link to critical error/warning reports for this file level error

