### PR TITLE
Updating SQL Rules to match backend

### DIFF
--- a/src/help/fabs_validations.csv
+++ b/src/help/fabs_validations.csv
@@ -1,9 +1,9 @@
 Relates to Files,Rule Name,Rule Detail,Severity,Status
 FABS,FABS1,"FAIN is required for non-aggregate and PII-redacted non-aggregate records (i.e., when RecordType = 2 or 3).",Fatal Error,Implemented
 FABS,FABS2.1,"The combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must be unique within the submission file.",Fatal Error,Implemented
-FABS,FABS2.2,"The combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must be unique when compared to currently published data--unless the record is a correction or deletion (i.e., if CorrectionDeleteIndicator = C or D). In this particular case, the combination of these four fields in this transaction has already been published in USAspending, making this second attempt a duplicate.",Fatal Error,Implemented
-FABS,FABS2.3,"The unique combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must exist as a currently published record when the record is a correction (i.e., if CorrectionDeleteIndicator = C).",Fatal Error,Implemented
-FABS,FABS2.4,"The unique combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must exist as a currently published record when the record is a deletion (i.e., if CorrectionDeleteIndicator = D).",Fatal Error,Implemented
+FABS,FABS2.2.1,"The combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must be unique when compared to currently published data--unless the record is a correction or deletion (i.e., if CorrectionDeleteIndicator = C or D). In this particular case, the combination of these four fields in this transaction has already been published in USAspending, making this second attempt a duplicate.",Fatal Error,Implemented
+FABS,FABS2.2.2,"The unique combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must exist as a currently published record when the record is a correction (i.e., if CorrectionDeleteIndicator = C).",Fatal Error,Implemented
+FABS,FABS2.2.3,"The unique combination of FAIN, AwardModificationAmendmentNumber, URI, and AwardingSubTierAgencyCode must exist as a currently published record when the record is a deletion (i.e., if CorrectionDeleteIndicator = D).",Fatal Error,Implemented
 FABS,FABS3.1,"ActionType is required for non-aggregate and PII-redacted non-aggregate records (i.e., when RecordType = 2 or 3).",Fatal Error,Implemented
 FABS,FABS3.2,"ActionType must contain one of the following values: ""A"", ""B"", ""C"", ""D"", or blank.",Fatal Error,Implemented
 FABS,FABS4.1,"ActionDate must follow YYYYMMDD format, where YYYY is the year, MM the month and DD the day.",Fatal Error,Implemented
@@ -32,8 +32,8 @@ FABS,FABS19,LegalEntityCountryCode Field must contain a valid three character GE
 FABS,FABS21,"FundingSubTierAgencyCode is an optional field, but when provided must be a valid 4-digit sub-tier agency code.",Fatal Error,Implemented
 FABS,FABS22,"When provided, CorrectionDeleteIndicator must contain one of the following values: ""C"" or ""D"".",Fatal Error,Implemented
 FABS,FABS23,AwardingSubTierAgencyCode must be a valid 4-digit sub-tier agency code.,Fatal Error,Implemented
-FABS,FABS24.1,"PrimaryPlaceOfPerformanceCountryCode must contain a valid three character GENC Standard Edition 3.0 (Update 4) country code for aggregate or non-aggregate records (i.e., when RecordType = 1 or 2).",Fatal Error,Implemented
-FABS,FABS24.2,"PrimaryPlaceOfPerformanceCountryCode must be blank for PII-redacted non-aggregate records (i.e., when RecordType = 3).",Fatal Error,Implemented
+FABS,FABS24.1,"PrimaryPlaceOfPerformanceCountryCode must be blank for PII-redacted non-aggregate records (i.e., when RecordType = 3).",Fatal Error,Implemented
+FABS,FABS24.2,"PrimaryPlaceOfPerformanceCountryCode must contain a valid three character GENC Standard Edition 3.0 (Update 4) country code for aggregate or non-aggregate records (i.e., when RecordType = 1 or 2).",Fatal Error,Implemented
 FABS,FABS26.1,"FederalActionObligation must be blank or 0 for loans (i.e., when AssistanceType = 07 or 08).",Fatal Error,Implemented
 FABS,FABS26.2,"FederalActionObligation is required for non-loans (i.e., when AssistanceType is not 07 or 08).",Fatal Error,Implemented
 FABS,FABS27,"NonFederalFundingAmount must be blank or 0 or for loans (i.e., when AssistanceType = 07 or 08).",Fatal Error,Implemented


### PR DESCRIPTION
1. Switch 24.1 and 24.2 in the Broker
2. Reassign these rules new code numbers (these should be reflected in the codes that appear in the error reports generated when these rule triggers) as follows:
FABS2.2 -> FABS2.2.1
FABS2.3 -> FABS2.2.2
FABS2.4 -> FABS2.2.3

[story link](https://federal-spending-transparency.atlassian.net/browse/DEV-888)

- [x] Frontend Review
- [x]  Merged with backend https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1210