### PR TITLE
Temporarily hard code min/max dates for Date Modified Filter

### DIFF
--- a/src/js/components/SharedComponents/CalendarRangeDatePicker.jsx
+++ b/src/js/components/SharedComponents/CalendarRangeDatePicker.jsx
@@ -93,8 +93,8 @@ export default class CalendarRangeDatePicker extends React.Component {
           return (<DayPicker
               showOutsideDays
               fixedWeeks
-              // fromMonth={this.props.minmaxDates.minDate}
-              // toMonth={this.props.minmaxDates.maxDate}
+              fromMonth={this.props.minmaxDates.minDate}
+              toMonth={this.props.minmaxDates.maxDate}
               navbarElement={<Navbar />}
               className="innerCalendarDatePicker"
               numberOfMonths={this.props.numberOfMonths}

--- a/src/js/containers/dashboard/LastDateModifiedContainer.jsx
+++ b/src/js/containers/dashboard/LastDateModifiedContainer.jsx
@@ -37,14 +37,9 @@ const defaultProps = {
 };
 
 class LastDateModifiedContainer extends React.Component {
-  componentDidMount() {
-    // Temporarily commented out until backend min/max dates endpoint is ready
-    // this.loadData();
-  }
-
   loadData() {
     if (_.isEmpty(this.props.lastDateModifiedList.lastDateModified)) {
-      // we need to populate the list
+      // we need to populate the list and load on mounting the component
       lastDateModifiedHelper.fetchLastDateModified()
         .then((data) => {
           const payload = [];
@@ -60,17 +55,6 @@ class LastDateModifiedContainer extends React.Component {
   }
 
   render() {
-      // Temporarily commented out until backend min/max dates endpoint is ready
-      // let values = this.props.lastDateModifiedList.lastDateModified.length > 0 ? this.props.lastDateModifiedList.lastDateModified : {};
-      // Find Min/Max for last modified dates
-      // if (!_.isEmpty(values)) {
-      //   const finalPayload = {
-      //       minDate: _.min(values),
-      //       maxDate: _.max(values)
-      //   };
-      //   values = finalPayload;
-      // }
-
       // Temporary min/max dates workaround until backend is ready
       const finalPayload = {
           minDate: new Date('01/01/2016'),

--- a/src/js/containers/dashboard/LastDateModifiedContainer.jsx
+++ b/src/js/containers/dashboard/LastDateModifiedContainer.jsx
@@ -38,7 +38,8 @@ const defaultProps = {
 
 class LastDateModifiedContainer extends React.Component {
   componentDidMount() {
-    this.loadData();
+    // Temporarily commented out until backend min/max dates endpoint is ready
+    // this.loadData();
   }
 
   loadData() {
@@ -59,17 +60,25 @@ class LastDateModifiedContainer extends React.Component {
   }
 
   render() {
-      let values = this.props.lastDateModifiedList.lastDateModified.length > 0 ? this.props.lastDateModifiedList.lastDateModified : {};
+      // Temporarily commented out until backend min/max dates endpoint is ready
+      // let values = this.props.lastDateModifiedList.lastDateModified.length > 0 ? this.props.lastDateModifiedList.lastDateModified : {};
       // Find Min/Max for last modified dates
-      if (!_.isEmpty(values)) {
-        const finalPayload = {
-            minDate: _.min(values),
-            maxDate: _.max(values)
-        };
-        values = finalPayload;
-      }
+      // if (!_.isEmpty(values)) {
+      //   const finalPayload = {
+      //       minDate: _.min(values),
+      //       maxDate: _.max(values)
+      //   };
+      //   values = finalPayload;
+      // }
+
+      // Temporary min/max dates workaround until backend is ready
+      const finalPayload = {
+          minDate: new Date('01/01/2016'),
+          maxDate: new Date(),
+      };
+
     return (
-        <CalendarRangeDatePicker minmaxDates={values} {...this.props} />
+        <CalendarRangeDatePicker minmaxDates={finalPayload} {...this.props} />
     );
   }
 }


### PR DESCRIPTION
**High level description:**
Temporarily disable API call for last date modified min/max dates and hardcode dates until backend endpoint is ready

**Technical details:**
Disabled `this.loadData()` in `LastDateModifiedContainer` and the code to parse its api response

**Link to JIRA Ticket:**
[DEV-1877](https://federal-spending-transparency.atlassian.net/browse/DEV-1877)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed