### PR TITLE
Hotfix for Upload file type error handling

### DIFF
--- a/src/_scss/pages/uploadFabsFile/uploadFabsFile.scss
+++ b/src/_scss/pages/uploadFabsFile/uploadFabsFile.scss
@@ -122,6 +122,9 @@
 	.usa-da-validate-item {
         @import "../validateData/fileItem/fileItem";
         @include fileItem;
+		.file-container {
+			padding-top: rem(20);
+		}
         .usa-da-validate-item-file-section {
         	.usa-da-validate-corrected-file-holder.full-width{
         		.full-overlay{

--- a/src/_scss/pages/validateData/fileItem/fileItem.scss
+++ b/src/_scss/pages/validateData/fileItem/fileItem.scss
@@ -31,6 +31,7 @@
         position: relative;
     }
     .usa-da-validate-item-status-section {
+		padding-top: rem(20);
         border-right: 1px solid #e4e2e0;
         min-height: 171px;
     }

--- a/src/js/components/addData/DropZone.jsx
+++ b/src/js/components/addData/DropZone.jsx
@@ -9,6 +9,8 @@ import DOMPurify from 'dompurify';
 
 import DropZoneDisplay from './DropZoneDisplay';
 
+import { validUploadFileChecker } from '../../helpers/util';
+
 const propTypes = {
   onDrop: PropTypes.func,
   resetSubmission: PropTypes.func,
@@ -44,8 +46,7 @@ export default class DropZone extends React.Component {
       const submissionItem = this.props.submission.files[this.props.requestName];
       dropped = ' dropped';
 
-      isFileValid = !!(submissionItem.file &&
-        (submissionItem.file.type === 'text/csv' || submissionItem.file.type === 'text/plain'));
+      isFileValid = validUploadFileChecker(submissionItem);
 
       if (submissionItem.state === 'ready' && isFileValid) {
         dropzoneString = `<b>${submissionItem.file.name}</b> file selected`;

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -12,6 +12,7 @@ import * as PermissionsHelper from '../../helpers/permissionsHelper';
 import * as GenerateFilesHelper from '../../helpers/generateFilesHelper';
 
 import UploadFabsFileError from '../uploadFabsFile/UploadFabsFileError';
+import { validUploadFileChecker } from '../../helpers/util';
 
 const propTypes = {
     onFileChange: PropTypes.func,
@@ -310,6 +311,7 @@ export default class ValidateDataFileComponent extends React.Component {
 
     render() {
         let disabledCorrect = '';
+        let isFileValid = 'unset';
         let messageClass = ' usa-da-validate-item-message';
         if (!this.state.isError && this.isFileReady()) {
             messageClass = '';
@@ -342,9 +344,12 @@ export default class ValidateDataFileComponent extends React.Component {
         let clickDownload = null;
         let clickDownloadClass = '';
 
+
         if (this.isReplacingFile()) {
             // also display the new file name
             const newFile = this.props.submission.files[this.props.type.requestName];
+
+            isFileValid = validUploadFileChecker(newFile);
             fileName = newFile.file.name;
 
             if (newFile.state === 'uploading') {
@@ -394,7 +399,7 @@ export default class ValidateDataFileComponent extends React.Component {
                                 <div
                                     className={"col-md-12 usa-da-validate-txt-wrap" + messageClass}
                                     data-testid="validate-message">
-                                    {this.state.headerTitle}
+                                    {isFileValid ? this.state.headerTitle : `${fileName} must be CSV or TXT format`}
                                 </div>
                             </div>
                             <div className="row usa-da-validate-item-footer-wrapper">
@@ -409,13 +414,13 @@ export default class ValidateDataFileComponent extends React.Component {
                             </div>
                         </div>
 
-                        <div className="col-md-3">
+                        <div className="col-md-3 file-container">
                             <div className="usa-da-validate-item-file-section">
                                 <div className="usa-da-validate-item-file-section-result">
                                     <div
                                         className="usa-da-icon"
                                         data-testid="validate-icon">
-                                        {this.displayIcon()}
+                                        {isFileValid ? this.displayIcon() : <Icons.ExclamationCircle />}
                                     </div>
                                 </div>
                                 {uploadProgress}
@@ -428,8 +433,9 @@ export default class ValidateDataFileComponent extends React.Component {
                                         {fileName}
                                     </div>
                                 </div>
+                                {isFileValid ? '' : `${fileName} must be CSV or TXT format`}
                                 <div
-                                    className={"usa-da-validate-item-file-section-correct-button" + disabledCorrect}
+                                    className={`usa-da-validate-item-file-section-correct-button ${isFileValid ? disabledCorrect : ''}`}
                                     data-testid="validate-upload">
                                     <div className="row">
                                         <div className="col-md-12">

--- a/src/js/components/validateData/ValidationOverlay.jsx
+++ b/src/js/components/validateData/ValidationOverlay.jsx
@@ -10,6 +10,7 @@ import CommonOverlay from '../SharedComponents/overlays/CommonOverlay';
 
 const propTypes = {
     uploadFiles: PropTypes.func,
+    uploadApiCallError: PropTypes.string,
     submission: PropTypes.object,
     errors: PropTypes.array,
     warnings: PropTypes.array,
@@ -19,6 +20,7 @@ const propTypes = {
 
 const defaultProps = {
     allowUpload: false,
+    uploadApiCallError: '',
     uploadFiles: () => {},
     submission: {},
     errors: [],
@@ -107,6 +109,10 @@ export default class ValidationOverlay extends React.Component {
             header = "You are not authorized to perform the requested task. Please contact your administrator.";
             icon = <Icons.ExclamationCircle />;
             iconClass = 'usa-da-errorRed';
+        }
+
+        if (this.props.uploadApiCallError) {
+            header = this.props.uploadApiCallError;
         }
 
         return (

--- a/src/js/containers/validateData/ValidationOverlayContainer.jsx
+++ b/src/js/containers/validateData/ValidationOverlayContainer.jsx
@@ -27,23 +27,37 @@ class ValidationOverlayContainer extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            notAllowed: false
+            notAllowed: false,
+            uploadApiCallError: ''
         };
     }
 
     uploadFiles() {
         if (kGlobalConstants.LOCAL === true) {
-            UploadHelper.performLocalCorrectedUpload(this.props.submission);
-        }
-        else {
-            UploadHelper.performRemoteCorrectedUpload(this.props.submission)
+            UploadHelper.performLocalCorrectedUpload(this.props.submission)
                 .catch((err) => {
                     if (err.httpStatus === 403) {
-                        console.error(err.message);
                         this.setState({
                             notAllowed: true
                         });
                     }
+                    this.setState({
+                        uploadApiCallError : err.message
+                    });
+                });
+        }
+        else {
+            UploadHelper.performRemoteCorrectedUpload(this.props.submission)
+                .catch((err) => {
+                    console.error(err);
+                    if (err.httpStatus === 403) {
+                        this.setState({
+                            notAllowed: true
+                        });
+                    }
+                    this.setState({
+                        uploadApiCallError : err.message
+                    });
                 });
         }
     }
@@ -77,6 +91,7 @@ class ValidationOverlayContainer extends React.Component {
             <ValidationOverlay
                 {...this.props}
                 uploadFiles={this.uploadFiles.bind(this)}
+                uploadApiCallError={this.state.uploadApiCallError}
                 allowUpload={allowUpload}
                 notAllowed={this.state.notAllowed} />
         );

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -100,3 +100,12 @@ export const fyStartDate = () => {
 
     return quarterToMonth(1, year, 'start');
 };
+
+export const validUploadFileChecker = (rawFile) => {
+    if (rawFile.file) {
+        const parsed = rawFile.file.name.split('.');
+        const fileType = parsed[parsed.length - 1];
+        return !!((fileType === 'csv' || fileType === 'txt'));
+    }
+    return 'unset';
+};


### PR DESCRIPTION
**High level description:**
- Hotfix for windows machines,  which incorrectly view all `.csv` files as excel files.
- Also adds error messages for incorrect file types in upload verification

**Technical details:**
-  Created new helper for determining correct file types
-  Updates components to catch and react to all errors not just  `403 forbidden`

**Link to JIRA Ticket:**
[DEV-1676](https://federal-spending-transparency.atlassian.net/browse/DEV-1676)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed