### PR TITLE
DB-2289 access raw agency fabs files

### DIFF
--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -366,16 +366,16 @@ class UploadDetachedFileValidation extends React.Component {
         
         if (this.state.agency !== '' && this.state.rep_start !== '' && this.state.rep_end !== ''){
             headerDate = <div className="col-md-2 ">
-                            <div className = 'header-box'>
-                                    <span>
-                                    Agency: {this.state.agency}
-                                    </span>
-                                    <br/>
-                                    <span>
-                                    Last Modified: {updated}
-                                    </span>
-                                </div>
-                        </div>;
+                             <div className = 'header-box'>
+                                 <span>
+                                     Agency: {this.state.agency}
+                                 </span>
+                                 <br/>
+                                 <span>
+                                     Last Modified: {updated}
+                                 </span>
+                             </div>
+                         </div>;
         }
 
         const type = {

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -29,62 +29,64 @@ import { kGlobalConstants } from '../../GlobalConstants.js';
 const timerDuration = 5;
 
 class UploadDetachedFileValidation extends React.Component {
-	constructor(props) {
-		super(props);
+    constructor(props) {
+        super(props);
 
-		this.isUnmounted = false;
+        this.isUnmounted = false;
 
-		this.state = {
-			agency: "",
-			submissionID: this.props.params.submissionID ? this.props.params.submissionID: 0,
-			detachedAward: {
-				startDate: null,
-				endDate: null,
-				error: {
-					show: false,
-					header: '',
-					description: ''
-				},
-				valid: false,
-				status: ""
-			},
-			cgac_code:'',
-			jobResults: {detached_award: {}},
-			headerErrors: false,
-			validationFinished: false,
-			error: 0,
-			rep_start: '',
-			rep_end: '',
-			published: 'unpublished',
-			submit: true,
-			showPublish: false,
-			modified_date: null,
-			type: this.props.route.type,
-			showSuccess: false,
-			error_message: '',
-			fabs_meta: {valid_rows:0, total_rows: 0, publish_date: null}
-		};
-	}
+        this.state = {
+            agency: "",
+            submissionID: this.props.params.submissionID ? this.props.params.submissionID: 0,
+            detachedAward: {
+                startDate: null,
+                endDate: null,
+                error: {
+                    show: false,
+                    header: '',
+                    description: ''
+                },
+                valid: false,
+                status: ""
+            },
+            cgac_code:'',
+            jobResults: {detached_award: {}},
+            headerErrors: false,
+            validationFinished: false,
+            error: 0,
+            rep_start: '',
+            rep_end: '',
+            published: 'unpublished',
+            submit: true,
+            showPublish: false,
+            modified_date: null,
+            type: this.props.route.type,
+            showSuccess: false,
+            error_message: '',
+            fabs_meta: {valid_rows:0, total_rows: 0, publish_date: null}, 
+            signedUrl: '',
+            signInProgress: false
+        };
+    }
 
-	componentDidMount() {
-		this.isUnmounted = false;
-		this.checkFile(this.state.submissionID)
-	}
+    componentDidMount() {
+        this.isUnmounted = false;
+        this.checkFile(this.state.submissionID)
+    }
 
-	componentWillReceiveProps(nextProps) {
-		if(this.state.agency==="" || nextProps.params.submissionID !== this.state.submissionID){
-			this.setState({
-				submissionID: nextProps.params.submissionID
-			})
-			this.checkFileStatus(nextProps.params.submissionID);	
-		}
-	}
+    componentWillReceiveProps(nextProps) {
+        if(this.state.agency==="" || nextProps.params.submissionID !== this.state.submissionID){
+            this.setState({
+                submissionID: nextProps.params.submissionID
+            })
+            this.checkFileStatus(nextProps.params.submissionID);    
+        }
+    }
 
-	componentWillUnmount() {
-		this.isUnmounted = true;
-	}
+    componentWillUnmount() {
+        this.isUnmounted = true;
+    }
 
-	openModal() {
+    openModal() {
         this.setState({
             showPublish: true
         });
@@ -94,333 +96,379 @@ class UploadDetachedFileValidation extends React.Component {
         this.setState({
             showPublish: false
         });
-	}
+    }
 
-	startRevalidation() {
-		this.setState({
-			validationFinished: false,
-			published:'unpublished'
-		}, this.revalidate())
-	}
-	
-	revalidate() {
-		ReviewHelper.revalidateSubmission(this.state.submissionID, true)
-			.then(() => {
-				this.checkFileStatus(this.state.submissionID)
-			})
-			.catch((error) => {
-				let errMsg = "An error occurred while attempting to revalidate the submission. Please contact the Service Desk.";
-				if (error.httpStatus == 400 || error.httpStatus == 403) {
-					errMsg = error.message;
-				}
+    startRevalidation() {
+        this.setState({
+            validationFinished: false,
+            published:'unpublished'
+        }, this.revalidate())
+    }
+    
+    revalidate() {
+        ReviewHelper.revalidateSubmission(this.state.submissionID, true)
+            .then(() => {
+                this.checkFileStatus(this.state.submissionID)
+            })
+            .catch((error) => {
+                let errMsg = "An error occurred while attempting to revalidate the submission. Please contact the Service Desk.";
+                if (error.httpStatus == 400 || error.httpStatus == 403) {
+                    errMsg = error.message;
+                }
 
-				this.setState({
-					error: 4,
-					error_message: errMsg
-				});
-			});
-	}
+                this.setState({
+                    error: 4,
+                    error_message: errMsg
+                });
+            });
+    }
 
-	checkFileStatus(submissionID) {
-		// callback to check file status
-		GenerateFilesHelper.fetchSubmissionMetadata(submissionID)
-			.then((response) => {
-				if (this.isUnmounted) {
-					return;
-				}
+    checkFileStatus(submissionID) {
+        // callback to check file status
+        GenerateFilesHelper.fetchSubmissionMetadata(submissionID)
+            .then((response) => {
+                if (this.isUnmounted) {
+                    return;
+                }
 
-				const job = Object.assign({}, this.state.jobResults);
-				job.detached_award = response.jobs[0];
+                const job = Object.assign({}, this.state.jobResults);
+                job.detached_award = response.jobs[0];
 
-				if (this.state.published !== 'publishing' && this.dataTimer) {
-					window.clearInterval(this.dataTimer);
-					this.dataTimer = null;
-				}
-				else if (!this.dataTimer && response.publish_status == 'publishing') {
-					this.checkFile(submissionID);
-					return;
-				}
-				this.setState({
-					jobResults: job,
-					agency: response.agency_name,
-					rep_start: response.reporting_period_start_date,
-					rep_end: response.reporting_period_end_date,
-					cgac_code: response.cgac_code,
-					published: response.publish_status,
-					modified_date: response.last_updated,
-					error: 0,
-					fabs_meta: response.fabs_meta
-				}, () => {
-					this.parseJobStates(response);
-				});			
-			})
-			.catch((err)=>{
-				if(err.status == 400){
-					this.setState({error: 2, submit: false});
-				}
-			});
-	}
+                if (this.state.published !== 'publishing' && this.dataTimer) {
+                    window.clearInterval(this.dataTimer);
+                    this.dataTimer = null;
+                }
+                else if (!this.dataTimer && response.publish_status == 'publishing') {
+                    this.checkFile(submissionID);
+                    return;
+                }
+                this.setState({
+                    jobResults: job,
+                    agency: response.agency_name,
+                    rep_start: response.reporting_period_start_date,
+                    rep_end: response.reporting_period_end_date,
+                    cgac_code: response.cgac_code,
+                    published: response.publish_status,
+                    modified_date: response.last_updated,
+                    error: 0,
+                    fabs_meta: response.fabs_meta
+                }, () => {
+                    this.parseJobStates(response);
+                });         
+            })
+            .catch((err)=>{
+                if(err.status == 400){
+                    this.setState({error: 2, submit: false});
+                }
+            });
+    }
 
-	checkFile(submissionID) {
-		this.dataTimer = window.setInterval(() => {
-			this.checkFileStatus(submissionID);
-		}, timerDuration * 1000);
-	}
+    checkFile(submissionID) {
+        this.dataTimer = window.setInterval(() => {
+            this.checkFileStatus(submissionID);
+        }, timerDuration * 1000);
+    }
 
-	validateSubmission(item){
-		ReviewHelper.validateDetachedSubmission(this.props.params.submissionID)
-				.then((response) => {
-					this.setState({
-						detachedAward: item,
-						validationFinished: true,
-						headerErrors: false,
-						jobResults: response
-					});
-				});
-	}
+    signReport(item){
+        let type = 'D2_detached';
+        GenerateFilesHelper.fetchFile(type, this.props.submission.id)
+            .then((result)=>{
+                this.setState({
+                    signedUrl: result.url,
+                    signInProgress: false
+                }, () => {
+                    this.openReport();
+                });
+            })
+            .catch((err) => {
+                this.setState({
+                    error: 1,
+                    error_message: 'Invalid File Type Selected '+item.file_type,
+                    signInProgress: false
+                });
+            });
+    }
 
-	parseJobStates(data) {
-		let runCheck = true;
+    openReport() {
+        window.open(this.state.signedUrl);
+    }
 
-		if (data.jobs[0].job_status === 'failed' || data.jobs[0].job_status === 'invalid') {
-			// don't run the check again if it failed
-			runCheck = false;
+    clickedReport(item) {
+        // check if the link is already signed
+        if (this.state.signInProgress) {
+            // sign is in progress, do nothing
+            return;
+        }
+        else if (this.state.signedUrl !== '') {
+            // it is signed, open immediately
+            this.openReport();
+        }
+        else {
+            // not signed yet, sign
+            this.setState({
+                signInProgress: true
+            }, () => {
+                this.signReport(item);
+            });
+        }
+    }
 
-			let message = 'Error during D2 validation.';
+    validateSubmission(item){
+        ReviewHelper.validateDetachedSubmission(this.props.params.submissionID)
+            .then((response) => {
+                this.setState({
+                    detachedAward: item,
+                    validationFinished: true,
+                    headerErrors: false,
+                    jobResults: response
+                });
+            });
+    }
 
-			if (!data.jobs[0].error_data[0] && data.jobs[0].error_data[0].error_description !== '') {
-				message = data.jobs[0].error_data[0].error_description;
-			}
+    parseJobStates(data) {
+        let runCheck = true;
 
-			// make a clone of the file's react state
-			const item = Object.assign({}, this.state.detachedAward);
-			item.status = "failed";
+        if (data.jobs[0].job_status === 'failed' || data.jobs[0].job_status === 'invalid') {
+            // don't run the check again if it failed
+            runCheck = false;
 
-			if (data.jobs[0].error_type && data.jobs[0].error_type === "header_errors") {
-				this.setState({
-					detachedAward: item,
-					validationFinished: true,
-					headerErrors: true
-				});
-			}
-			else {
-				this.validateSubmission(item);
-			}
-		}
-		else if (data.jobs[0].job_status === 'finished') {
-			// don't run the check again if it's done
-			runCheck = false;
+            let message = 'Error during D2 validation.';
 
-			// display dowload buttons
-			// make a clone of the file's react state
-			const item = Object.assign({}, this.state.detachedAward);
-			item.status = "done";
-			this.validateSubmission(item);
-		}
+            if (!data.jobs[0].error_data[0] && data.jobs[0].error_data[0].error_description !== '') {
+                message = data.jobs[0].error_data[0].error_description;
+            }
 
-		if (this.isUnmounted) {
-			return;
-		}
+            // make a clone of the file's react state
+            const item = Object.assign({}, this.state.detachedAward);
+            item.status = "failed";
 
-		if (runCheck && !this.isUnmounted) {
-			// wait 5 seconds and check the file status again
-			window.setTimeout(() => {
-				if(this.props.params.submissionID){
-					this.checkFileStatus(this.props.params.submissionID);	
-				}
-			}, timerDuration * 1000);
-		}
-	}
+            if (data.jobs[0].error_type && data.jobs[0].error_type === "header_errors") {
+                this.setState({
+                    detachedAward: item,
+                    validationFinished: true,
+                    headerErrors: true
+                });
+            }
+            else {
+                this.validateSubmission(item);
+            }
+        }
+        else if (data.jobs[0].job_status === 'finished') {
+            // don't run the check again if it's done
+            runCheck = false;
 
-	submitFabs(){
-		UploadHelper.submitFabs({'submission_id': this.props.submission.id})
-			.then((response)=>{
-				this.setState({submit: false, published: true, showPublish: false, showSuccess: true})
-				this.checkFile(this.props.submission.id);
-			})
-			.catch((error)=>{
-				if (error.httpStatus === 400) {
-					this.setState({error: 1, submit: false, error_message: error.message});
-				}
-				else if (error.httpStatus === 500) {
-					this.setState({error: 4, submit: false, showPublish: false});
-				}
-			})
-		this.setState({
-			published: 'publishing',
-			showPublish: false
-		})
-	}
+            // display dowload buttons
+            // make a clone of the file's react state
+            const item = Object.assign({}, this.state.detachedAward);
+            item.status = "done";
+            this.validateSubmission(item);
+        }
 
-	// ERRORS
-	// 1: Submission is already published
-	// 2: Fetching file metadata failed
-	// 3: File already has been submitted in another submission
+        if (this.isUnmounted) {
+            return;
+        }
 
-	uploadFileHelper(local, submission){
-		if (local) {
-			return UploadHelper.performDetachedLocalCorrectedUpload(submission);
-		}
-		return UploadHelper.performDetachedFileCorrectedUpload(submission);
-	}
+        if (runCheck && !this.isUnmounted) {
+            // wait 5 seconds and check the file status again
+            window.setTimeout(() => {
+                if(this.props.params.submissionID){
+                    this.checkFileStatus(this.props.params.submissionID);   
+                }
+            }, timerDuration * 1000);
+        }
+    }
 
-	uploadFile(item) {
-		if (this.isUnmounted) {
-			return;
-		}
+    submitFabs(){
+        UploadHelper.submitFabs({'submission_id': this.props.submission.id})
+            .then((response)=>{
+                this.setState({submit: false, published: true, showPublish: false, showSuccess: true})
+                this.checkFile(this.props.submission.id);
+            })
+            .catch((error)=>{
+                if (error.httpStatus === 400) {
+                    this.setState({error: 1, submit: false, error_message: error.message});
+                }
+                else if (error.httpStatus === 500) {
+                    this.setState({error: 4, submit: false, showPublish: false});
+                }
+            })
+        this.setState({
+            published: 'publishing',
+            showPublish: false
+        })
+    }
 
-		// upload specified file
-		this.props.setSubmissionState('uploading');
-		let submission = this.props.submission;
-		submission.files.detached_award = this.state.detachedAward;
-		submission.files.detached_award.file = item;
-		submission.sub = this.state.submissionID;
-		submission.meta['startDate'] = this.state.rep_start;
-		submission.meta['endDate'] = this.state.rep_end;
-		submission.meta['subTierAgency'] = this.state.agency;
+    // ERRORS
+    // 1: Submission is already published
+    // 2: Fetching file metadata failed
+    // 3: File already has been submitted in another submission
 
-		// reset file and job status
-		let currentResults = this.state.jobResults;
-		currentResults['detached_award'].file_status = '';
-		currentResults['detached_award'].job_status = '';
-		this.setState({
-			jobResults: currentResults
-		});
+    uploadFileHelper(local, submission){
+        if (local) {
+            return UploadHelper.performDetachedLocalCorrectedUpload(submission);
+        }
+        return UploadHelper.performDetachedFileCorrectedUpload(submission);
+    }
 
-		this.uploadFileHelper(kGlobalConstants.LOCAL, submission)
-			.then((submissionID) => {
-				this.setState({
-					validationFinished: false
-				})
-				setTimeout(()=>{
-					this.checkFileStatus(submissionID);
-				}, 2000);
-			})
-			.catch((err) => {
-				this.setState({
-					validationFinished: false,
-					notAllowed: err.httpStatus === 403,
-					errorMessage: err.httpStatus === 403 ? err.message : err.body.message
-				});
-			});
-	}
+    uploadFile(item) {
+        if (this.isUnmounted) {
+            return;
+        }
 
-	render() {
-		let validationButton = null;
-		let revalidateButton = null;
-		let validationBox = null;
-		let headerDate = null;
-		let updated = null;
+        // upload specified file
+        this.props.setSubmissionState('uploading');
+        let submission = this.props.submission;
+        submission.files.detached_award = this.state.detachedAward;
+        submission.files.detached_award.file = item;
+        submission.sub = this.state.submissionID;
+        submission.meta['startDate'] = this.state.rep_start;
+        submission.meta['endDate'] = this.state.rep_end;
+        submission.meta['subTierAgency'] = this.state.agency;
 
-		if(this.state.modified_date) {
-			updated = moment.utc(this.state.modified_date).local().format('MM/DD/YYYY h:mm a')
-		}
-		
-		if (this.state.agency !== '' && this.state.rep_start !== '' && this.state.rep_end !== ''){
-			headerDate = <div className="col-md-2 ">
-							<div className = 'header-box'>
-									<span>
-									Agency: {this.state.agency}
-									</span>
-									<br/>
-									<span>
-									Last Modified: {updated}
-									</span>
-								</div>
-						</div>;
-		}
+        // reset file and job status
+        let currentResults = this.state.jobResults;
+        currentResults['detached_award'].file_status = '';
+        currentResults['detached_award'].job_status = '';
+        this.setState({
+            jobResults: currentResults
+        });
 
-		const type = {
-			fileTitle: 'Upload',
-			fileTemplateName: 'detached_award.csv',
-			requestName: 'detached_award',
-			progress: '0'
-		}
+        this.uploadFileHelper(kGlobalConstants.LOCAL, submission)
+            .then((submissionID) => {
+                this.setState({
+                    validationFinished: false
+                })
+                setTimeout(()=>{
+                    this.checkFileStatus(submissionID);
+                }, 2000);
+            })
+            .catch((err) => {
+                this.setState({
+                    validationFinished: false,
+                    notAllowed: err.httpStatus === 403,
+                    errorMessage: err.httpStatus === 403 ? err.message : err.body.message
+                });
+            });
+    }
 
-		const fileData = this.state.jobResults[type.requestName];
-		const status = fileData.job_status;
-		let errorMessage = null;
-		validationBox = <ValidateDataFileContainer type={type} data={this.state.jobResults}
-												   setUploadItem={this.uploadFile.bind(this)}
-												   updateItem={this.uploadFile.bind(this)} 
-												   publishing={this.state.published === 'publishing'}/>;
-		if (fileData.file_status == 'complete' && this.state.validationFinished && this.state.published !== 'publishing') {
-			if (status != 'invalid' || fileData.file_status == 'complete') {
-				validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults}
-														 	 setUploadItem={this.uploadFile.bind(this)}
-														 	 updateItem={this.uploadFile.bind(this)}
-														 	 published={this.state.published} />;
-			}
+    render() {
+        let validationButton = null;
+        let revalidateButton = null;
+        let downloadButton = null;
+        let validationBox = null;
+        let headerDate = null;
+        let updated = null;
 
-			if (this.state.showSuccess) {
-				errorMessage = <UploadDetachedFilesError errorCode={this.state.error} type='success' message={this.state.error_message} />
-				validationButton = null;
-				revalidateButton = null;
-			}
-			else if (this.state.published === 'published') {
-				// This submission is already published and cannot be republished
-				validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' disabled>File Published:<span className='plain'> {this.state.fabs_meta.valid_rows} rows published at {this.state.fabs_meta.publish_date}</span></button>;
-				revalidateButton = null;
-			}
-			else if (PermissionsHelper.checkFabsPermissions(this.props.session)) {
-				// User has permissions to publish this unpublished submission
-				validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.openModal.bind(this)}>Publish</button>;
-				revalidateButton = <button className='pull-right col-xs-3 us-da-button revalidate-button' onClick={this.startRevalidation.bind(this)}>Revalidate</button>;
-			}
-			else {
-				// User does not have permissions to publish
-				validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' disabled>You do not have permissions to publish</button>;
-				revalidateButton = null;
-			}
-		}
+        if (this.state.modified_date) {
+            updated = moment.utc(this.state.modified_date).local().format('MM/DD/YYYY h:mm a')
+        }
+        
+        if (this.state.agency !== '' && this.state.rep_start !== '' && this.state.rep_end !== ''){
+            headerDate = <div className="col-md-2 ">
+                            <div className = 'header-box'>
+                                    <span>
+                                    Agency: {this.state.agency}
+                                    </span>
+                                    <br/>
+                                    <span>
+                                    Last Modified: {updated}
+                                    </span>
+                                </div>
+                        </div>;
+        }
 
-		if (this.state.published == 'publishing' && this.state.error !== 0) {
-			errorMessage = <UploadDetachedFilesError errorCode={this.state.error} type='error' message={this.state.error_message} />
-			validationButton = null;
-			revalidateButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.startRevalidation.bind(this)}>Revalidate</button>;
-		}
-		else if (this.state.published == 'unpublished' && this.state.error !== 0) {
-			errorMessage = <UploadDetachedFilesError errorCode={this.state.error} type='error' message={this.state.error_message} />
-			validationButton = null;
-			revalidateButton = null;
-		}
-		
-		return (
-			<div>
-				<div className="usa-da-content-teal">
-					<div className="container">
-						<div className="row usa-da-page-title">
-							<div className="col-md-10 mt-40 mb-20">
-								<div className="display-2">
-									Upload FABS Data
-								</div>
-							</div>
-							{headerDate}
-						</div>
-					</div>
-				</div>
-				<Banner type='fabs' />
-				<div className='container'>
-					<div className = 'col-xs-12 mt-60 mb-60'>
-						<div className = 'validation-holder'>
+        const type = {
+            fileTitle: 'Upload',
+            fileTemplateName: 'detached_award.csv',
+            requestName: 'detached_award',
+            progress: '0'
+        }
 
-							<ReactCSSTransitionGroup transitionName="usa-da-meta-fade" transitionEnterTimeout={600} transitionLeaveTimeout={200}>
-								{validationBox}
-							</ReactCSSTransitionGroup>
+        const fileData = this.state.jobResults[type.requestName];
+        const status = fileData.job_status;
+        let errorMessage = null;
+        validationBox = <ValidateDataFileContainer type={type} data={this.state.jobResults}
+                                                   setUploadItem={this.uploadFile.bind(this)}
+                                                   updateItem={this.uploadFile.bind(this)} 
+                                                   publishing={this.state.published === 'publishing'}/>;
+        if (fileData.file_status == 'complete' && this.state.validationFinished && this.state.published !== 'publishing') {
+            if (status != 'invalid' || fileData.file_status == 'complete') {
+                validationBox = <ValidateValuesFileContainer type={type} data={this.state.jobResults}
+                                                             setUploadItem={this.uploadFile.bind(this)}
+                                                             updateItem={this.uploadFile.bind(this)}
+                                                             published={this.state.published} />;
+            }
 
-							{errorMessage}
+            if (this.state.showSuccess) {
+                errorMessage = <UploadDetachedFilesError errorCode={this.state.error} type='success' message={this.state.error_message} />;
+            }
+            else if (this.state.published === 'published') {
+                // This submission is already published and cannot be republished
+                if (this.state.fabs_meta.published_file == null) {
+                    validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' disabled>File Published:<span className='plain'> {this.state.fabs_meta.valid_rows} rows published at {this.state.fabs_meta.publish_date}</span></button>;
+                }
+                else {
+                    downloadButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.clickedReport.bind(this, this.props.item)} download={this.state.fabs_meta.published_file} rel="noopener noreferrer">File Published:<span className='plain'> {this.state.fabs_meta.valid_rows} rows published at {this.state.fabs_meta.publish_date}</span></button>;
+                }
+            }
+            else if (PermissionsHelper.checkFabsPermissions(this.props.session)) {
+                // User has permissions to publish this unpublished submission
+                validationButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.openModal.bind(this)}>Publish</button>;
+                revalidateButton = <button className='pull-right col-xs-3 us-da-button revalidate-button' onClick={this.startRevalidation.bind(this)}>Revalidate</button>;
+            }
+            else {
+                // User does not have permissions to publish
+                validationButton = <button className='pull-right col-xs-3 us-da-disabled-button' disabled>You do not have permissions to publish</button>;
+            }
+        }
 
-							<ReactCSSTransitionGroup transitionName="usa-da-meta-fade" transitionEnterTimeout={600} transitionLeaveTimeout={200}>
-								{validationButton}
-								{revalidateButton}
-							</ReactCSSTransitionGroup>
-						</div>
-					</div>
-				</div>
-				<PublishModal rows={this.state.fabs_meta} validate={this.submitFabs.bind(this)} submissionID={this.state.submissionID} closeModal={this.closeModal.bind(this)} isOpen={this.state.showPublish} published={this.state.published} />
-			</div>
-		);
-	}
+        if (this.state.published == 'publishing' && this.state.error !== 0) {
+            errorMessage = <UploadDetachedFilesError errorCode={this.state.error} type='error' message={this.state.error_message} />;
+            validationButton = null;
+            revalidateButton = <button className='pull-right col-xs-3 us-da-button' onClick={this.startRevalidation.bind(this)}>Revalidate</button>;
+        }
+        else if (this.state.published == 'unpublished' && this.state.error !== 0) {
+            errorMessage = <UploadDetachedFilesError errorCode={this.state.error} type='error' message={this.state.error_message} />;
+            validationButton = null;
+            revalidateButton = null;
+        }
+        
+        return (
+            <div>
+                <div className="usa-da-content-teal">
+                    <div className="container">
+                        <div className="row usa-da-page-title">
+                            <div className="col-md-10 mt-40 mb-20">
+                                <div className="display-2">
+                                    Upload FABS Data
+                                </div>
+                            </div>
+                            {headerDate}
+                        </div>
+                    </div>
+                </div>
+                <Banner type='fabs' />
+                <div className='container'>
+                    <div className = 'col-xs-12 mt-60 mb-60'>
+                        <div className = 'validation-holder'>
+                            <ReactCSSTransitionGroup transitionName="usa-da-meta-fade" transitionEnterTimeout={600} transitionLeaveTimeout={200}>
+                                {validationBox}
+                            </ReactCSSTransitionGroup>
+
+                            {errorMessage}
+
+                            <ReactCSSTransitionGroup transitionName="usa-da-meta-fade" transitionEnterTimeout={600} transitionLeaveTimeout={200}>
+                                {validationButton}
+                                {revalidateButton}
+                                {downloadButton}
+                            </ReactCSSTransitionGroup>
+                        </div>
+                    </div>
+                </div>
+                <PublishModal rows={this.state.fabs_meta} validate={this.submitFabs.bind(this)} submissionID={this.state.submissionID} closeModal={this.closeModal.bind(this)} isOpen={this.state.showPublish} published={this.state.published} />
+            </div>
+        );
+    }
 }
 
 export default connect(

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFileValidation.jsx
@@ -170,11 +170,10 @@ class UploadDetachedFileValidation extends React.Component {
     }
 
     signReport(item){
-        let type = 'D2_detached';
-        GenerateFilesHelper.fetchFile(type, this.props.submission.id)
+        GenerateFilesHelper.getFabsMeta(this.props.submission.id)
             .then((result)=>{
                 this.setState({
-                    signedUrl: result.url,
+                    signedUrl: result.published_file,
                     signInProgress: false
                 }, () => {
                     this.openReport();

--- a/src/js/components/uploadDetachedFiles/UploadDetachedFilesError.jsx
+++ b/src/js/components/uploadDetachedFiles/UploadDetachedFilesError.jsx
@@ -35,7 +35,7 @@ export default class UploadDetachedFilesError extends React.Component {
 		let message = '';
 
 		if (this.state.type == 'success') {
-			header = 'Your submission has been succesfully published';
+			header = 'Your submission has been successfully published';
 		}
 		else if (this.props.error) {
 			header = this.props.error.header;

--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -62,11 +62,28 @@ export const fetchFile = (type, submissionId) => {
                 'file_type': type
             })
             .end((errFile, res) => {
-
                 if (errFile) {
                     const response = Object.assign({}, res.body);
                     response.httpStatus = res.status;
                     deferred.reject(response);
+                }
+                else {
+                    deferred.resolve(res.body);
+                }
+
+            });
+
+    return deferred.promise;
+}
+
+export const getFabsMeta = (submissionId) => {
+    const deferred = Q.defer();
+
+    Request.post(kGlobalConstants.API + 'get_fabs_meta/')
+            .send({'submission_id': submissionId})
+            .end((errFile, res) => {
+                if (errFile) {
+                    deferred.reject(errFile);
                 }
                 else {
                     deferred.resolve(res.body);


### PR DESCRIPTION
- [ ] backend PR merged (https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1019)

AC:
- Write published submission rows to a file, including derived fields
- Allow user to download the file from the published submission page