### PR TITLE
Db 2125 prevent duplicate fabs time

### DIFF
--- a/src/_scss/pages/uploadDetachedFiles/uploadDetachedFiles.scss
+++ b/src/_scss/pages/uploadDetachedFiles/uploadDetachedFiles.scss
@@ -169,4 +169,8 @@
 	font-weight: 700;
 	border-style: none;
 	box-shadow: none;
+
+	&.revalidate-button {
+		margin-right: 5px;
+	}
 }

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -536,11 +536,14 @@ export const deleteSubmission = (submission_id) => {
     return deferred.promise;
 }
 
-export const revalidateSubmission = (submission_id) => {
+export const revalidateSubmission = (submission_id, d2_submission = false) => {
 	const deferred = Q.defer();
 
 	Request.post(kGlobalConstants.API + 'restart_validation/')
-		.send({submission_id})
+		.send({
+			"submission_id": submission_id,
+			"d2_submission": d2_submission
+		})
 		.end((err, res) => {
 			if (err) {
 				deferred.reject(err);


### PR DESCRIPTION
Prevent duplicate transactions from being published if a different submission with the same new entries is published and provide a revalidate button for fabs submissions.

- [ ] Merged concurrently with https://github.com/fedspendingtransparency/data-act-broker-backend/pull/996
- [ ] Reviewed by frontend