### PR TITLE
Fix Validate Treemap Cells

### DIFF
--- a/src/js/components/validateData/treemap/Treemap.jsx
+++ b/src/js/components/validateData/treemap/Treemap.jsx
@@ -113,7 +113,7 @@ export default class Treemap extends React.Component {
             const color = tinycolor(baseColor).lighten(tint).toString();
 
             return (<TreemapCell
-                key={node.description}
+                key={`${node.description}-${node.index}`}
                 width={node.dx}
                 height={node.dy}
                 x={node.x}


### PR DESCRIPTION
**High level description:**
The Warnings & Errors report treemap was not rendering correctly because each cell did not always have a unique `key` value. 

**Technical details:**
- Caused by this change: https://github.com/fedspendingtransparency/data-act-broker-web-app/commit/915e1fbdb7d85f33510776fa1a6982447e716944#diff-fe05e4274626a200e56c89a4dd872f74R116
- Updated the `key` value to include the cell index to prevent duplicates when multiple cells have the same `description`.

**Link to JIRA Ticket:**
[DEV-2097](https://federal-spending-transparency.atlassian.net/browse/DEV-2097)

The following are ALL required for the PR to be merged:
- [x] Code review completed
