### PR TITLE
File D Agency Toggle

### DIFF
--- a/src/_scss/abstract/mixins/buttons.scss
+++ b/src/_scss/abstract/mixins/buttons.scss
@@ -2,3 +2,17 @@
     color: $txtColor;
     background: $bgColor;
 }
+
+@mixin button-unstyled {
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    font-weight: $font-normal;
+    margin: 0;
+    outline: 0;
+    padding: 0;
+    text-align: left;
+    &:hover {
+        background-color: transparent;
+    }
+}

--- a/src/_scss/abstract/mixins/buttons.scss
+++ b/src/_scss/abstract/mixins/buttons.scss
@@ -9,7 +9,6 @@
     border-radius: 0;
     font-weight: $font-normal;
     margin: 0;
-    outline: 0;
     padding: 0;
     text-align: left;
     &:hover {

--- a/src/_scss/abstract/variables/typography.scss
+++ b/src/_scss/abstract/variables/typography.scss
@@ -3,6 +3,7 @@ $em-base:             10px;
 
 $base-font-size:      1.4rem;
 $small-font-size:     1.4rem;
+$smallest-font-size:  1.1rem;
 $lead-font-size:      2.0rem;
 $title-font-size:     5.2rem;
 
@@ -21,4 +22,5 @@ $font-serif:          'Merriweather', 'Georgia', 'Times New Roman', serif;
 
 $font-light:		  200;
 $font-normal:         400;
+$font-semibold:       600;
 $font-bold:           700;

--- a/src/_scss/components/tooltip/_arrow.scss
+++ b/src/_scss/components/tooltip/_arrow.scss
@@ -1,0 +1,26 @@
+.tooltip-pointer {
+    width: 0;
+    height: 0;
+    position: absolute;
+    top: rem(12);
+    left: rem(-9);
+    &:after {
+        content: "";
+        position: absolute;
+        width: rem(16);
+        height: rem(16);
+        background: $color-white;
+        border-bottom: 1px solid $color-tooltip-border;
+        border-left: 1px solid $color-tooltip-border;
+        transform: rotate(45deg);
+        pointer-events: none;
+    }
+    &.bottom {
+        z-index: 11;
+        top: calc(100% - 8px);
+        left: calc(100% - 45px);
+        &:after {
+            transform: rotate(315deg);
+        }
+    }
+}

--- a/src/_scss/pages/generateDetachedFiles/_agencyToggle.scss
+++ b/src/_scss/pages/generateDetachedFiles/_agencyToggle.scss
@@ -1,0 +1,56 @@
+.agency-toggle {
+    @include display(flex);
+    @include align-items(center);
+    @include justify-content(space-between);
+    padding-bottom: rem(15);
+    .agency-toggle__button {
+        @include button-unstyled;
+        @include display(flex);
+        @include justify-content(flex-end);
+        @include align-items(center);
+        color: $color-base;
+        padding: 0 rem(2);
+
+        .agency-toggle__label {
+            font-size: $smallest-font-size;
+            color: #494E58;
+            // use a 2px offset to deal with the text width difference due to bold vs not bold text
+            margin: 0 0 0 2px;
+            &:first-child {
+                margin: 0 2px 0 0;
+            }
+
+            &.agency-toggle__label_active {
+                font-weight: $font-semibold;
+                margin: 0;
+            }
+        }
+    }
+
+    .agency-toggle__switch {
+        margin: 0 rem(12);
+        .agency-switch__track {
+            fill: #0074BE;
+            box-shadow: inset 0 0 1px 1px rgba(0,0,0,0.31), 0 2px 2px 0 rgba(0,0,0,0.5);
+            @include transition(fill 200ms);
+        }
+
+        .agency-switch__switch {
+            @include transition(transform 200ms);
+        }
+
+        .agency-switch__switch-fill {
+            fill: $color-white;
+        }
+    }
+
+    .agency-toggle__tooltip {
+        @include display(flex);
+        @include flex(0 0 auto);
+        svg {
+            height: rem(15);
+            width: rem(15);
+            fill: $color-gray;
+        }
+    }
+}

--- a/src/_scss/pages/generateDetachedFiles/_agencyToggle.scss
+++ b/src/_scss/pages/generateDetachedFiles/_agencyToggle.scss
@@ -2,12 +2,14 @@
     @include display(flex);
     @include align-items(center);
     padding-bottom: rem(15);
+
     .agency-toggle__text {
         font-size: rem(13);
         padding-right: rem(5);
         @include display(flex);
         @include flex(1 1 auto);
     }
+
     .agency-toggle__button {
         @include button-unstyled;
         @include display(flex);
@@ -46,13 +48,5 @@
         }
     }
 
-    .agency-toggle__tooltip {
-        @include display(flex);
-        @include flex(0 0 auto);
-        svg {
-            height: rem(15);
-            width: rem(15);
-            fill: $color-gray;
-        }
-    }
+    @import "./_agencyToggleTooltip";
 }

--- a/src/_scss/pages/generateDetachedFiles/_agencyToggle.scss
+++ b/src/_scss/pages/generateDetachedFiles/_agencyToggle.scss
@@ -1,8 +1,13 @@
 .agency-toggle {
     @include display(flex);
     @include align-items(center);
-    @include justify-content(space-between);
     padding-bottom: rem(15);
+    .agency-toggle__text {
+        font-size: rem(13);
+        padding-right: rem(5);
+        @include display(flex);
+        @include flex(1 1 auto);
+    }
     .agency-toggle__button {
         @include button-unstyled;
         @include display(flex);
@@ -12,13 +17,10 @@
         padding: 0 rem(2);
 
         .agency-toggle__label {
-            font-size: $smallest-font-size;
+            font-size: rem(12);
             color: #494E58;
-            // use a 2px offset to deal with the text width difference due to bold vs not bold text
-            margin: 0 0 0 2px;
-            &:first-child {
-                margin: 0 2px 0 0;
-            }
+            // use a fixed width to deal with the text width difference due to bold vs not bold text
+            width: rem(105);
 
             &.agency-toggle__label_active {
                 font-weight: $font-semibold;
@@ -28,7 +30,7 @@
     }
 
     .agency-toggle__switch {
-        margin: 0 rem(12);
+        margin: 0 rem(10);
         .agency-switch__track {
             fill: #0074BE;
             box-shadow: inset 0 0 1px 1px rgba(0,0,0,0.31), 0 2px 2px 0 rgba(0,0,0,0.5);

--- a/src/_scss/pages/generateDetachedFiles/_agencyToggleTooltip.scss
+++ b/src/_scss/pages/generateDetachedFiles/_agencyToggleTooltip.scss
@@ -1,0 +1,41 @@
+.agency-toggle__info-icon-holder {
+    z-index: 10;
+
+    .agency-toggle__tooltip-spacer {
+        display: block;
+        position: absolute;
+    }
+
+    .agency-toggle-tooltip {
+        width: rem(270);
+        .agency-toggle-tooltip__interior {
+            position: relative;
+            // inherit from the standard tooltip arrow style
+            $color-tooltip-border: $color-gray;
+            @import "../../components/tooltip/_arrow";
+            .agency-toggle-tooltip__content {
+                @include display(flex);
+                @include justify-content(center);
+                @include align-items(center);
+                position: relative;
+                box-shadow: $box-shadow;
+                background-color: $color-white;
+                border: solid rem(1) $color-gray;
+                padding: rem(15);
+                text-align: left;
+                font-size: $small-font-size;
+            }
+        }
+    }
+
+    .agency-toggle__info-icon {
+        @include display(flex);
+        @include flex(0 0 auto);
+        @include button-unstyled;
+        svg {
+            height: rem(15);
+            width: rem(15);
+            fill: $color-gray;
+        }
+    }
+}

--- a/src/_scss/pages/generateDetachedFiles/generateDetachedFiles.scss
+++ b/src/_scss/pages/generateDetachedFiles/generateDetachedFiles.scss
@@ -5,6 +5,8 @@
     // import typeahead styles
     @import "../../components/typeahead/_typeahead";
 
+    @import "./_agencyToggle";
+
     .select-agency-holder {
         padding: 15px 30px 30px 30px;
         @include contentBlockWrapper;

--- a/src/_scss/pages/generateDetachedFiles/generateDetachedFiles.scss
+++ b/src/_scss/pages/generateDetachedFiles/generateDetachedFiles.scss
@@ -12,7 +12,7 @@
         @include contentBlockWrapper;
 
         .usa-da-select-agency-label {
-            margin: 15px 0px 10px;
+            margin: 15px 0 10px;
             text-align: left;
             font-size: 1.6rem;
         }

--- a/src/js/components/generateDetachedFiles/AgencyToggle.jsx
+++ b/src/js/components/generateDetachedFiles/AgencyToggle.jsx
@@ -29,7 +29,7 @@ export default class AgencyToggle extends React.Component {
         const currentSelection = this.props.funding ? 'Funding Agency' : 'Awarding Agency';
         return (
             <button
-                className="agency-toggle"
+                className="agency-toggle__button"
                 onClick={this.toggledSwitch}
                 aria-pressed={!this.props.funding}
                 aria-label={`Toggle between Awarding Agency and Funding Agency. Currently selected: ${currentSelection}`}>
@@ -37,7 +37,7 @@ export default class AgencyToggle extends React.Component {
                     Awarding Agency
                 </div>
                 <svg
-                    className="agency-toggle__switch subaward-switch"
+                    className="agency-toggle__switch"
                     width="45"
                     height="24">
                     <filter id="agency-toggle__filters">

--- a/src/js/components/generateDetachedFiles/AgencyToggle.jsx
+++ b/src/js/components/generateDetachedFiles/AgencyToggle.jsx
@@ -1,0 +1,79 @@
+/**
+ * AgencyToggle.jsx
+ * Created by Lizzie Salita 10/9/18
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    funding: PropTypes.bool,
+    setAgencyType: PropTypes.func
+};
+
+export default class AgencyToggle extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.toggledSwitch = this.toggledSwitch.bind(this);
+    }
+    toggledSwitch() {
+        const newValue = !this.props.funding;
+        this.props.setAgencyType(newValue);
+    }
+
+    render() {
+        const awardingActive = this.props.funding ? '' : 'agency-toggle__label_active';
+        const fundingActive = this.props.funding ? 'agency-toggle__label_active' : '';
+        const switchPosition = this.props.funding ? 'translate(30 0)' : 'translate(9 0)';
+        const currentSelection = this.props.funding ? 'Funding Agency' : 'Awarding Agency';
+        return (
+            <button
+                className="agency-toggle"
+                onClick={this.toggledSwitch}
+                aria-pressed={!this.props.funding}
+                aria-label={`Toggle between Awarding Agency and Funding Agency. Currently selected: ${currentSelection}`}>
+                <div className={`agency-toggle__label ${awardingActive}`}>
+                    Awarding Agency
+                </div>
+                <svg
+                    className="agency-toggle__switch subaward-switch"
+                    width="45"
+                    height="24">
+                    <filter id="agency-toggle__filters">
+                        <feGaussianBlur in="SourceAlpha" stdDeviation="1" />
+                        <feOffset dx="0" dy="0" />
+                        <feMerge>
+                            <feMergeNode />
+                            <feMergeNode in="SourceGraphic" />
+                        </feMerge>
+                    </filter>
+                    <g
+                        className="agency-switch__graphic"
+                        transform="translate(4 2)">
+                        <rect
+                            className="agency-switch__track"
+                            width="40"
+                            height="20"
+                            rx="10"
+                            ry="10" />
+                        <g
+                            className="agency-switch__switch"
+                            transform={switchPosition}>
+                            <circle
+                                className="agency-switch__switch-fill"
+                                cy="10"
+                                r="10"
+                                filter="url(#agency-toggle__filters)" />
+                        </g>
+                    </g>
+                </svg>
+                <div className={`agency-toggle__label ${fundingActive}`}>
+                    Funding Agency
+                </div>
+            </button>
+        );
+    }
+}
+
+AgencyToggle.propTypes = propTypes;

--- a/src/js/components/generateDetachedFiles/AgencyToggle.jsx
+++ b/src/js/components/generateDetachedFiles/AgencyToggle.jsx
@@ -8,20 +8,15 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     funding: PropTypes.bool,
-    setAgencyType: PropTypes.func
+    toggleAgencyType: PropTypes.func
+};
+
+const defaultProps = {
+    funding: false,
+    toggleAgencyType: null
 };
 
 export default class AgencyToggle extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.toggledSwitch = this.toggledSwitch.bind(this);
-    }
-    toggledSwitch() {
-        const newValue = !this.props.funding;
-        this.props.setAgencyType(newValue);
-    }
-
     render() {
         const awardingActive = this.props.funding ? '' : 'agency-toggle__label_active';
         const fundingActive = this.props.funding ? 'agency-toggle__label_active' : '';
@@ -30,7 +25,7 @@ export default class AgencyToggle extends React.Component {
         return (
             <button
                 className="agency-toggle__button"
-                onClick={this.toggledSwitch}
+                onClick={this.props.toggleAgencyType}
                 aria-pressed={!this.props.funding}
                 aria-label={`Toggle between Awarding Agency and Funding Agency. Currently selected: ${currentSelection}`}>
                 <div className={`agency-toggle__label ${awardingActive}`}>
@@ -64,6 +59,8 @@ export default class AgencyToggle extends React.Component {
                                 className="agency-switch__switch-fill"
                                 cy="10"
                                 r="10"
+                                stroke="#d6d7d9"
+                                strokeWidth="1"
                                 filter="url(#agency-toggle__filters)" />
                         </g>
                     </g>
@@ -77,3 +74,4 @@ export default class AgencyToggle extends React.Component {
 }
 
 AgencyToggle.propTypes = propTypes;
+AgencyToggle.defaultProps = defaultProps;

--- a/src/js/components/generateDetachedFiles/AgencyToggle.jsx
+++ b/src/js/components/generateDetachedFiles/AgencyToggle.jsx
@@ -26,6 +26,7 @@ export default class AgencyToggle extends React.Component {
             <button
                 className="agency-toggle__button"
                 onClick={this.props.toggleAgencyType}
+                role="switch"
                 aria-pressed={!this.props.funding}
                 aria-label={`Toggle between Awarding Agency and Funding Agency. Currently selected: ${currentSelection}`}>
                 <div className={`agency-toggle__label ${awardingActive}`}>

--- a/src/js/components/generateDetachedFiles/AgencyToggleTooltip.jsx
+++ b/src/js/components/generateDetachedFiles/AgencyToggleTooltip.jsx
@@ -1,0 +1,25 @@
+/**
+ * AgencyToggleTooltip.jsx
+ * Created by Lizzie Salita 10/11/18
+ */
+
+import React from 'react';
+
+export default class AgencyToggleTooltip extends React.Component {
+    render() {
+        return (
+            <div
+                className="agency-toggle-tooltip"
+                role="tooltip">
+                <div className="agency-toggle-tooltip__interior">
+                    <div className="tooltip-pointer bottom" />
+                    <div className="agency-toggle-tooltip__content">
+                        This toggle may benefit small agencies that use a shared service provider (SSP) to manage and
+                        issue awards that they fund. The vast majority of agencies will want to leave the toggle in the
+                        default "Awarding Agency" position.
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -14,7 +14,9 @@ const propTypes = {
     handleDateChange: PropTypes.func,
     updateError: PropTypes.func,
     d1: PropTypes.object,
-    d2: PropTypes.object
+    d2: PropTypes.object,
+    fundingAgency: PropTypes.bool,
+    toggleAgencyType: PropTypes.func
 };
 
 const defaultProps = {
@@ -22,32 +24,18 @@ const defaultProps = {
     handleDateChange: null,
     updateError: null,
     d1: null,
-    d2: null
+    d2: null,
+    fundingAgency: false,
+    toggleAgencyType: null
 };
 
 export default class DateSelect extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            fundingAgency: false
-        };
-
-        this.toggleAgencyType = this.toggleAgencyType.bind(this);
-    }
-
     handleDateChange(file, date, dateType) {
         this.props.handleDateChange(file, date, dateType);
     }
 
     updateError(file, header = '', description = '') {
         this.props.updateError(file, header, description);
-    }
-
-    toggleAgencyType() {
-        this.setState({
-            fundingAgency: !this.state.fundingAgency
-        });
     }
 
     render() {
@@ -77,8 +65,8 @@ export default class DateSelect extends React.Component {
                         Generate File D1 and D2 from records where my agency is the:
                     </div>
                     <AgencyToggle
-                        funding={this.state.fundingAgency}
-                        toggleAgencyType={this.toggleAgencyType} />
+                        funding={this.props.fundingAgency}
+                        toggleAgencyType={this.props.toggleAgencyType} />
                     <div className="agency-toggle__tooltip">
                         <InfoCircle />
                     </div>

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -56,10 +56,10 @@ export default class DateSelect extends React.Component {
         }
         return (
             <div className="usa-da-date-select dashed-border-top">
-                <div className="agency-toggle-section">
+                <div className="agency-toggle">
                     Generate File D1 and D2 from records where my agency is the:
                     <AgencyToggle />
-                    <div className="toggle__tooltip">
+                    <div className="agency-toggle__tooltip">
                         <InfoCircle />
                     </div>
                 </div>

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -6,6 +6,8 @@
 import React, { PropTypes } from 'react';
 import GenerateFileBox from '../generateFiles/components/GenerateFileBox';
 import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
+import AgencyToggle from './AgencyToggle';
+import { InfoCircle } from "../SharedComponents/icons/Icons";
 
 const propTypes = {
     generateFile: PropTypes.func,
@@ -54,6 +56,13 @@ export default class DateSelect extends React.Component {
         }
         return (
             <div className="usa-da-date-select dashed-border-top">
+                <div className="agency-toggle-section">
+                    Generate File D1 and D2 from records where my agency is the:
+                    <AgencyToggle />
+                    <div className="toggle__tooltip">
+                        <InfoCircle />
+                    </div>
+                </div>
                 <GenerateFileBox
                     label="File D1: Procurement Awards (FPDS data)"
                     datePlaceholder="Sign"

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -7,7 +7,8 @@ import React, { PropTypes } from 'react';
 import GenerateFileBox from '../generateFiles/components/GenerateFileBox';
 import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
 import AgencyToggle from './AgencyToggle';
-import { InfoCircle } from "../SharedComponents/icons/Icons";
+import AgencyToggleTooltip from './AgencyToggleTooltip';
+import { InfoCircle } from '../SharedComponents/icons/Icons';
 
 const propTypes = {
     generateFile: PropTypes.func,
@@ -30,12 +31,35 @@ const defaultProps = {
 };
 
 export default class DateSelect extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showInfoTooltip: false
+        };
+
+        this.showTooltip = this.showTooltip.bind(this);
+        this.closeTooltip = this.closeTooltip.bind(this);
+    }
+
     handleDateChange(file, date, dateType) {
         this.props.handleDateChange(file, date, dateType);
     }
 
     updateError(file, header = '', description = '') {
         this.props.updateError(file, header, description);
+    }
+
+    showTooltip() {
+        this.setState({
+            showInfoTooltip: true
+        });
+    }
+
+    closeTooltip() {
+        this.setState({
+            showInfoTooltip: false
+        });
     }
 
     render() {
@@ -58,6 +82,23 @@ export default class DateSelect extends React.Component {
         else if (this.props.d2.status === "done") {
             d2Text = "Regenerate D2 File";
         }
+
+        let tooltip = null;
+        if (this.state.showInfoTooltip) {
+            const style = {
+                top: this.referenceDiv.offsetTop - 180,
+                right: 15
+            };
+
+            tooltip = (
+                <div
+                    className="agency-toggle__tooltip-spacer"
+                    style={style}>
+                    <AgencyToggleTooltip />
+                </div>
+            );
+        }
+
         return (
             <div className="usa-da-date-select dashed-border-top">
                 <div className="agency-toggle">
@@ -67,9 +108,22 @@ export default class DateSelect extends React.Component {
                     <AgencyToggle
                         funding={this.props.fundingAgency}
                         toggleAgencyType={this.props.toggleAgencyType} />
-                    <div className="agency-toggle__tooltip">
-                        <InfoCircle />
-                    </div>
+                    <span className="agency-toggle__info-icon-holder">
+                        <div ref={(div) => {
+                            this.referenceDiv = div;
+                        }}>
+                            {tooltip}
+                            <button
+                                id="agency-toggle__info-icon"
+                                className="agency-toggle__info-icon"
+                                onFocus={this.showTooltip}
+                                onBlur={this.closeTooltip}
+                                onMouseLeave={this.closeTooltip}
+                                onMouseEnter={this.showTooltip} >
+                                <InfoCircle />
+                            </button>
+                        </div>
+                    </span>
                 </div>
                 <GenerateFileBox
                     label="File D1: Procurement Awards (FPDS data)"

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -26,12 +26,28 @@ const defaultProps = {
 };
 
 export default class DateSelect extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            fundingAgency: false
+        };
+
+        this.toggleAgencyType = this.toggleAgencyType.bind(this);
+    }
+
     handleDateChange(file, date, dateType) {
         this.props.handleDateChange(file, date, dateType);
     }
 
     updateError(file, header = '', description = '') {
         this.props.updateError(file, header, description);
+    }
+
+    toggleAgencyType() {
+        this.setState({
+            fundingAgency: !this.state.fundingAgency
+        });
     }
 
     render() {
@@ -57,8 +73,12 @@ export default class DateSelect extends React.Component {
         return (
             <div className="usa-da-date-select dashed-border-top">
                 <div className="agency-toggle">
-                    Generate File D1 and D2 from records where my agency is the:
-                    <AgencyToggle />
+                    <div className="agency-toggle__text">
+                        Generate File D1 and D2 from records where my agency is the:
+                    </div>
+                    <AgencyToggle
+                        funding={this.state.fundingAgency}
+                        toggleAgencyType={this.toggleAgencyType} />
                     <div className="agency-toggle__tooltip">
                         <InfoCircle />
                     </div>

--- a/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
+++ b/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
@@ -39,6 +39,7 @@ export default class GenerateDetachedFilesPage extends React.Component {
             showDateSelect: false,
             showSubmitButton: false,
             buttonDisabled: true,
+            fundingAgency: false,
             d1: {
                 startDate: null,
                 endDate: null,
@@ -70,6 +71,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 status: ""
             }
         };
+
+        this.toggleAgencyType = this.toggleAgencyType.bind(this);
     }
 
     componentDidMount() {
@@ -182,17 +185,24 @@ export default class GenerateDetachedFilesPage extends React.Component {
         });
     }
 
+    toggleAgencyType() {
+        this.setState({
+            fundingAgency: !this.state.fundingAgency
+        });
+    }
+
     generateFile(file) {
         // generate specified file
         const cgacCode = this.state.codeType !== 'frec_code' ? this.state.agency : '';
         const frecCode = this.state.codeType === 'frec_code' ? this.state.agency : '';
+        const agencyType = this.state.fundingAgency ? 'funding' : 'awarding';
 
         const tmpFile = Object.assign({}, this.state[file]);
         tmpFile.status = "generating";
         this.setState({ [file]: tmpFile });
 
         GenerateFilesHelper.generateDetachedFile(file.toUpperCase(), tmpFile.startDate.format('MM/DD/YYYY'),
-            tmpFile.endDate.format('MM/DD/YYYY'), cgacCode, frecCode)
+            tmpFile.endDate.format('MM/DD/YYYY'), cgacCode, frecCode, agencyType)
             .then((response) => {
                 if (this.isUnmounted) {
                     return;
@@ -289,7 +299,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 {...this.state}
                 handleDateChange={this.handleDateChange.bind(this)}
                 updateError={this.updateError.bind(this)}
-                generateFile={this.generateFile.bind(this)} />);
+                generateFile={this.generateFile.bind(this)}
+                toggleAgencyType={this.toggleAgencyType} />);
         }
 
         return (

--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -87,7 +87,7 @@ export const getFabsMeta = (submissionId) => {
     return deferred.promise;
 };
 
-export const generateDetachedFile = (type, start, end, cgacCode, frecCode) => {
+export const generateDetachedFile = (type, start, end, cgacCode, frecCode, agencyType) => {
     const deferred = Q.defer();
 
     Request.post(kGlobalConstants.API + 'generate_detached_file/')
@@ -96,7 +96,8 @@ export const generateDetachedFile = (type, start, end, cgacCode, frecCode) => {
             start,
             end,
             cgac_code: cgacCode,
-            frec_code: frecCode
+            frec_code: frecCode,
+            agency_type: agencyType
         })
         .end((errFile, res) => {
             if (errFile) {


### PR DESCRIPTION
**High level description:**
Adds a toggle for awarding/funding agency to the DABS detached generation page.

**Technical details:**
- Adds the `agency_type` parameter to the `/v1/generate_detached_file` request. Documentation [here](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/development/dataactbroker/README.md#post-v1generate_detached_file).
- Animates an svg slider element based on a state boolean
- Displays a tooltip on hover/focus of info icon

**Link to JIRA Ticket:**
[DEV-1350](https://federal-spending-transparency.atlassian.net/browse/DEV-1350)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Design review completed