### PR TITLE
Fix agency toggle tooltip

### DIFF
--- a/src/_scss/pages/generateDetachedFiles/_agencyToggleTooltip.scss
+++ b/src/_scss/pages/generateDetachedFiles/_agencyToggleTooltip.scss
@@ -1,6 +1,7 @@
 .agency-toggle__info-icon-holder {
     z-index: 10;
-
+    position: relative;
+    
     .agency-toggle__tooltip-spacer {
         display: block;
         position: absolute;

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -87,7 +87,7 @@ export default class DateSelect extends React.Component {
         if (this.state.showInfoTooltip) {
             const style = {
                 top: this.referenceDiv.offsetTop - 180,
-                right: 15
+                right: -30
             };
 
             tooltip = (

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -64,9 +64,23 @@ export default class GenerateFilesContent extends React.Component {
     render() {
         let tooltip = null;
         if (this.state.showInfoTooltip) {
+            // Calculate the right margin based on window width breakpoints
+            const windowWidth = window.innerWidth;
+
+            let rightMargin = 0;
+            if (windowWidth >= 1200) {
+                rightMargin = (windowWidth - 1170) / 2;
+            }
+            else if (windowWidth >= 992) {
+                rightMargin = (windowWidth - 970) / 2;
+            }
+            else if (windowWidth >= 768) {
+                rightMargin = (windowWidth - 750) / 2;
+            }
+
             const style = {
                 top: this.referenceDiv.offsetTop - 180,
-                right: 115
+                right: rightMargin - 15
             };
 
             tooltip = (

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -64,23 +64,9 @@ export default class GenerateFilesContent extends React.Component {
     render() {
         let tooltip = null;
         if (this.state.showInfoTooltip) {
-            // Calculate the right margin based on window width breakpoints
-            const windowWidth = window.innerWidth;
-
-            let rightMargin = 0;
-            if (windowWidth >= 1200) {
-                rightMargin = (windowWidth - 1170) / 2;
-            }
-            else if (windowWidth >= 992) {
-                rightMargin = (windowWidth - 970) / 2;
-            }
-            else if (windowWidth >= 768) {
-                rightMargin = (windowWidth - 750) / 2;
-            }
-
             const style = {
                 top: this.referenceDiv.offsetTop - 180,
-                right: rightMargin - 15
+                right: -30
             };
 
             tooltip = (


### PR DESCRIPTION
**High level description:**
Fixes funding agency tooltip (see latest comments on [DEV-1350](https://federal-spending-transparency.atlassian.net/browse/DEV-1350))

**Technical details:**
In IE, the z-index property only applies to objects that have the position property set to `relative` or `absolute`. Changed the info icon holder to `position: relative;` to prevent overlap with another icon in IE and updated the right position of the tooltip. 

**Link to JIRA Ticket:**
[DEV-1350](https://federal-spending-transparency.atlassian.net/browse/DEV-1350)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed