### PR TITLE
Dev 1031 broken links

### DIFF
--- a/src/js/components/help/helpSidebar.jsx
+++ b/src/js/components/help/helpSidebar.jsx
@@ -119,9 +119,6 @@ export default class HelpSidebar extends React.Component {
                         <a href={help + "?section=membership"}>Contact the Service Desk</a>
                     </li>
                     <li>
-                        <a href={help + "?section=filingIssue"}>Filing an Issue</a>
-                    </li>
-                    <li>
                         <a href={resources}>Resources - DAIMS</a>
                     </li>
                     <li>

--- a/src/js/components/help/resourcesContent.jsx
+++ b/src/js/components/help/resourcesContent.jsx
@@ -155,7 +155,7 @@ export default class ResourcesContent extends React.Component {
                     <ul>
                         <li>
                             <a
-                                href={github + "DAIMS_RSS_Diagram_File_A_v1.1.pdf"}
+                                href={github + "DAIMS_RSS_Diagram_File_A_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File A - Appropriation Account Detail
@@ -163,7 +163,7 @@ export default class ResourcesContent extends React.Component {
                         </li>
                         <li>
                             <a
-                                href={github + "DAIMS_RSS_Diagram_File_B_v1.1.pdf"}
+                                href={github + "DAIMS_RSS_Diagram_File_B_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File B - Object Class and Program Activity Detail
@@ -171,7 +171,7 @@ export default class ResourcesContent extends React.Component {
                         </li>
                         <li>
                             <a
-                                href={github + "DAIMS_RSS_Diagram_File_C_v1.1.pdf"}
+                                href={github + "DAIMS_RSS_Diagram_File_C_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File C - Award Financial Detail
@@ -185,7 +185,7 @@ export default class ResourcesContent extends React.Component {
                     </p>
                     <ul>
                         <li>
-                            <a href={github + "DAIMS_IDD_v1.1.xlsx"}>IDD v1.1</a>
+                            <a href={github + "DAIMS_IDD_v1.2.xlsx"}>IDD v1.2</a>
                         </li>
                     </ul>
                     <h6>DAIMS Diagrams for IDD</h6>
@@ -196,7 +196,7 @@ export default class ResourcesContent extends React.Component {
                     <ul>
                         <li>
                             <a
-                                href={github + "DAIMS_IDD_Diagram_File_D1_v1.1.pdf"}
+                                href={github + "DAIMS_IDD_Diagram_File_D1_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File D1 - Award and Awardee Attributes (Procurement)
@@ -204,7 +204,7 @@ export default class ResourcesContent extends React.Component {
                         </li>
                         <li>
                             <a
-                                href={github + "DAIMS_IDD_Diagram_File_D2_v1.1.pdf"}
+                                href={github + "DAIMS_IDD_Diagram_File_D2_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File D2 - Award and Awardee Attributes (Financial Assistance)
@@ -212,7 +212,7 @@ export default class ResourcesContent extends React.Component {
                         </li>
                         <li>
                             <a
-                                href={github + "DAIMS_IDD_Diagram_File_E_v1.1.pdf"}
+                                href={github + "DAIMS_IDD_Diagram_File_E_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File E - Additional Awardee Attributes
@@ -220,7 +220,7 @@ export default class ResourcesContent extends React.Component {
                         </li>
                         <li>
                             <a
-                                href={github + "DAIMS_IDD_Diagram_File_F_v1.1.pdf"}
+                                href={github + "DAIMS_IDD_Diagram_File_F_v1.2.pdf"}
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 File F - Sub-Award Attributes
@@ -255,12 +255,6 @@ export default class ResourcesContent extends React.Component {
                             <a href="/#/FABSresources" target="_blank" rel="noopener noreferrer">
                                 FABS Resources Page
                             </a>
-                        </li>
-                        <li>
-                            <a href={github + "DAIMS_Agency_Label_To_Terse_Label_v1.1.xlsx"}>
-                                Long Element Name to Short Element Name Crosswalk
-                            </a> - A listing of the shortened column names for the data elements
-                            in the RSS and IDD.
                         </li>
                     </ul>
                 </div>

--- a/src/js/containers/help/HelpContainer.jsx
+++ b/src/js/containers/help/HelpContainer.jsx
@@ -33,17 +33,16 @@ class HelpPageContainer extends React.Component {
         };
     }
 
+    componentWillMount() {
+        this.setHelpRoute(this.props);
+    }
+
     componentDidMount() {
         this.checkHelpOnly();
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.route.type !== this.state.type || nextProps.route.path !== this.state.path) {
-            this.setState({
-                type: nextProps.route.type,
-                path: nextProps.route.path.toLowerCase()
-            });
-        }
+        this.setHelpRoute(nextProps);
     }
 
     componentDidUpdate(prevProps) {
@@ -56,6 +55,15 @@ class HelpPageContainer extends React.Component {
         this.setState({
             helpOnly: this.props.session.user.helpOnly
         });
+    }
+
+    setHelpRoute(incomingProps) {
+        if (incomingProps.route.type !== this.state.type || incomingProps.route.path !== this.state.path) {
+            this.setState({
+                type: incomingProps.route.type,
+                path: incomingProps.route.path.toLowerCase()
+            });
+        }
     }
 
     render() {


### PR DESCRIPTION
Fixing old v1.1 links to v1.2 and updating a sample file in S3.
Bonus (which was requested but isn't really something new): fixed a long-standing bug where refreshing on the resources page made it go to the main help page

- [ ] Reviewed by frontend
- [x] New `appropValid.csv` file uploaded to S3