### PR TITLE
DEV-1308: detached file url generation

### DIFF
--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -11,6 +11,7 @@ import AgencyToggleTooltip from './AgencyToggleTooltip';
 import { InfoCircle } from '../SharedComponents/icons/Icons';
 
 const propTypes = {
+    clickedDownload: PropTypes.func,
     generateFile: PropTypes.func,
     handleDateChange: PropTypes.func,
     updateError: PropTypes.func,
@@ -21,6 +22,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    clickedDownload: null,
     generateFile: null,
     handleDateChange: null,
     updateError: null,
@@ -40,6 +42,10 @@ export default class DateSelect extends React.Component {
 
         this.showTooltip = this.showTooltip.bind(this);
         this.closeTooltip = this.closeTooltip.bind(this);
+    }
+
+    clickedDownload(fileType) {
+        this.props.clickedDownload(fileType);
     }
 
     handleDateChange(file, date, dateType) {
@@ -131,9 +137,10 @@ export default class DateSelect extends React.Component {
                     startingTab={1}
                     value={this.props.d1}
                     error={this.props.d1.error}
-                    download={this.props.d1.download}
+                    showDownload={this.props.d1.showDownload}
                     onDateChange={this.handleDateChange.bind(this, "d1")}
-                    updateError={this.updateError.bind(this, "d1")} />
+                    updateError={this.updateError.bind(this, "d1")}
+                    clickedDownload={this.clickedDownload.bind(this, "d1")} />
 
                 <div className="right-align-box">
                     <button
@@ -150,9 +157,10 @@ export default class DateSelect extends React.Component {
                     startingTab={9}
                     value={this.props.d2}
                     error={this.props.d2.error}
-                    download={this.props.d2.download}
+                    showDownload={this.props.d2.showDownload}
                     onDateChange={this.handleDateChange.bind(this, "d2")}
-                    updateError={this.updateError.bind(this, "d2")} />
+                    updateError={this.updateError.bind(this, "d2")}
+                    clickedDownload={this.clickedDownload.bind(this, "d2")} />
 
                 <div className="right-align-box">
                     <button

--- a/src/js/components/generateDetachedFiles/DetachedFileA.jsx
+++ b/src/js/components/generateDetachedFiles/DetachedFileA.jsx
@@ -21,21 +21,23 @@ const initialPeriod = defaultPeriods();
 
 const propTypes = {
     route: PropTypes.object,
+    clickedDownload: PropTypes.func,
     generateFileA: PropTypes.func,
     status: PropTypes.string,
     errorType: PropTypes.string,
     errorMessage: PropTypes.string,
-    url: PropTypes.string
+    showDownload: PropTypes.bool
 };
 
 const defaultProps = {
     route: null,
     agencyList: [],
+    clickedDownload: null,
     generateFileA: () => { },
     status: '',
     errorType: '',
     errorMessage: '',
-    url: ''
+    showDownload: false
 };
 
 export default class DetachedFileA extends React.Component {
@@ -230,7 +232,8 @@ export default class DetachedFileA extends React.Component {
                                             label="File A: Appropriations Accounts"
                                             errorType={this.props.errorType}
                                             errorMessage={this.props.errorMessage}
-                                            url={this.props.url} />
+                                            clickedDownload={this.props.clickedDownload}
+                                            showDownload={this.props.showDownload} />
                                         <GenerateButton
                                             agency={this.state.agency}
                                             generate={this.generate}

--- a/src/js/components/generateDetachedFiles/DetachedFileA.jsx
+++ b/src/js/components/generateDetachedFiles/DetachedFileA.jsx
@@ -103,7 +103,8 @@ export default class DetachedFileA extends React.Component {
         this.setState({
             downloadFields: `${this.state.agencyName} | FY ${this.state.fy} | ${minPeriod} - ${maxPeriod}`
         });
-        this.props.generateFileA(this.state.agency, this.state.codeType, this.state.period, parseInt(this.state.fy, 10));
+        this.props.generateFileA(this.state.agency, this.state.codeType, this.state.period,
+            parseInt(this.state.fy, 10));
     }
 
     render() {
@@ -189,9 +190,10 @@ export default class DetachedFileA extends React.Component {
                                                     with the child agency. File A is generated based on GTAS SF-133
                                                     data, which GTAS provides to the Broker on a daily basis during any
                                                     reporting/revision windows (note that it will take up to 24
-                                                    hours for changes agencies make in GTAS to be reflected in the Broker).
-                                                    For a more detailed explanation of the approach for generating File
-                                                    A, see the Practices and Procedures document available on the&nbsp;
+                                                    hours for changes agencies make in GTAS to be reflected in the
+                                                    Broker). For a more detailed explanation of the approach for
+                                                    generating File A, see the Practices and Procedures document
+                                                    available on the&nbsp;
                                                     <a
                                                         target="_blank"
                                                         rel="noopener noreferrer"
@@ -202,12 +204,13 @@ export default class DetachedFileA extends React.Component {
                                                     Bureau of the Fiscal Service.
                                                 </p>
                                                 <p>
-                                                    Note: Because there is no Period 01 (October) reporting window in GTAS, a
-                                                    generated File A for a new Fiscal Year is not available until the Period 02
-                                                    GTAS reporting window.
+                                                    Note: Because there is no Period 01 (October) reporting window in
+                                                    GTAS, a generated File A for a new Fiscal Year is not available
+                                                    until the Period 02 GTAS reporting window.
 
-                                                    While Period 01 data is automatically included with data from later periods
-                                                    (because File A Data is cumulative within the Fiscal year), it is not selectable on its own.
+                                                    While Period 01 data is automatically included with data from
+                                                    later periods (because File A Data is cumulative within the Fiscal
+                                                    year), it is not selectable on its own.
                                                 </p>
                                             </div>
                                         </div>

--- a/src/js/components/generateDetachedFiles/DownloadFile.jsx
+++ b/src/js/components/generateDetachedFiles/DownloadFile.jsx
@@ -7,19 +7,21 @@ import React, { PropTypes } from 'react';
 import * as Icons from '../SharedComponents/icons/Icons';
 
 const propTypes = {
+    clickedDownload: PropTypes.func,
     fileInfo: PropTypes.string,
     errorType: PropTypes.string,
     errorMessage: PropTypes.string,
-    url: PropTypes.string,
-    label: PropTypes.string
+    label: PropTypes.string,
+    showDownload: PropTypes.bool
 };
 
 const defaultProps = {
+    clickedDownload: null,
     fileInfo: '',
-    url: '',
     errorType: '',
     errorMessage: '',
-    label: ''
+    label: '',
+    showDownload: false
 };
 
 export default class DownloadFile extends React.Component {
@@ -30,7 +32,7 @@ export default class DownloadFile extends React.Component {
         }
 
         let showDownload = ' hide';
-        if (this.props.url) {
+        if (this.props.showDownload) {
             showDownload = '';
         }
 
@@ -46,16 +48,17 @@ export default class DownloadFile extends React.Component {
                                 <div className="col-sm-12">
                                     {this.props.fileInfo}
                                 </div>
-                                <a
-                                    href={this.props.url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
+                                <div
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={this.props.clickedDownload}
+                                    onKeyDown={this.props.clickedDownload}
                                     className="usa-da-download file-download-btn">
                                     <span className="usa-da-icon usa-da-download-report">
                                         <Icons.CloudDownload />
                                     </span>
                                     Download File
-                                </a>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
+++ b/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
@@ -48,12 +48,10 @@ export default class GenerateDetachedFilesPage extends React.Component {
                     header: '',
                     description: ''
                 },
-                download: {
-                    show: false,
-                    url: ''
-                },
+                showDownload: false,
                 valid: false,
-                status: ""
+                status: "",
+                jobID: null
             },
             d2: {
                 startDate: null,
@@ -63,12 +61,10 @@ export default class GenerateDetachedFilesPage extends React.Component {
                     header: '',
                     description: ''
                 },
-                download: {
-                    show: false,
-                    url: ''
-                },
+                showDownload: false,
                 valid: false,
-                status: ""
+                status: "",
+                jobID: null
             }
         };
 
@@ -99,6 +95,17 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 agencyError: true
             }, this.checkComplete);
         }
+    }
+
+    clickedDownload(fileType) {
+        const item = Object.assign({}, this.state[fileType]);
+        GenerateFilesHelper.fetchDetachedFileUrl(item.jobID)
+            .then((result) => {
+                window.open(result.url);
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
 
     checkComplete() {
@@ -272,10 +279,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
             const item = Object.assign({}, this.state[fileType]);
 
             // update the download properties
-            item.download = {
-                show: true,
-                url: data.url
-            };
+            item.showDownload = true;
+            item.jobID = data.job_id;
             item.status = "done";
 
             this.setState({ [fileType]: item });
@@ -308,7 +313,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 handleDateChange={this.handleDateChange.bind(this)}
                 updateError={this.updateError.bind(this)}
                 generateFile={this.generateFile.bind(this)}
-                toggleAgencyType={this.toggleAgencyType} />);
+                toggleAgencyType={this.toggleAgencyType}
+                clickedDownload={this.clickedDownload.bind(this)} />);
         }
 
         return (

--- a/src/js/containers/generateDetachedFiles/DetachedFileAContainer.jsx
+++ b/src/js/containers/generateDetachedFiles/DetachedFileAContainer.jsx
@@ -111,7 +111,7 @@ export class DetachedFileAContainer extends React.Component {
                 errorMessage: '',
                 status: 'done',
                 showDownload: true,
-                jobId: data.job_id,
+                jobId: data.job_id
             });
         }
         if (runCheck) {

--- a/src/js/containers/generateDetachedFiles/DetachedFileAContainer.jsx
+++ b/src/js/containers/generateDetachedFiles/DetachedFileAContainer.jsx
@@ -30,10 +30,21 @@ export class DetachedFileAContainer extends React.Component {
             errorType: '',
             errorMessage: '',
             status: '',
-            url: ''
+            showDownload: false,
+            jobId: null
         };
 
         this.generateFileA = this.generateFileA.bind(this);
+    }
+
+    clickedDownload() {
+        GenerateFilesHelper.fetchDetachedFileUrl(this.state.jobId)
+            .then((result) => {
+                window.open(result.url);
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
 
     generateFileA(agency, codeType, period, fy) {
@@ -99,7 +110,8 @@ export class DetachedFileAContainer extends React.Component {
                 errorType: '',
                 errorMessage: '',
                 status: 'done',
-                url: data.url
+                showDownload: true,
+                jobId: data.job_id,
             });
         }
         if (runCheck) {
@@ -115,7 +127,8 @@ export class DetachedFileAContainer extends React.Component {
             <DetachedFileA
                 {...this.props}
                 {...this.state}
-                generateFileA={this.generateFileA} />
+                generateFileA={this.generateFileA}
+                clickedDownload={this.clickedDownload.bind(this)} />
         );
     }
 }

--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -74,6 +74,25 @@ export const fetchFile = (type, submissionId) => {
     return deferred.promise;
 };
 
+export const fetchDetachedFileUrl = (jobId) => {
+    const deferred = Q.defer();
+
+    Request.get(`${kGlobalConstants.API}get_detached_file_url?job_id=${jobId}`)
+        .send()
+        .end((errFile, res) => {
+            if (errFile) {
+                const response = Object.assign({}, res.body);
+                response.httpStatus = res.status;
+                deferred.reject(response);
+            }
+            else {
+                deferred.resolve(res.body);
+            }
+        });
+
+    return deferred.promise;
+};
+
 export const getFabsMeta = (submissionId) => {
     const deferred = Q.defer();
 

--- a/tests/containers/generateDetachedFiles/DetachedFileAContainer-test.jsx
+++ b/tests/containers/generateDetachedFiles/DetachedFileAContainer-test.jsx
@@ -49,7 +49,7 @@ describe('DetachedFileAContainer', () => {
 
             expect(container.state().errorType).toEqual('File A Error');
         });
-        it('should set the url if the status is finished', () => {
+        it('should set showDownload if the status is finished', () => {
             const container = shallow(<DetachedFileAContainer />);
 
             container.instance().parseFileState({
@@ -63,7 +63,7 @@ describe('DetachedFileAContainer', () => {
                 message: ''
             });
 
-            expect(container.state().url).toEqual('http://mockurl.gov');
+            expect(container.state().showDownload).toEqual(true);
         });
         it('should call checkFileStatus after 10 seconds if status is waiting', () => {
             const container = shallow(<DetachedFileAContainer />);


### PR DESCRIPTION
**High level description:**
Forgot to account for detached files in the file generation on click

**Technical details:**
Had to add a new endpoint to account for how both detached file D and detached file A generation work.

**Link to JIRA Ticket:**
[DEV-1308](https://federal-spending-transparency.atlassian.net/browse/DEV-1308)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Merged after [Backend#1548](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1548)