### PR TITLE
DB-2155 Cannot download files with file_type_errors

### DIFF
--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -122,7 +122,6 @@ export default class ValidateDataFileComponent extends React.Component {
                     data: item[key]
                 });
             });
-
         }
         else if (item.error_type == 'header_errors') {
             // special case where the header rows could not be read
@@ -149,6 +148,7 @@ export default class ValidateDataFileComponent extends React.Component {
                     break;
                 case 'file_type_error':
                     headerTitle = 'Critical Error: Invalid file type. Valid file types include .csv and .txt';
+                    canDownload = false;
                     break;
                 case 'unknown_error':
                     isError = false;


### PR DESCRIPTION
AC:
- Provide more accurate error code logic/text that fits the case of uploading a file with the wrong extension
- ~~Make sure the submitted file is downloadable from this screen~~
- Remove link to critical error/warning reports for this file level error