### PR TITLE
DEV-1378: Update list_submissions param names

### DIFF
--- a/src/js/helpers/lastDateModifiedHelper.js
+++ b/src/js/helpers/lastDateModifiedHelper.js
@@ -9,7 +9,7 @@ export const fetchLastDateModified = () => {
     Request.post(`${kGlobalConstants.API}list_submissions/`)
         .send({
             certified: 'false',
-            d2_submission: false,
+            fabs: false,
             limit: 200,
             order: 'desc'
         })

--- a/src/js/helpers/submissionListHelper.js
+++ b/src/js/helpers/submissionListHelper.js
@@ -57,7 +57,7 @@ const parseRecentActivity = (submissions) => {
 };
 
 export const loadSubmissionList = (
-    page = 1, limit = 10, certified = false, sort = 'updated', order = 'desc', d2Submission = false, filters = {}) => {
+    page = 1, limit = 10, certified = false, sort = 'updated', order = 'desc', fabs = false, filters = {}) => {
     const deferred = Q.defer();
 
     Request.post(`${kGlobalConstants.API}list_submissions/`)
@@ -67,7 +67,7 @@ export const loadSubmissionList = (
             certified: certified.toString(),
             sort,
             order,
-            d2_submission: d2Submission,
+            fabs,
             filters
         })
         .end((err, res) => {


### PR DESCRIPTION
**High level description:**
Updating parameters to send to backend

**Technical details:**
Rename `d2_submission` param to `fabs` in `list_submissions` to match the backend

**Link to JIRA Ticket:**
[DEV-1378](https://federal-spending-transparency.atlassian.net/browse/DEV-1378)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#1476](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1476)