### PR TITLE
Fix/period picker quarters

### DIFF
--- a/src/_scss/pages/generateDetachedFiles/_periodPicker.scss
+++ b/src/_scss/pages/generateDetachedFiles/_periodPicker.scss
@@ -88,7 +88,7 @@
             .period-picker__tooltip {
                 position: absolute;
                 top: rem(10);
-                right: rem(-300);
+                right: rem(-250);
                 width: rem(300);
                 text-align: left;
                 padding: rem(5);
@@ -122,7 +122,7 @@
                 background-color: $color-gray-lightest;
             }
 
-            &:disabled {
+            &.period-picker__list-button_disabled  {
                 cursor: not-allowed;
                 background-color: $color-gray-lightest;
                 color:$color-gray-lighter;

--- a/src/_scss/pages/generateDetachedFiles/_periodPicker.scss
+++ b/src/_scss/pages/generateDetachedFiles/_periodPicker.scss
@@ -84,6 +84,25 @@
                     border-top: none;
                 }
             }
+
+            .period-picker__tooltip {
+                position: absolute;
+                top: rem(10);
+                right: rem(-300);
+                width: rem(300);
+                text-align: left;
+                padding: rem(5);
+                background-color: $color-gray-lightest;
+                border: solid rem(1) $color-gray;
+                box-shadow: $box-shadow;
+                p {
+                    font-size: rem(13);
+                    margin: 0;
+                    &:first-child {
+                        padding-bottom: rem(10);
+                    }
+                }
+            }
         }
 
         .period-picker__list-button {

--- a/src/js/components/generateDetachedFiles/PeriodButton.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButton.jsx
@@ -36,10 +36,10 @@ const PeriodButton = (props) => {
     const activeClass = props.active ? 'period-picker__list-button_active' : '';
 
     let quarterIndicator = null;
-    if ((props.period + 1) % 4 === 0) {
-        // Every 4th period corresponds to the end of a fiscal quarter
+    if ((props.period + 1) % 3 === 0) {
+        // Every 3rd period corresponds to the end of a fiscal quarter
         let quarterText = 'Quarter 1';
-        const quarter = (props.period + 1) / 4;
+        const quarter = (props.period + 1) / 3;
         if (quarter > 1) {
             quarterText = `Quarters 1 - ${quarter}`;
         }

--- a/src/js/components/generateDetachedFiles/PeriodButton.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButton.jsx
@@ -36,10 +36,10 @@ const PeriodButton = (props) => {
     const activeClass = props.active ? 'period-picker__list-button_active' : '';
 
     let quarterIndicator = null;
-    if ((props.period + 1) % 3 === 0) {
+    if ((props.period) % 3 === 0) {
         // Every 3rd period corresponds to the end of a fiscal quarter
         let quarterText = 'Quarter 1';
-        const quarter = (props.period + 1) / 3;
+        const quarter = props.period / 3;
         if (quarter > 1) {
             quarterText = `Quarters 1 - ${quarter}`;
         }

--- a/src/js/components/generateDetachedFiles/PeriodButton.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButton.jsx
@@ -5,6 +5,7 @@
 
 import React, { PropTypes } from 'react';
 import * as utils from '../../helpers/util';
+import PeriodButtonWithTooltip from './PeriodButtonWithTooltip';
 
 const propTypes = {
     active: PropTypes.bool,
@@ -51,33 +52,26 @@ const PeriodButton = (props) => {
     }
 
     let button = (
-        <button
-            className={`period-picker__list-button ${activeClass}`}
-            onMouseOver={hoveredPeriod}
-            onFocus={hoveredPeriod}
-            onMouseLeave={props.endHover}
-            onBlur={props.endHover}
-            onClick={clickedPeriod}>
-            {utils.getPeriodTextFromValue(props.period)}{quarterIndicator}
-        </button>
+        <li className="period-picker__list-item">
+            <button
+                className={`period-picker__list-button ${activeClass}`}
+                onMouseOver={hoveredPeriod}
+                onFocus={hoveredPeriod}
+                onMouseLeave={props.endHover}
+                onBlur={props.endHover}
+                onClick={clickedPeriod}>
+                {utils.getPeriodTextFromValue(props.period)}{quarterIndicator}
+            </button>
+        </li>
     );
 
     if (props.period === 1) {
         button = (
-            <button
-                className={`period-picker__list-button ${activeClass}`}
-                disabled
-                data-tooltip="October is not directly selectable since there is no Period 1 reporting window in GTAS. Because File A Data is cumulative within the Fiscal year, Period 1 data is automatically included with data from later periods.">
-                {utils.getPeriodTextFromValue(props.period)}
-            </button>
+            <PeriodButtonWithTooltip active={props.active} />
         );
     }
 
-    return (
-        <li className="period-picker__list-item">
-            { button }
-        </li>
-    );
+    return button;
 };
 
 

--- a/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
@@ -1,0 +1,81 @@
+/**
+* PeriodButtonWithTooltip.jsx
+* Created by Lizzie Salita 3/4/19
+*/
+
+import React, { PropTypes } from 'react';
+import * as utils from '../../helpers/util';
+
+const propTypes = {
+    active: PropTypes.bool
+};
+
+const defaultProps = {
+    active: false
+};
+
+export default class PeriodButtonWithTooltip extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showTooltip: false
+        };
+
+        this.showTooltip = this.showTooltip.bind(this);
+        this.hideTooltip = this.hideTooltip.bind(this);
+    }
+
+    showTooltip() {
+        this.setState({
+            showTooltip: true
+        });
+    }
+
+    hideTooltip() {
+        this.setState({
+            showTooltip: false
+        });
+    }
+
+    render() {
+        const activeClass = this.props.active ? 'period-picker__list-button_active' : '';
+        const button = (
+            <button
+                className={`period-picker__list-button ${activeClass}`}
+                disabled>
+                {utils.getPeriodTextFromValue(1)}
+            </button >
+        );
+
+        let tooltip = null;
+        if (this.state.showTooltip) {
+            tooltip = (
+                <div className="period-picker__tooltip">
+                    <p>
+                        October is not directly selectable since there is no <em>Period 1</em> reporting window in GTAS.
+                    </p>
+                    <p>
+                        Because File A Data is cumulative within the Fiscal year, <em>Period 1</em> data is automatically included with data from later periods.
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <li
+                onMouseEnter={this.showTooltip}
+                onFocus={this.showTooltip}
+                onMouseLeave={this.hideTooltip}
+                onBlur={this.hideTooltip}
+                className="period-picker__list-item">
+                {button}
+                {tooltip}
+            </li>
+        );
+    };
+}
+
+
+PeriodButtonWithTooltip.propTypes = propTypes;
+PeriodButtonWithTooltip.defaultProps = defaultProps;

--- a/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
@@ -39,11 +39,13 @@ export default class PeriodButtonWithTooltip extends React.Component {
     }
 
     render() {
-        const activeClass = this.props.active ? 'period-picker__list-button_active' : '';
         const button = (
             <button
-                className={`period-picker__list-button ${activeClass}`}
-                disabled>
+                onMouseEnter={this.showTooltip}
+                onFocus={this.showTooltip}
+                onMouseLeave={this.hideTooltip}
+                onBlur={this.hideTooltip}
+                className="period-picker__list-button period-picker__list-button_disabled">
                 {utils.getPeriodTextFromValue(1)}
             </button >
         );
@@ -64,10 +66,6 @@ export default class PeriodButtonWithTooltip extends React.Component {
 
         return (
             <li
-                onMouseEnter={this.showTooltip}
-                onFocus={this.showTooltip}
-                onMouseLeave={this.hideTooltip}
-                onBlur={this.hideTooltip}
                 className="period-picker__list-item">
                 {button}
                 {tooltip}


### PR DESCRIPTION
**High level description:**
Fixes the labels for quarters on the Generate File A period picker. 

**Technical details:**
Updates the logic to display a label every 3rd period, and removes where it was adding 1 to the period because they have already been adjusted for zero-indexing. 

**Link to JIRA Ticket:**
[DEV-2333](https://federal-spending-transparency.atlassian.net/browse/DEV-2333)

**Mockup**
https://bahdigital.invisionapp.com/share/69IA8EPGPCM#/296003247_Broker_-_File_A_Generation_-_001

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Design review completed