### PR TITLE
DEV-1222: c9 assistance type correction

### DIFF
--- a/src/help/validations.csv
+++ b/src/help/validations.csv
@@ -48,7 +48,7 @@ C,C6,"GrossOutlaysUndeliveredOrdersPrepaidTotal in File C = USSGL 4802 + 4882 in
 C,C7,"GrossOutlaysDeliveredOrdersPaidTotal in File C = USSGL 4902 + 4908 + 4982 in File C for the same date context (FYB or CPE). This applies to the award level. Note for FYB values, only 4908 is expected to have a balance other than zero.",Warning,Implemented
 "C, D2",C8,Unique FAIN and/or URI from file C should exist in file D2. FAIN may be null for aggregated records.  URI may be null for non-aggregated records.,Warning,Implemented
 "C, D2",C9,"Unique FAIN and/or URI from file D2 should exist in file C, except for:
-1)    Loans (AssistanceType = 08 or 09) with OriginalLoanSubsidyCost <= 0 in D2; or
+1)    Loans (AssistanceType = 07 or 08) with OriginalLoanSubsidyCost <= 0 in D2; or
 2)    Non-Loans with FederalActionObligation = 0 in D2.
 FAIN may be null for aggregated records.  URI may be null for non-aggregated records. ",Warning,Implemented
 "C, D1",C11,Each unique PIID (or combination of PIID/ParentAwardId) from file C should exist in file D1.,Warning,Implemented


### PR DESCRIPTION
**High level description:**
Updating rule text to match the corrections on the backend

**Technical details:**
Updating C9 so it says AssistanceType of 07 and 08 rather than 08 and 09 (based on backend changes)

**Link to JIRA Ticket:**
[DEV-1222](https://federal-spending-transparency.atlassian.net/browse/DEV-1222)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [ ] Merged concurrently with [Backend#1362](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1362)