### PR TITLE
DEV-1212: get_obligations from a POST to a GET

### DIFF
--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -328,8 +328,7 @@ export const sendNotification = (users, id) => {
 export const fetchObligations = (submissionId) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'get_obligations/')
-        .send({ submission_id: submissionId })
+    Request.get(kGlobalConstants.API + 'get_obligations/?submission_id=' + submissionId)
         .end((errFile, res) => {
             if (errFile) {
                 deferred.reject(errFile);


### PR DESCRIPTION
**High level description:**
Update `get_obligations` from a POST request to a GET.

**Technical details:**
Replace POST request of `{"submission_id": submissionId}` to `get_obligations` to a GET request from `get_obligations/?submission_id=submissionId`.

**Link to JIRA Ticket:**
[DEV-1212](https://federal-spending-transparency.atlassian.net/browse/DEV-1212)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [ ] Merged concurrently with [#1295](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1295)