### PR TITLE
File D agency toggle - submissions

### DIFF
--- a/src/_scss/pages/generateFiles/generateFiles.scss
+++ b/src/_scss/pages/generateFiles/generateFiles.scss
@@ -18,6 +18,7 @@
 		@import "./generateItem/generateItem";
 	}
 
+	@import "../generateDetachedFiles/_agencyToggle";
 	@import "../../components/alerts/_alerts";
 
 	.alert-warning {

--- a/src/js/components/generateDetachedFiles/AgencyToggle.jsx
+++ b/src/js/components/generateDetachedFiles/AgencyToggle.jsx
@@ -27,7 +27,7 @@ export default class AgencyToggle extends React.Component {
                 className="agency-toggle__button"
                 onClick={this.props.toggleAgencyType}
                 role="switch"
-                aria-pressed={!this.props.funding}
+                aria-checked={!this.props.funding}
                 aria-label={`Toggle between Awarding Agency and Funding Agency. Currently selected: ${currentSelection}`}>
                 <div className={`agency-toggle__label ${awardingActive}`}>
                     Awarding Agency

--- a/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
+++ b/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
@@ -324,7 +324,7 @@ export default class GenerateDetachedFilesPage extends React.Component {
                                     <h5>Please begin by telling us about files you would like to generate</h5>
                                     <div className="select-agency-holder">
                                         <div className="row usa-da-select-agency-label">
-                                            The generated files will be used when submiting data for...
+                                            The generated files will be used when submitting data for...
                                         </div>
 
                                         <div className="row">

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -7,22 +7,40 @@ import React, { PropTypes } from 'react';
 
 import GenerateFileBox from './components/GenerateFileBox';
 import GenerateFilesOverlay from './GenerateFilesOverlay';
+import AgencyToggle from '../generateDetachedFiles/AgencyToggle';
+import AgencyToggleTooltip from '../generateDetachedFiles/AgencyToggleTooltip';
+import { InfoCircle } from '../SharedComponents/icons/Icons';
 
 const propTypes = {
     handleDateChange: PropTypes.func,
     updateError: PropTypes.func,
     d1: PropTypes.object,
-    d2: PropTypes.object
+    d2: PropTypes.object,
+    fundingAgency: PropTypes.bool,
+    toggleAgencyType: PropTypes.func
 };
 
 const defaultProps = {
     handleDateChange: null,
     updateError: null,
     d1: null,
-    d2: null
+    d2: null,
+    fundingAgency: false,
+    toggleAgencyType: null
 };
 
 export default class GenerateFilesContent extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showInfoTooltip: false
+        };
+
+        this.showTooltip = this.showTooltip.bind(this);
+        this.closeTooltip = this.closeTooltip.bind(this);
+    }
+
     handleDateChange(file, date, dateType) {
         this.props.handleDateChange(file, date, dateType);
     }
@@ -31,7 +49,34 @@ export default class GenerateFilesContent extends React.Component {
         this.props.updateError(file, header, description);
     }
 
+    showTooltip() {
+        this.setState({
+            showInfoTooltip: true
+        });
+    }
+
+    closeTooltip() {
+        this.setState({
+            showInfoTooltip: false
+        });
+    }
+
     render() {
+        let tooltip = null;
+        if (this.state.showInfoTooltip) {
+            const style = {
+                top: this.referenceDiv.offsetTop - 180,
+                right: 115
+            };
+
+            tooltip = (
+                <div
+                    className="agency-toggle__tooltip-spacer"
+                    style={style}>
+                    <AgencyToggleTooltip />
+                </div>
+            );
+        }
         return (
             <div>
                 <div className="container center-block with-overlay">
@@ -42,6 +87,31 @@ export default class GenerateFilesContent extends React.Component {
                                 the submission date range you selected in step one.
                             </p>
                         </div>
+                    </div>
+
+                    <div className="agency-toggle">
+                        <div className="agency-toggle__text">
+                            Generate File D1 and D2 from records where my agency is the:
+                        </div>
+                        <AgencyToggle
+                            funding={this.props.fundingAgency}
+                            toggleAgencyType={this.props.toggleAgencyType} />
+                        <span className="agency-toggle__info-icon-holder">
+                            <div ref={(div) => {
+                                this.referenceDiv = div;
+                            }}>
+                            {tooltip}
+                                <button
+                                    id="agency-toggle__info-icon"
+                                    className="agency-toggle__info-icon"
+                                    onFocus={this.showTooltip}
+                                    onBlur={this.closeTooltip}
+                                    onMouseLeave={this.closeTooltip}
+                                    onMouseEnter={this.showTooltip} >
+                                    <InfoCircle />
+                                </button>
+                            </div>
+                        </span>
                     </div>
 
                     <div className="usa-da-generate-content">

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -100,7 +100,7 @@ export default class GenerateFilesContent extends React.Component {
                             <div ref={(div) => {
                                 this.referenceDiv = div;
                             }}>
-                            {tooltip}
+                                {tooltip}
                                 <button
                                     id="agency-toggle__info-icon"
                                     className="agency-toggle__info-icon"

--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -77,8 +77,11 @@ class GenerateFilesContainer extends React.Component {
             d1Status: "waiting",
             d2Status: "waiting",
             errorDetails: "",
-            agency_name: ""
+            agency_name: "",
+            fundingAgency: false
         };
+
+        this.toggleAgencyType = this.toggleAgencyType.bind(this);
     }
 
     componentDidMount() {
@@ -331,16 +334,25 @@ class GenerateFilesContainer extends React.Component {
         });
     }
 
+    toggleAgencyType() {
+        this.setState({
+            fundingAgency: !this.state.fundingAgency
+        });
+    }
+
     generateFiles() {
         this.setState({
             state: 'generating'
         });
+
+        const agencyType = this.state.fundingAgency ? 'funding' : 'awarding';
+
         // submit both D1 and D2 date ranges to the API
         Q.allSettled([
             GenerateFilesHelper.generateFile('D1', this.props.submissionID,
-                this.state.d1.startDate.format('MM/DD/YYYY'), this.state.d1.endDate.format('MM/DD/YYYY')),
+                this.state.d1.startDate.format('MM/DD/YYYY'), this.state.d1.endDate.format('MM/DD/YYYY'), agencyType),
             GenerateFilesHelper.generateFile('D2', this.props.submissionID,
-                this.state.d2.startDate.format('MM/DD/YYYY'), this.state.d2.endDate.format('MM/DD/YYYY'))
+                this.state.d2.startDate.format('MM/DD/YYYY'), this.state.d2.endDate.format('MM/DD/YYYY'), agencyType)
         ])
             .then((allResponses) => {
                 if (this.isUnmounted) {
@@ -517,7 +529,8 @@ class GenerateFilesContainer extends React.Component {
                     handleDateChange={this.handleDateChange.bind(this)}
                     updateError={this.updateError.bind(this)}
                     generateFiles={this.generateFiles.bind(this)}
-                    nextPage={this.nextPage.bind(this)} />
+                    nextPage={this.nextPage.bind(this)}
+                    toggleAgencyType={this.toggleAgencyType} />
             </div>
         );
     }

--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -3,7 +3,7 @@ import Request from './sessionSuperagent';
 
 import { kGlobalConstants } from '../GlobalConstants';
 
-export const generateFile = (type, submissionId, start, end) => {
+export const generateFile = (type, submissionId, start, end, agencyType) => {
     const deferred = Q.defer();
 
     const callBody = {
@@ -16,6 +16,9 @@ export const generateFile = (type, submissionId, start, end) => {
     }
     if (end) {
         callBody.end = end;
+    }
+    if (agencyType) {
+        callBody.agency_type = agencyType;
     }
 
     Request.post(kGlobalConstants.API + 'generate_file/')


### PR DESCRIPTION
**High level description:**
Adds a toggle for awarding/funding agency to the generate D files page, during a submission.

**Technical details:**
- Adds the `agency_type` parameter to the `/v1/generate_file` request. Documentation [here](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/development/dataactbroker/README.md#post-v1generate_file).
- Animates the svg slider element based on a state boolean
- Adds the info tooltip

**Link to JIRA Ticket:**
[DEV-1350](https://federal-spending-transparency.atlassian.net/browse/DEV-1350)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Design review completed