### PR TITLE
DEV-1328: rename submit files route

### DIFF
--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -10,7 +10,7 @@ import * as uploadActions from '../redux/actions/uploadActions';
 const prepareFilesNewSub = (fileDict) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'submit_files/')
+    Request.post(kGlobalConstants.API + 'upload_dabs_files/')
         .attach('appropriations', fileDict.appropriations)
         .attach('program_activity', fileDict.program_activity)
         .attach('award_financial', fileDict.award_financial)
@@ -36,7 +36,7 @@ const prepareFilesNewSub = (fileDict) => {
 const prepareFilesExistingSub = (fileDict) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'submit_files/')
+    Request.post(kGlobalConstants.API + 'upload_dabs_files/')
         .attach('appropriations', fileDict.appropriations)
         .attach('program_activity', fileDict.program_activity)
         .attach('award_financial', fileDict.award_financial)


### PR DESCRIPTION
**High level description:**
Renaming `submit_files` to `upload_dabs_files`.

**Technical details:**
Renaming `submit_files` to `upload_dabs_files` to reflect the changes on the backend

**Link to JIRA Ticket:**
[DEV-1328](https://federal-spending-transparency.atlassian.net/browse/DEV-1328)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#1327](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1327)