### PR TITLE
DEV-1465: Firefox upload corrected files bugfix

### DIFF
--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -36,11 +36,17 @@ const prepareFilesNewSub = (fileDict) => {
 const prepareFilesExistingSub = (fileDict) => {
     const deferred = Q.defer();
 
-    Request.post(kGlobalConstants.API + 'upload_dabs_files/')
-        .attach('appropriations', fileDict.appropriations)
-        .attach('program_activity', fileDict.program_activity)
-        .attach('award_financial', fileDict.award_financial)
-        .field('existing_submission_id', fileDict.existing_submission_id)
+    const req = Request.post(kGlobalConstants.API + 'upload_dabs_files/')
+    if (fileDict.appropriations) {
+        req.attach('appropriations', fileDict.appropriations)
+    }
+    if (fileDict.program_activity) {
+        req.attach('program_activity', fileDict.program_activity)
+    }
+    if (fileDict.award_financial) {
+        req.attach('award_financial', fileDict.award_financial)
+    }
+    req.field('existing_submission_id', fileDict.existing_submission_id)
         .end((err, res) => {
             if (err) {
                 const response = Object.assign({}, res.body);

--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -36,15 +36,15 @@ const prepareFilesNewSub = (fileDict) => {
 const prepareFilesExistingSub = (fileDict) => {
     const deferred = Q.defer();
 
-    const req = Request.post(kGlobalConstants.API + 'upload_dabs_files/')
+    const req = Request.post(kGlobalConstants.API + 'upload_dabs_files/');
     if (fileDict.appropriations) {
-        req.attach('appropriations', fileDict.appropriations)
+        req.attach('appropriations', fileDict.appropriations);
     }
     if (fileDict.program_activity) {
-        req.attach('program_activity', fileDict.program_activity)
+        req.attach('program_activity', fileDict.program_activity);
     }
     if (fileDict.award_financial) {
-        req.attach('award_financial', fileDict.award_financial)
+        req.attach('award_financial', fileDict.award_financial);
     }
     req.field('existing_submission_id', fileDict.existing_submission_id)
         .end((err, res) => {


### PR DESCRIPTION
**High level description:**
Firefox users cannot upload one or two corrected files on the `/#/validateData` page.

**Technical details:**
Firefox cannot handle attaching empty objects to the Request, and will throw an (unhandled) error. We must only attempt to attach these files to the Request if the file exists.

**Link to JIRA Ticket:**
[DEV-1465](https://federal-spending-transparency.atlassian.net/browse/DEV-1465)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- Merged concurrently with Backend N/A
- Backend impact assessment completed N/A