### PR TITLE
DEV-1208: Switch check_generation_status and check_detached_generation_status to GET

### DIFF
--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -30,11 +30,7 @@ export const generateFile = (type, submissionId, start, end) => {
 export const checkGenerationStatus = (type, submissionId) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'check_generation_status/')
-        .send({
-            submission_id: submissionId,
-            file_type: type
-        })
+    Request.get(kGlobalConstants.API + 'check_generation_status/?submission_id=' + submissionId + '&file_type=' + type)
         .end((errFile, res) => {
             if (errFile) {
                 const response = Object.assign({}, res.body);
@@ -112,10 +108,7 @@ export const generateDetachedFile = (type, start, end, cgacCode, frecCode) => {
 export const fetchDetachedFile = (jobId) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'check_detached_generation_status/')
-        .send({
-            job_id: jobId
-        })
+    Request.get(kGlobalConstants.API + 'check_detached_generation_status/?job_id=' + jobId)
         .end((errFile, res) => {
             if (errFile) {
                 const response = Object.assign({}, res.body);


### PR DESCRIPTION
**High level description:**
Update `check_generation_status` and `check_detached_generation_status` from POST requests to GET.

**Technical details:**
Change the request for `check_generation_status` and `check_detached_generation_status` from POST to GET.

**Link to JIRA Ticket:**
[DEV-1208](https://federal-spending-transparency.atlassian.net/browse/DEV-1208)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [ ] Merged concurrently with [Backend#1302](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1302)