### PR TITLE
Only pass start/end if they're given

### DIFF
--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -6,13 +6,20 @@ import { kGlobalConstants } from '../GlobalConstants';
 export const generateFile = (type, submissionId, start, end) => {
     const deferred = Q.defer();
 
+    const call_body = {
+        submission_id: submissionId,
+        file_type: type
+    };
+
+    if (start) {
+        call_body.start = start;
+    }
+    if (end) {
+        call_body.end = end;
+    }
+
     Request.post(kGlobalConstants.API + 'generate_file/')
-        .send({
-            submission_id: submissionId,
-            file_type: type,
-            start,
-            end
-        })
+        .send(call_body)
         .end((errFile, res) => {
             if (errFile) {
                 const response = Object.assign({}, res.body);

--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -6,20 +6,20 @@ import { kGlobalConstants } from '../GlobalConstants';
 export const generateFile = (type, submissionId, start, end) => {
     const deferred = Q.defer();
 
-    const call_body = {
+    const callBody = {
         submission_id: submissionId,
         file_type: type
     };
 
     if (start) {
-        call_body.start = start;
+        callBody.start = start;
     }
     if (end) {
-        call_body.end = end;
+        callBody.end = end;
     }
 
     Request.post(kGlobalConstants.API + 'generate_file/')
-        .send(call_body)
+        .send(callBody)
         .end((errFile, res) => {
             if (errFile) {
                 const response = Object.assign({}, res.body);


### PR DESCRIPTION
**High level description:**
Updating frontend so E/F generation isn't broken

**Technical details:**
Updating so we only pass start/end date for file generation if it's a D1/D2 file. We don't want to pass it for E/F files

**Link to JIRA Ticket:**
[DEV-1211](https://federal-spending-transparency.atlassian.net/browse/DEV-1211)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [ ] Merged concurrently with [Backend#1305](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1305)