### PR TITLE
Feature dashboard agency filter

### DIFF
--- a/src/_scss/components/typeahead/_typeahead.scss
+++ b/src/_scss/components/typeahead/_typeahead.scss
@@ -19,8 +19,8 @@
     .error-icon {
         svg {
             fill: $color-secondary !important;
-            height: 45px !important;
-            width: 45px !important;
+            height: 45px;
+            width: 45px;
             right: 0px !important;
         }
     }

--- a/src/_scss/pages/dashboard/_filters.scss
+++ b/src/_scss/pages/dashboard/_filters.scss
@@ -5,7 +5,7 @@
     border-bottom: 0;
     @include display(flex);
     @include align-items(center);
-    @include justify-content(space-between);
+    @include justify-content(flex-start);
     .dashboard-filters__label {
         @include display(flex);
         @include flex(0 0 auto);

--- a/src/_scss/pages/dashboard/_filters.scss
+++ b/src/_scss/pages/dashboard/_filters.scss
@@ -27,6 +27,16 @@
         @include flex(0 0 auto);
         @import './_textFilter';
         padding-right: rem(10);
+
+        &.dashboard-filters__filter_agency {
+            @import '../../components/typeahead/_typeahead';
+            // override dropdown width
+            .typeahead-holder {
+                .awesomplete ul {
+                    width: 35%;
+                }
+            }
+        }
     }
     .dashboard-filters__submit-content {
         @include display(flex);

--- a/src/_scss/pages/dashboard/_filters.scss
+++ b/src/_scss/pages/dashboard/_filters.scss
@@ -4,7 +4,7 @@
     border: solid rem(1) $color-white;
     border-bottom: 0;
     @include display(flex);
-    @include align-items(baseline);
+    @include align-items(center);
     @include justify-content(space-between);
     .dashboard-filters__label {
         @include display(flex);
@@ -26,52 +26,10 @@
     .dashboard-filters__filter {
         @include display(flex);
         @include flex(0 0 auto);
-        @import './_textFilter';
         padding-right: rem(10);
-
-        &.dashboard-filters__filter_agency {
-            @import '../../components/typeahead/_typeahead';
-            // override typeahead styles
-            .typeahead-holder {
-                .usa-da-typeahead {
-                    margin: 0;
-                    .awesomplete {
-                        margin: 0;
-                        input {
-                            margin: 0;
-                            padding: rem(5) rem(10);
-                            border-radius: rem(5);
-                        }
-                        ul {
-                            width: 35%;
-                        }
-                    }
-                    .alert-error {
-                        @include display(flex);
-                        @include align-items(center);
-                        margin-bottom: 0;
-                        border: 0;
-                        padding: 0;
-                        .error-icon {
-                            padding-right: rem(5);
-                            svg {
-                                height: rem(20);
-                                width: rem(20);
-                            }
-                        }
-                        .alert-header-text {
-                            font-size: $small-font-size;
-                            width: auto;
-                            color: $color-white;
-                        }
-                        p {
-                            display: none;
-                        }
-                    }
-                }
-            }
-        }
+        @import './_textFilter';
     }
+    @import './_typeaheadFilter';
     .dashboard-filters__submit-content {
         @include display(flex);
         .dashboard-filters__reset {

--- a/src/_scss/pages/dashboard/_filters.scss
+++ b/src/_scss/pages/dashboard/_filters.scss
@@ -4,7 +4,8 @@
     border: solid rem(1) $color-white;
     border-bottom: 0;
     @include display(flex);
-    @include align-items(center);
+    @include align-items(baseline);
+    @include justify-content(space-between);
     .dashboard-filters__label {
         @include display(flex);
         @include flex(0 0 auto);
@@ -30,10 +31,43 @@
 
         &.dashboard-filters__filter_agency {
             @import '../../components/typeahead/_typeahead';
-            // override dropdown width
+            // override typeahead styles
             .typeahead-holder {
-                .awesomplete ul {
-                    width: 35%;
+                .usa-da-typeahead {
+                    margin: 0;
+                    .awesomplete {
+                        margin: 0;
+                        input {
+                            margin: 0;
+                            padding: rem(5) rem(10);
+                            border-radius: rem(5);
+                        }
+                        ul {
+                            width: 35%;
+                        }
+                    }
+                    .alert-error {
+                        @include display(flex);
+                        @include align-items(center);
+                        margin-bottom: 0;
+                        border: 0;
+                        padding: 0;
+                        .error-icon {
+                            padding-right: rem(5);
+                            svg {
+                                height: rem(20);
+                                width: rem(20);
+                            }
+                        }
+                        .alert-header-text {
+                            font-size: $small-font-size;
+                            width: auto;
+                            color: $color-white;
+                        }
+                        p {
+                            display: none;
+                        }
+                    }
                 }
             }
         }

--- a/src/_scss/pages/dashboard/_textFilter.scss
+++ b/src/_scss/pages/dashboard/_textFilter.scss
@@ -18,6 +18,7 @@ form.text-filter {
         border-bottom-right-radius: rem(5);
         padding: rem(5) rem(10) rem(5) rem(5);
         color: $color-primary;
+        background-color: $color-white;
         &:disabled {
             color: $color-gray-light;
             cursor: not-allowed;

--- a/src/_scss/pages/dashboard/_typeaheadFilter.scss
+++ b/src/_scss/pages/dashboard/_typeaheadFilter.scss
@@ -1,0 +1,42 @@
+.dashboard-filters__filter_typeahead {
+    @import '../../components/typeahead/_typeahead';
+    // override typeahead styles
+    .typeahead-holder {
+        .usa-da-typeahead {
+            margin: 0;
+            .awesomplete {
+                margin: 0;
+                input {
+                    margin: 0;
+                    padding: rem(5) rem(10);
+                    border-radius: rem(5);
+                }
+                ul {
+                    width: 35%;
+                }
+            }
+            .alert-error {
+                @include display(flex);
+                @include align-items(center);
+                margin-bottom: 0;
+                border: 0;
+                padding: 0;
+                .error-icon {
+                    padding-right: rem(5);
+                    svg {
+                        height: rem(20);
+                        width: rem(20);
+                    }
+                }
+                .alert-header-text {
+                    font-size: $small-font-size;
+                    width: auto;
+                    color: $color-white;
+                }
+                p {
+                    display: none;
+                }
+            }
+        }
+    }
+}

--- a/src/js/components/SharedComponents/Typeahead.jsx
+++ b/src/js/components/SharedComponents/Typeahead.jsx
@@ -111,10 +111,6 @@ export default class Typeahead extends React.Component {
             this.typeahead.close();
         });
 
-        this.refs.awesomplete.addEventListener('blur', () => {
-            this.bubbleUpChange();
-        });
-
         // enable tab keyboard shortcut for selection
         this.refs.awesomplete.addEventListener('keydown', (e) => {
             if (e.keyCode === 9) {
@@ -153,7 +149,7 @@ export default class Typeahead extends React.Component {
         // validate the current value is on the autocomplete list
         const validity = this.dataDictionary.hasOwnProperty(this.state.value);
         this.props.onSelect(this.dataDictionary[this.state.value],
-            this.internalValueDictionary[this.state.value], validity);
+            this.internalValueDictionary[this.state.value], validity, this.state.value);
     }
 
 

--- a/src/js/components/dashboard/DashboardFilters.jsx
+++ b/src/js/components/dashboard/DashboardFilters.jsx
@@ -9,6 +9,7 @@ import { Filter } from '../../components/SharedComponents/icons/Icons';
 import FilterSubmitContainer from '../../containers/dashboard/FilterSubmitContainer';
 import SubmissionIdFilter from './filters/SubmissionIdFilter';
 import FileNameFilter from './filters/FileNameFilter';
+import AgencyFilter from './filters/AgencyFilter';
 
 const propTypes = {
     toggleFilter: PropTypes.func,
@@ -46,6 +47,8 @@ export default class DashboardFilters extends React.Component {
                     </span>
                     Filter by:
                 </div>
+                <AgencyFilter
+                    updateFilterList={this.updateFilterList} />
                 <FileNameFilter
                     updateFilterList={this.updateFilterList} />
                 <SubmissionIdFilter

--- a/src/js/components/dashboard/DashboardFilters.jsx
+++ b/src/js/components/dashboard/DashboardFilters.jsx
@@ -48,6 +48,8 @@ export default class DashboardFilters extends React.Component {
                     Filter by:
                 </div>
                 <AgencyFilter
+                    type={this.props.type}
+                    table={this.props.table}
                     updateFilterList={this.updateFilterList} />
                 <FileNameFilter
                     updateFilterList={this.updateFilterList} />

--- a/src/js/components/dashboard/filters/AgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/AgencyFilter.jsx
@@ -40,7 +40,7 @@ export default class AgencyFilter extends React.Component {
 
     render() {
         return (
-            <div className="dashboard-filters__filter dashboard-filters__filter_agency">
+            <div className="dashboard-filters__filter dashboard-filters__filter_typeahead">
                 <div className="typeahead-holder">
                     <AgencyFilterContainer
                         type={this.props.type}

--- a/src/js/components/dashboard/filters/AgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/AgencyFilter.jsx
@@ -1,0 +1,51 @@
+/**
+ * AgencyFilter.jsx
+ * Created by Lizzie Salita 8/24/18
+ */
+
+import React, { PropTypes } from 'react';
+
+import AgencyListContainer from '../../../containers/SharedContainers/AgencyListContainer';
+
+const propTypes = {
+    updateFilterList: PropTypes.func
+};
+
+const defaultProps = {
+    updateFilterList: null
+};
+
+export default class AgencyFilter extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.handleAgencySelect = this.handleAgencySelect.bind(this);
+    }
+
+    handleAgencySelect(code, codeType, isValid, name) {
+        if (code && name && isValid) {
+            this.props.updateFilterList(
+                'agencies',
+                {
+                    code,
+                    name
+                }
+            );
+        }
+    }
+
+    render() {
+        return (
+            <div className="dashboard-filters__filter dashboard-filters__filter_agency">
+                <div className="typeahead-holder">
+                    <AgencyListContainer
+                        placeholder="Agency Name"
+                        onSelect={this.handleAgencySelect} />
+                </div>
+            </div>
+        );
+    }
+}
+
+AgencyFilter.propTypes = propTypes;
+AgencyFilter.defaultProps = defaultProps;

--- a/src/js/components/dashboard/filters/AgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/AgencyFilter.jsx
@@ -5,14 +5,18 @@
 
 import React, { PropTypes } from 'react';
 
-import AgencyListContainer from '../../../containers/SharedContainers/AgencyListContainer';
+import AgencyFilterContainer from '../../../containers/dashboard/AgencyFilterContainer';
 
 const propTypes = {
-    updateFilterList: PropTypes.func
+    updateFilterList: PropTypes.func,
+    type: PropTypes.string,
+    table: PropTypes.string
 };
 
 const defaultProps = {
-    updateFilterList: null
+    updateFilterList: null,
+    type: '',
+    table: ''
 };
 
 export default class AgencyFilter extends React.Component {
@@ -38,7 +42,9 @@ export default class AgencyFilter extends React.Component {
         return (
             <div className="dashboard-filters__filter dashboard-filters__filter_agency">
                 <div className="typeahead-holder">
-                    <AgencyListContainer
+                    <AgencyFilterContainer
+                        type={this.props.type}
+                        table={this.props.table}
                         placeholder="Agency Name"
                         onSelect={this.handleAgencySelect} />
                 </div>

--- a/src/js/components/dashboard/filters/TagItem.jsx
+++ b/src/js/components/dashboard/filters/TagItem.jsx
@@ -8,7 +8,10 @@ import { Times } from '../../SharedComponents/icons/Icons';
 
 const propTypes = {
     name: PropTypes.string,
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ]),
     group: PropTypes.string,
     applied: PropTypes.bool,
     toggleFilter: PropTypes.func

--- a/src/js/containers/dashboard/AgencyFilterContainer.jsx
+++ b/src/js/containers/dashboard/AgencyFilterContainer.jsx
@@ -1,0 +1,101 @@
+/**
+ * AgencyFilterContainer.jsx
+ * Created by Lizzie Salita 8/30/18
+ */
+
+import React, { PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import * as agencyActions from '../../redux/actions/agencyActions';
+import * as AgencyHelper from '../../helpers/agencyHelper';
+
+import Typeahead from '../../components/SharedComponents/Typeahead';
+
+const propTypes = {
+    setAgencyList: PropTypes.func,
+    agencyList: PropTypes.object,
+    detached: PropTypes.bool,
+    selectedFilters: PropTypes.object,
+    type: PropTypes.string,
+    table: PropTypes.string
+};
+
+const defaultProps = {
+    setAgencyList: () => {},
+    agencyList: {},
+    detached: true,
+    selectedFilters: [],
+    table: '',
+    type: ''
+};
+
+class AgencyFilterContainer extends React.Component {
+    componentDidMount() {
+        this.loadData();
+    }
+
+    loadData() {
+        if (this.props.agencyList.agencies.length === 0) {
+            // we need to populate the list
+            if (this.props.detached) {
+                AgencyHelper.fetchAllAgencies()
+                    .then((agencies) => {
+                        this.props.setAgencyList(agencies);
+                    })
+                    .catch((err) => {
+                        console.error(err);
+                    });
+            }
+            else {
+                AgencyHelper.fetchAgencies()
+                    .then((agencies) => {
+                        this.props.setAgencyList(agencies);
+                    })
+                    .catch((err) => {
+                        console.error(err);
+                    });
+            }
+        }
+    }
+
+    dataFormatter(item) {
+        return {
+            label: item.agency_name,
+            value: item.cgac_code ? item.cgac_code : item.frec_code
+        };
+    }
+
+    render() {
+        let values = this.props.agencyList.agencies;
+        if (this.props.type && this.props.table) {
+            const selectedAgencies = this.props.selectedFilters[this.props.type][this.props.table].agencies;
+            if (selectedAgencies.length > 0) {
+                // remove selected agencies from the options
+                const selectedAgencyCodes = selectedAgencies.map((selectedAgency) => selectedAgency.code);
+                values = values.filter((agency) => {
+                    const code = agency.cgac_code || agency.frec_code;
+                    return !selectedAgencyCodes.includes(code);
+                });
+            }
+        }
+        return (
+            <Typeahead
+                {...this.props}
+                values={values}
+                formatter={this.dataFormatter}
+                prioritySort={false} />
+        );
+    }
+}
+
+AgencyFilterContainer.propTypes = propTypes;
+AgencyFilterContainer.defaultProps = defaultProps;
+
+export default connect(
+    (state) => ({
+        agencyList: state.agencyList,
+        selectedFilters: state.dashboardFilters
+    }),
+    (dispatch) => bindActionCreators(agencyActions, dispatch)
+)(AgencyFilterContainer);

--- a/src/js/containers/dashboard/DashboardContainer.jsx
+++ b/src/js/containers/dashboard/DashboardContainer.jsx
@@ -87,6 +87,9 @@ class DashboardContainer extends React.Component {
             if (appliedFilters.fileNames && appliedFilters.fileNames.length > 0) {
                 filters.file_names = appliedFilters.fileNames;
             }
+            if (appliedFilters.agencies && appliedFilters.agencies.length > 0) {
+                filters.agency_codes = appliedFilters.agencies.map((agency) => agency.code);
+            }
         }
 
         this.setState({

--- a/src/js/containers/dashboard/FilterBarContainer.jsx
+++ b/src/js/containers/dashboard/FilterBarContainer.jsx
@@ -77,6 +77,12 @@ export class FilterBarContainer extends React.Component {
             filters = filters.concat(submissionIdFilters);
         }
 
+        // prepare the agency filters
+        const agencyFilters = this.prepareAgencies(props);
+        if (agencyFilters) {
+            filters = filters.concat(agencyFilters);
+        }
+
         this.setState({
             filters,
             applied,
@@ -89,11 +95,10 @@ export class FilterBarContainer extends React.Component {
     prepareFileNames(props) {
         if (props.fileNames.length > 0) {
             return props.fileNames.map((name) => ({
-                    name,
-                    value: name,
-                    group: 'fileNames'
-                }
-            ));
+                name,
+                value: name,
+                group: 'fileNames'
+            }));
         }
         return null;
     }
@@ -101,11 +106,21 @@ export class FilterBarContainer extends React.Component {
     prepareSubmissionIds(props) {
         if (props.submissionIds.length > 0) {
             return props.submissionIds.map((id) => ({
-                    name: id,
-                    value: id,
-                    group: 'submissionIds'
-                }
-            ));
+                name: id,
+                value: id,
+                group: 'submissionIds'
+            }));
+        }
+        return null;
+    }
+
+    prepareAgencies(props) {
+        if (props.agencies.length > 0) {
+            return props.agencies.map((agency) => ({
+                name: agency.name,
+                value: agency,
+                group: 'agencies'
+            }));
         }
         return null;
     }


### PR DESCRIPTION
**High level description:**
Implements the submission dashboard agency filter. 

**Technical details:**
- `AgencyFilterContainer` (similar to the existing `AgencyListContainer`) makes a call to the `list_all_agencies` endpoint, removes agencies that are already staged as filters, and passes the remaining agency values to populate the dropdown of an [Awesomeplete](https://www.npmjs.com/package/awesomplete) Typeahead component. 
- Updates the Typeahead component to return the name of the agency in addition to the code upon selection
- Processes staged/applied Agency filter tags for display
- Processes applied agency filters and adds them to the `list_submissions` `filters` request param
- Overrides existing Typeahead styling within the Submission Dashboard 

**Link to JIRA Ticket:**
[DEV-1364](https://federal-spending-transparency.atlassian.net/browse/DEV-1364)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- ~Unit & integration tests updated with relevant test cases~ N/A
- [x] Backend impact assessment completed
- [x] Design review completed