### PR TITLE
Fix for thrown upload error not showing up in frontend UI

### DIFF
--- a/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
@@ -50,12 +50,13 @@ export default class UploadFabsFileError extends React.Component {
         if (this.state.type === 'success') {
             header = 'Your submission has been succesfully published';
         }
-        else if (this.props.error) {
+        else if (this.props.error.header || this.props.error.description) {
             header = this.props.error.header;
             message = this.props.error.description;
         }
         else if (this.props.message) {
-            header = this.props.message;
+            header = 'Upload Error';
+            message = this.props.message;
         }
         else {
             switch (this.props.errorCode) {

--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -134,11 +134,8 @@ class UploadFabsFileValidation extends React.Component {
                 this.checkFileStatus(this.state.submissionID);
             })
             .catch((error) => {
-                let errMsg = "An error occurred while attempting to revalidate the submission. " +
+                const errMsg = error.message || "An error occurred while attempting to revalidate the submission. " +
                     "Please contact the Service Desk.";
-                if (error.httpStatus === 400 || error.httpStatus === 403) {
-                    errMsg = error.message;
-                }
 
                 this.setState({
                     error: 4,
@@ -259,7 +256,10 @@ class UploadFabsFileValidation extends React.Component {
                             this.setState({ error: 1, error_message: error.message, published: 'unpublished' });
                         }
                         else if (error.httpStatus === 500) {
-                            this.setState({ error: 4, published: 'unpublished' });
+                            this.setState({ error: 4, error_message: error.message, published: 'unpublished' });
+                        }
+                        else {
+                            this.setState({ error: 1, error_message: error.message, published: 'unpublished' });
                         }
                     });
             }


### PR DESCRIPTION
**High level description:**
Fixes an issue with FABS upload that would simply display a red exclamation mark when there was an error, without any explanation/suggestion to fix the issue.

**Link to JIRA Ticket:**
[DEV-2033](https://federal-spending-transparency.atlassian.net/browse/DEV-2033)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed