### PR TITLE
Bringing frontend Docker in line with node 6.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5
+FROM node:6.16
 
 RUN npm install --global gulp
 


### PR DESCRIPTION
**High level description:**
Upgrade docker container used for local development to use node 6.16

**Technical details:**
Developers have been using node 6.16, and this container was still using 5.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [ ] Merged concurrently with [Backend#1555](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1555)