### PR TITLE
DEV-1308: D File URL Generation On Click

### DIFF
--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -41,6 +41,10 @@ export default class GenerateFilesContent extends React.Component {
         this.closeTooltip = this.closeTooltip.bind(this);
     }
 
+    clickedDownload(fileType) {
+        this.props.clickedDownload(fileType);
+    }
+
     handleDateChange(file, date, dateType) {
         this.props.handleDateChange(file, date, dateType);
     }
@@ -121,9 +125,10 @@ export default class GenerateFilesContent extends React.Component {
                             startingTab={1}
                             value={this.props.d1}
                             error={this.props.d1.error}
-                            download={this.props.d1.download}
+                            showDownload={this.props.d1.showDownload}
                             onDateChange={this.handleDateChange.bind(this, "d1")}
-                            updateError={this.updateError.bind(this, "d1")} />
+                            updateError={this.updateError.bind(this, "d1")}
+                            clickedDownload={this.clickedDownload.bind(this, "D1")} />
 
                         <GenerateFileBox
                             label="File D2: Financial Assistance"
@@ -131,9 +136,10 @@ export default class GenerateFilesContent extends React.Component {
                             startingTab={9}
                             value={this.props.d2}
                             error={this.props.d2.error}
-                            download={this.props.d2.download}
+                            showDownload={this.props.d2.showDownload}
                             onDateChange={this.handleDateChange.bind(this, "d2")}
-                            updateError={this.updateError.bind(this, "d2")} />
+                            updateError={this.updateError.bind(this, "d2")}
+                            clickedDownload={this.clickedDownload.bind(this, "D2")} />
                     </div>
                 </div>
                 <GenerateFilesOverlay {...this.props} />

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -12,6 +12,7 @@ import AgencyToggleTooltip from '../generateDetachedFiles/AgencyToggleTooltip';
 import { InfoCircle } from '../SharedComponents/icons/Icons';
 
 const propTypes = {
+    clickedDownload: PropTypes.func,
     handleDateChange: PropTypes.func,
     updateError: PropTypes.func,
     d1: PropTypes.object,
@@ -21,6 +22,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    clickedDownload: null,
     handleDateChange: null,
     updateError: null,
     d1: null,

--- a/src/js/components/generateFiles/components/GenerateFileBox.jsx
+++ b/src/js/components/generateFiles/components/GenerateFileBox.jsx
@@ -10,7 +10,7 @@ import DatePicker from './DatePicker';
 const propTypes = {
     onDateChange: PropTypes.func,
     updateError: PropTypes.func,
-    download: PropTypes.object,
+    showDownload: PropTypes.bool,
     error: PropTypes.object,
     value: PropTypes.object,
     datePlaceholder: PropTypes.string,
@@ -20,10 +20,7 @@ const propTypes = {
 
 const defaultProps = {
     startingTab: 1,
-    download: {
-        show: false,
-        url: '#'
-    },
+    showDownload: false,
     onDateChange: null,
     updateError: null,
     error: null,
@@ -39,9 +36,9 @@ export default class GenerateFileBox extends React.Component {
             errorClass = '';
         }
 
-        let showDownload = ' hide';
-        if (this.props.download.show && this.props.download.url !== '#') {
-            showDownload = '';
+        let downloadClass = ' hide';
+        if (this.props.showDownload) {
+            downloadClass = '';
         }
 
         return (
@@ -73,20 +70,20 @@ export default class GenerateFileBox extends React.Component {
                                 updateError={this.props.updateError} />
                         </div>
                     </div>
-                    <div className={`usa-da-generate-download${showDownload}`}>
+                    <div className={`usa-da-generate-download${downloadClass}`}>
                         <div className="row">
                             <div className="col-sm-12">
                                 <div className="download-title text-right">
                                     Download {this.props.label}
                                 </div>
-                                <a
-                                    href={this.props.download.url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
+                                <div
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={this.props.clickedDownload}
                                     className="usa-da-download pull-right">
                                     <span className="usa-da-icon usa-da-download-report"><Icons.CloudDownload />
                                     </span>Download File
-                                </a>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/generateFiles/components/GenerateFileBox.jsx
+++ b/src/js/components/generateFiles/components/GenerateFileBox.jsx
@@ -8,6 +8,7 @@ import * as Icons from '../../SharedComponents/icons/Icons';
 import DatePicker from './DatePicker';
 
 const propTypes = {
+    clickedDownload: PropTypes.func,
     onDateChange: PropTypes.func,
     updateError: PropTypes.func,
     showDownload: PropTypes.bool,
@@ -19,14 +20,15 @@ const propTypes = {
 };
 
 const defaultProps = {
-    startingTab: 1,
-    showDownload: false,
+    clickedDownload: null,
     onDateChange: null,
     updateError: null,
+    showDownload: false,
     error: null,
     value: null,
     datePlaceholder: '',
-    label: ''
+    label: '',
+    startingTab: 1
 };
 
 export default class GenerateFileBox extends React.Component {
@@ -80,6 +82,7 @@ export default class GenerateFileBox extends React.Component {
                                     role="button"
                                     tabIndex={0}
                                     onClick={this.props.clickedDownload}
+                                    onKeyDown={this.props.clickedDownload}
                                     className="usa-da-download pull-right">
                                     <span className="usa-da-icon usa-da-download-report"><Icons.CloudDownload />
                                     </span>Download File

--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -56,10 +56,7 @@ class GenerateFilesContainer extends React.Component {
                     header: '',
                     description: ''
                 },
-                download: {
-                    show: false,
-                    url: ''
-                }
+                showDownload: false
             },
             d2: {
                 startDate: null,
@@ -69,10 +66,7 @@ class GenerateFilesContainer extends React.Component {
                     header: '',
                     description: ''
                 },
-                download: {
-                    show: false,
-                    url: ''
-                }
+                showDownload: false
             },
             d1Status: "waiting",
             d2Status: "waiting",
@@ -112,6 +106,16 @@ class GenerateFilesContainer extends React.Component {
                     console.error(error);
                 });
         }
+    }
+
+    clickedDownload(fileType) {
+        GenerateFilesHelper.fetchFile(fileType, this.props.submissionID)
+            .then((result) => {
+                window.open(result.url)
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
 
     parseDate(raw, type) {
@@ -439,10 +443,7 @@ class GenerateFilesContainer extends React.Component {
 
                 if (fileData.url && fileData.size) {
                     // update the download properties
-                    item.download = {
-                        show: true,
-                        url: fileData.url
-                    };
+                    item.showDownload = true;
                     const header = `${fileData.file_type.toUpperCase()} File Error`;
                     item.error = {
                         show: header !== '' && message !== '',
@@ -458,10 +459,7 @@ class GenerateFilesContainer extends React.Component {
                 // make a clone of the file's react state
                 const item = Object.assign({}, this.state[file]);
                 // update the download properties
-                item.download = {
-                    show: true,
-                    url: fileData.url
-                };
+                item.showDownload = true;
                 const failCases = ['', '#', null];
                 if (_.findIndex(failCases, fileData.url) !== -1) {
                     const header = `${fileData.file_type.toUpperCase()} File Error`;
@@ -530,7 +528,8 @@ class GenerateFilesContainer extends React.Component {
                     updateError={this.updateError.bind(this)}
                     generateFiles={this.generateFiles.bind(this)}
                     nextPage={this.nextPage.bind(this)}
-                    toggleAgencyType={this.toggleAgencyType} />
+                    toggleAgencyType={this.toggleAgencyType}
+                    clickedDownload={this.clickedDownload.bind(this)} />
             </div>
         );
     }

--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -111,7 +111,7 @@ class GenerateFilesContainer extends React.Component {
     clickedDownload(fileType) {
         GenerateFilesHelper.fetchFile(fileType, this.props.submissionID)
             .then((result) => {
-                window.open(result.url)
+                window.open(result.url);
             })
             .catch((error) => {
                 console.error(error);


### PR DESCRIPTION
**High level description:**
Updating how we get the file url for D file downloads.

**Technical details:**
Instead of generating the URL on page load or on completion of generation, we just query the backend for a URL every time someone clicks "download" so there's no chance of it expiring before it gets used.

**Link to JIRA Ticket:**
[DEV-1308](https://federal-spending-transparency.atlassian.net/browse/DEV-1308)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed