### PR TITLE
Fix - File E and F Generation Text

### DIFF
--- a/src/js/components/generateEF/GenerateEFContent.jsx
+++ b/src/js/components/generateEF/GenerateEFContent.jsx
@@ -28,13 +28,13 @@ export default class GenerateFilesContent extends React.Component {
                         type="E"
                         title="Executive Compensation Data"
                         description={"Executive Compensation data is generated from the System for Award Management" +
-                            " and includes data for the receiving entities of the awards in file C."} />
+                            " and includes data for the receiving entities of the awards in file D."} />
                     <GenerateEFItem
                         {...this.props}
                         type="F"
                         title="Sub-Award Data"
                         description={"Sub-award data is generated from the Federal Subaward Reporting System and " +
-                            "includes the subawards for the prime awards in file C."} />
+                            "includes the subawards for the prime awards in file D."} />
                 </div>
                 <GenerateEFOverlay {...this.props} />
             </div>


### PR DESCRIPTION
- Updates file generation text to reflect that Files E and F are based off of File D, not File C

Bug: https://federal-spending-transparency.atlassian.net/browse/DEV-451