### PR TITLE
DEV-2014: Handling invalid submission ID in Broker Web App

### DIFF
--- a/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
@@ -70,7 +70,7 @@ export default class UploadFabsFileError extends React.Component {
                     header = 'This file has already been submitted in another submission';
                     break;
                 case 4:
-                    header = 'This file does not exist';
+                    header = 'Submission does not exist or has been deleted.';
                     break;
                 default:
                     header = 'There was an error with your submission. Please contact the Service Desk';

--- a/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
@@ -69,6 +69,8 @@ export default class UploadFabsFileError extends React.Component {
                 case 3:
                     header = 'This file has already been submitted in another submission';
                     break;
+                case 4:
+                    header = 'This file does not exist';
                 default:
                     header = 'There was an error with your submission. Please contact the Service Desk';
                     break;

--- a/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileError.jsx
@@ -71,6 +71,7 @@ export default class UploadFabsFileError extends React.Component {
                     break;
                 case 4:
                     header = 'This file does not exist';
+                    break;
                 default:
                     header = 'There was an error with your submission. Please contact the Service Desk';
                     break;

--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -2,7 +2,7 @@
 * UploadFabsFileValidation.jsx
 * Created by Minahm Kim
 */
-/* eslint-disable */
+
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 
 import React, { PropTypes } from "react";
@@ -107,7 +107,6 @@ class UploadFabsFileValidation extends React.Component {
             .catch((error) => {
                 // Invalid Submission ID
                 if (error.httpStatus === 400) {
-                    console.log("errMsgElse");
                     const errMsg = "This is not a valid submission. Check your validation URL and try again.";
                     this.setState({
                         published: 'unpublished',
@@ -156,17 +155,12 @@ class UploadFabsFileValidation extends React.Component {
     checkFileStatus(submissionID) {
         // callback to check file status
 
-        console.log("checkFileStatus1")
         ReviewHelper.fetchStatus(submissionID)
             .then((response) => {
-
-                console.log("checkFileStatus2")
                 if (this.isUnmounted) {
-                    console.log("unmounted")
                     return;
                 }
 
-                console.log("checkFileStatusThen");
                 const fabsData = response.fabs;
                 if (fabsData.status !== 'uploading' && fabsData.status !== 'running') {
                     let success = false;
@@ -203,12 +197,9 @@ class UploadFabsFileValidation extends React.Component {
             })
             .catch((err) => {
                 if (err.status === 400) {
-                    console.log("checkFileStatusCatch");
                     this.setState({ error: 2, submit: false });
                 }
             });
-
-        console.log("checkfilestatusOut");
     }
 
     checkFile(submissionID) {
@@ -335,7 +326,6 @@ class UploadFabsFileValidation extends React.Component {
     }
 
     render() {
-        console.log("rendering");
         let validationButton = null;
         let revalidateButton = null;
         let downloadButton = null;
@@ -350,18 +340,17 @@ class UploadFabsFileValidation extends React.Component {
         const fileData = this.state.jobResults[type.requestName];
         const status = fileData.job_status;
         let errorMessage = null;
-        if(this.state.error === 0 || this.state.published === "publishing" || this.state.validationFinished) {
+        if (this.state.error === 0 || this.state.published === "publishing" || this.state.validationFinished) {
             validationBox = (<ValidateDataFileContainer
                 type={type}
                 data={this.state.jobResults}
                 setUploadItem={this.uploadFile.bind(this)}
                 updateItem={this.uploadFile.bind(this)}
                 publishing={this.state.published === "publishing"}
-                agencyName={this.state.agency}/>);
+                agencyName={this.state.agency} />);
         }
         if (fileData.file_status === "complete" && this.state.validationFinished &&
             this.state.published !== "publishing") {
-            console.log("passed into fileData");
             if (status !== "invalid" || fileData.file_status === "complete") {
                 validationBox = (<ValidateValuesFileContainer
                     type={type}
@@ -423,7 +412,6 @@ class UploadFabsFileValidation extends React.Component {
                     );
                 }
                 else {
-                    console.log("elsed");
                     downloadButton = (
                         <div className="col-xs-12">
                             <div className="row">
@@ -435,7 +423,9 @@ class UploadFabsFileValidation extends React.Component {
                                     <span className="tooltip-popover-container">
                                         <Icons.InfoCircle />
                                         <span className="tooltip-popover above">
-                                            <span>The published file differs from the submitted file in four ways: </span>
+                                            <span>
+                                                The published file differs from the submitted file in four ways:
+                                            </span>
                                             <span>1) It contains derivations based on agency data, as described
                                         in the DAIMS Practices and Procedures document;
                                             </span>
@@ -491,7 +481,6 @@ class UploadFabsFileValidation extends React.Component {
         }
 
         if (this.state.published === "publishing" && this.state.error !== 0) {
-            console.log("marked as publishing");
             errorMessage = (<UploadFabsFileError
                 errorCode={this.state.error}
                 type="error"
@@ -505,7 +494,6 @@ class UploadFabsFileValidation extends React.Component {
                 </button>);
         }
         else if (this.state.published === "unpublished" && this.state.error !== 0) {
-            console.log("unpublished elif");
             errorMessage = (<UploadFabsFileError
                 errorCode={this.state.error}
                 type="error"

--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -105,13 +105,18 @@ class UploadFabsFileValidation extends React.Component {
                 });
             })
             .catch((error) => {
-                // Invalid Submission ID
                 if (error.httpStatus === 400) {
                     const errMsg = "Submission does not exist or has been deleted.";
                     this.setState({
                         published: 'unpublished',
                         error: 4,
                         error_message: errMsg
+                    });
+                }
+                else {
+                    this.setState({
+                        published: 'unpublished',
+                        error_message: error.httpStatus
                     });
                 }
             });

--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -107,7 +107,7 @@ class UploadFabsFileValidation extends React.Component {
             .catch((error) => {
                 // Invalid Submission ID
                 if (error.httpStatus === 400) {
-                    const errMsg = "This is not a valid submission. Check your validation URL and try again.";
+                    const errMsg = "Submission does not exist or has been deleted.";
                     this.setState({
                         published: 'unpublished',
                         error: 4,

--- a/src/js/components/validateData/ValidateDataFileComponent.jsx
+++ b/src/js/components/validateData/ValidateDataFileComponent.jsx
@@ -95,7 +95,6 @@ export default class ValidateDataFileComponent extends React.Component {
         if (!item) {
             return;
         }
-
         let headerTitle = 'Validating...';
         let isError = false;
         let hasErrorReport = false;


### PR DESCRIPTION
**High level description:**
Directly accessing Broker using an invalid ID, e.g. 
`https://broker.usaspending.gov/#/FABSAddData/<ID of a nonexistent submission (including deleted submissions)>` 
would display a `Validating...` page rather than an error. This fix adds an error message for accessing invalid submission IDs.

**Technical details:**
New `response 400` error handler added in `setSubmissionMetadata` function within `UploadFabsFileValidation.jsx` to address invalid IDs. The new error message given is: `Submission does not exist or has been deleted.` 

**Link to JIRA Ticket:**
[DEV-2014](https://federal-spending-transparency.atlassian.net/browse/DEV-2014)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed