### PR TITLE
DEV-1280: Remove unnecessary params in upload_detached_file

### DIFF
--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -412,7 +412,6 @@ export const performFabsFileUpload = (submission) => {
         }
     }
 
-    request = prepareMetadata(submission.meta, request);
     request.agency_code = submission.meta.subTierAgency;
 
     // submit it to the API to set up S3
@@ -490,7 +489,6 @@ export const performFabsLocalUpload = (submission) => {
     const store = new StoreSingleton().store;
     store.dispatch(uploadActions.setSubmissionState('uploading'));
 
-    request = prepareMetadata(submission.meta, request);
     request.agency_code = submission.meta.subTierAgency;
 
     const uploadOperations = [];


### PR DESCRIPTION
**High level description:**
Cleaning up upload_detached_file route params.

**Technical details:**
Dates, cgac/frec codes, and quarter checks in upload_detached_file are useless because we don't do anything with any of them. Removed this metadata from the upload_detached_file calls

**Link to JIRA Ticket:**
[DEV-1280](https://federal-spending-transparency.atlassian.net/browse/DEV-1280)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed