### PR TITLE
DEV-1329: rename upload detached file route

### DIFF
--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -101,7 +101,7 @@ const prepareFabsFile = (fileDict) => {
         fieldType = 'existing_submission_id';
     }
 
-    Request.post(kGlobalConstants.API + 'upload_detached_file/')
+    Request.post(kGlobalConstants.API + 'upload_fabs_file/')
         .attach('fabs', fileDict.fabs)
         .field(fieldType, fileDict[fieldType])
         .end((err, res) => {


### PR DESCRIPTION
**High level description:**
Renaming `upload_detached_file` to `upload_fabs_file`.

**Technical details:**
Renaming `upload_detached_file` to `upload_fabs_file` to reflect the changes on the backend

**Link to JIRA Ticket:**
[DEV-1329](https://federal-spending-transparency.atlassian.net/browse/DEV-1329)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#1328](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1328)