### PR TITLE
DEV-2198 help page styling

### DIFF
--- a/src/_scss/pages/help/_content.scss
+++ b/src/_scss/pages/help/_content.scss
@@ -7,18 +7,6 @@
 		margin-bottom: 1rem;
 	}
 
-	.usa-da-help-content__date {
-		font-size: 2rem;
-	}
-
-	.usa-da-help-content__content {
-		margin-top: 1rem;
-	}
-
-	.usa-da-help-content__list {
-		margin-bottom: 0.5rem;
-	}
-
 	.resources-page-content {
 		max-width: 100%;
 	}
@@ -28,13 +16,16 @@
     	max-width: 100%;
     }
 
-	// margin updates for changelog
-	h4 {
+	h4 { // Dates
 		margin-bottom: 1.6rem;
+		font-size: 2.0rem;
+		font-weight: bold;
 	}
 
 	h5 {
 		margin-bottom: 1rem;
+		font-size: 1.8rem;
+		font-weight: normal;
 	}
 
 	h6 {

--- a/src/_scss/pages/help/_topButton.scss
+++ b/src/_scss/pages/help/_topButton.scss
@@ -1,14 +1,16 @@
 .usa-da-help-top-button {
-    width: 40px;
-    height: 40px;
+    
     position: fixed;
     bottom: 60px;
     right: 40px;
     overflow: hidden;
-    background-color: $color-gray-light;
     @include transition(all 0.5s ease-in-out);
-    a {
+    button {
+        @include button-unstyled;
+        width: 40px;
+        height: 40px;
         display: block;
+        background-color: $color-gray-light;
         svg {
             fill: $color-white;
             position: relative;
@@ -18,11 +20,11 @@
         .hidden-label {
             font-size: 0;
         }
-    }
-    &:hover {
-        background-color: $color-primary-alt-dark;
-        & svg {
-            top: -5px;
+        &:hover {
+            background-color: $color-primary-alt-dark;
+            & svg {
+                top: -5px;
+            }
         }
     }
 }

--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -1,4 +1,4 @@
-##### April 5, 2019
+#### April 5, 2019
 In this release of the Broker, we:
 
 * Updated Broker Resource page to reference DAIMS v1.3.1 documents.

--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -1,4 +1,4 @@
-#### April 5, 2019
+#### April 5, 2019{section=changelog}
 In this release of the Broker, we:
 
 * Updated Broker Resource page to reference DAIMS v1.3.1 documents.

--- a/src/help/technical.md
+++ b/src/help/technical.md
@@ -1,8 +1,8 @@
-##### April 5, 2019{section=technical}
+#### April 5, 2019{section=technical}
 
 In this release, here is a list of technical changes that may require infrastructure or database updates, or represents additional functionality.
 
 * Updated unique award keys in transaction data to be consistent with USAspending.gov.
 * Updated the CFDA loader to pull from a common source shared with USAspending.gov.
-* Removed deprecated submit_detached_file endpoint from the API. This should not affect Broker Inbound API users given that they do not use this endpoint.
+* Removed deprecated `submit_detached_file` endpoint from the API. This should not affect Broker Inbound API users given that they do not use this endpoint.
 * Fixed the logic of providing current fiscal quarter on the frontend.

--- a/src/help/technicalHistory.md
+++ b/src/help/technicalHistory.md
@@ -2,7 +2,7 @@
 
 In this release, here is a list of technical changes that may require infrastructure or database updates, or represents additional functionality.
 
-* Updated certify_submission API endpoint documents to include new errors for standard quarterly revalidation thresholds and special revalidation thresholds. This rule checks the validation date and confirms the submission is certifiable.
+* Updated `certify_submission` API endpoint documents to include new errors for standard quarterly revalidation thresholds and special revalidation thresholds. This rule checks the validation date and confirms the submission is certifiable.
 * Modified the TAS loader to prevent loading any possible duplicates.
 * Standardized unique award keys between Broker and USASpending.gov.
 * Optimized File F generation for performance in memory and speed.
@@ -44,7 +44,7 @@ In this release, here is a list of technical changes that may require infrastruc
 
 In this release, here is a list of technical changes that may require infrastructure or database updates, or represents additional functionality.
 
-* Database migration to include unique_award_key in the FPDS and FABS staging tables.
+* Database migration to include `unique_award_key` in the FPDS and FABS staging tables.
 * Upgrade boto to boto3 and remove boto from the requirements.
 * Move file type validation to before file upload.
 * Enforce 30-minute session timeout.

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -30,7 +30,6 @@ const defaultProps = {
 };
 
 export default class DateSelect extends React.Component {
-
     toggleAgencyType(type) {
         this.props.toggleAgencyType(type);
     }

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -28,7 +28,6 @@ const defaultProps = {
 };
 
 export default class GenerateFilesContent extends React.Component {
-
     toggleAgencyType(type) {
         this.props.toggleAgencyType(type);
     }

--- a/src/js/components/help/helpContent.jsx
+++ b/src/js/components/help/helpContent.jsx
@@ -7,12 +7,16 @@ import React, { PropTypes } from 'react';
 import $ from 'jquery';
 
 const propTypes = {
+    changelog: PropTypes.string,
     section: PropTypes.string,
+    technical: PropTypes.string,
     helpOnly: PropTypes.bool
 };
 
 const defaultProps = {
+    changelog: '',
     section: '',
+    technical: '',
     helpOnly: false
 };
 
@@ -70,7 +74,7 @@ export default class HelpContent extends React.Component {
             membership = (
                 <p name="membership">
                     If you encounter a bug, have a question, or need help,
-                    please register for the
+                    please register for the&nbsp;
                     <a href="https://servicedesk.usaspending.gov" rel="noopener noreferrer" target="_blank">
                         USAspending Service Desk
                     </a> and submit a ticket.
@@ -83,40 +87,16 @@ export default class HelpContent extends React.Component {
 
         return (
             <div className="usa-da-help-content">
-
                 <h2 className="usa-da-help-content__header">What&#8217;s New in This Release</h2>
-                <strong className="usa-da-help-content__date">April 5, 2019</strong>
-
-                <p className="usa-da-help-content__content">In this release of the Broker, we:</p>
-                <ul className="usa-da-help-content__list">
-                    <li>Updated Broker Resource page to reference DAIMS v1.3.1 documents.</li>
-                    <li>Implemented DAIMS v1.3.1 changes to elements in File D1 and D2. Users who have scripts based on D1/D2 files should update them to match the D1/D2 elements and names in DAIMS v1.3.1.</li>
-                    <li>Updated Submission Dashboard to notify user if there are no submissions to display.</li>
-                    <li>Fixed edge-case issue with email sent after the creation of the DABS submission. These errors only occurred for agencies associated with a FREC. </li>
-                    <li>Fixed small issue with line count inaccuracies in File A that occurred when extra carriage returns were present in the submission file.</li>
-                    <li>Fixed validation rule A34 to correctly generate a critical error when the BudgetAuthorityUnobligatedBalanceBroughtForward value is empty.</li>
-                    <li>Fixed download URL expiration issue for File A/D1/D2. Links are now generated upon click.</li>
-                    <li>Various backend changes and improvements surrounding job handling and memory management.</li>
-                </ul>
-
+                <div dangerouslySetInnerHTML={{ __html: this.props.changelog }} />
                 <h2 className="usa-da-help-content__header">Technical Notes for this Release</h2>
-                <strong className="usa-da-help-content__date">April 5, 2019</strong>
-
-                <p className="usa-da-help-content__content">In this release, here is a list of technical changes that may require infrastructure or database updates, or represents additional functionality.</p>
-                <ul className="usa-da-help-content__list">
-                    <li>Updated unique award keys in transaction data to be consistent with USAspending.gov.</li>
-                    <li>Updated the CFDA loader to pull from a common source shared with USAspending.gov.</li>
-                    <li>Removed deprecated submit_detached_file endpoint from the API. This should not affect Broker Inbound API users given that they do not use this endpoint.</li>
-                    <li>Fixed the logic of providing current fiscal quarter on the frontend.</li>
-                </ul>
+                <div dangerouslySetInnerHTML={{ __html: this.props.technical }} />
                 <h2 className="usa-da-help-content-subheading">Getting More Help</h2>
-
                 {membership}
-
                 <p>
                     If you need assistance using the Broker or if you would like to schedule a hands-on sandbox session
-                    with Treasury staff, please email
-                    <a href="mailto:DATAPMO@fiscal.treasury.gov"> DATAPMO@fiscal.treasury.gov</a>.
+                    with Treasury staff, please email&nbsp;
+                    <a href="mailto:DATAPMO@fiscal.treasury.gov">DATAPMO@fiscal.treasury.gov</a>.
                 </p>
             </div>
         );

--- a/src/js/components/help/helpPage.jsx
+++ b/src/js/components/help/helpPage.jsx
@@ -70,6 +70,13 @@ export default class HelpPage extends React.Component {
             });
     }
 
+    scrollToTop() {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth"
+        });
+    }
+
     render() {
         const help = this.props.type === 'fabs' ? 'FABShelp' : 'help';
         const color = this.props.type === 'fabs' ? 'teal' : 'dark';
@@ -111,12 +118,14 @@ export default class HelpPage extends React.Component {
                 </div>
                 <Footer />
                 <div className="usa-da-help-top-button">
-                    <a href={`#/${help}?section=top`} aria-label="Back to top">
+                    <button
+                        onClick={this.scrollToTop}
+                        aria-label="Back to top">
                         <div className="usa-da-icon">
                             <Icons.AngleUp alt="Arrow pointing up" />
                         </div>
                         <span className="hidden-label">Back to top</span>
-                    </a>
+                    </button>
                 </div>
             </div>
         );

--- a/src/js/components/help/helpSidebar.jsx
+++ b/src/js/components/help/helpSidebar.jsx
@@ -4,7 +4,6 @@
  */
 
 import React, { PropTypes } from 'react';
-import { kGlobalConstants } from '../../GlobalConstants';
 import HelpSidebarItem from './helpSidebarItem';
 
 const propTypes = {

--- a/src/js/components/help/helpSidebar.jsx
+++ b/src/js/components/help/helpSidebar.jsx
@@ -78,7 +78,7 @@ export default class HelpSidebar extends React.Component {
                         <a href={history}>Release Notes Archive</a>
                     </li>
                 </ul>
-                <h6>This Releases Technical Notes</h6>
+                <h6>This Release&rsquo;s Technical Notes</h6>
                 <ul>
                     {tSectionList}
                     <li>

--- a/src/js/components/help/helpSidebar.jsx
+++ b/src/js/components/help/helpSidebar.jsx
@@ -71,7 +71,7 @@ export default class HelpSidebar extends React.Component {
         return (
             <div className="usa-da-help-sidebar">
                 {schedule}
-                <h6>What’s New in This Release</h6>
+                <h6>What&rsquo;s New in This Release</h6>
                 <ul>
                     {clSectionList}
                     <li>

--- a/src/js/components/help/historyPage.jsx
+++ b/src/js/components/help/historyPage.jsx
@@ -94,8 +94,14 @@ export default class HelpPage extends React.Component {
             });
     }
 
+    scrollToTop() {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth"
+        });
+    }
+
     render() {
-        const history = this.props.type === 'fabs' ? '#/FABSHistory' : '#/history';
         const activeTab = this.props.type === 'fabs' ? 'FABSHelp' : 'help';
         const color = this.props.type === 'fabs' ? 'teal' : 'dark';
         return (
@@ -131,12 +137,14 @@ export default class HelpPage extends React.Component {
                 </div>
                 <Footer />
                 <div className="usa-da-help-top-button">
-                    <a href={`${history}?section=top`} aria-label="Back to top">
+                    <button
+                        onClick={this.scrollToTop}
+                        aria-label="Back to top">
                         <div className="usa-da-icon">
                             <Icons.AngleUp alt="Arrow pointing up" />
                         </div>
                         <span className="hidden-label">Back to top</span>
-                    </a>
+                    </button>
                 </div>
             </div>
         );

--- a/src/js/components/help/resourcesPage.jsx
+++ b/src/js/components/help/resourcesPage.jsx
@@ -41,8 +41,14 @@ export default class ResourcesPage extends React.Component {
         }
     }
 
+    scrollToTop() {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth"
+        });
+    }
+
     render() {
-        const resources = this.props.type === 'fabs' ? '#/FABSResources' : '#/resources';
         const activeTab = this.props.type === 'fabs' ? 'FABSHelp' : 'help';
         const color = this.state.type === 'fabs' ? 'teal' : 'dark';
         return (
@@ -72,12 +78,14 @@ export default class ResourcesPage extends React.Component {
                 </div>
                 <Footer />
                 <div className="usa-da-help-top-button">
-                    <a href={`${resources}?section=top`} aria-label="Back to top">
+                    <button
+                        onClick={this.scrollToTop}
+                        aria-label="Back to top">
                         <div className="usa-da-icon">
                             <Icons.AngleUp alt="Arrow pointing up" />
                         </div>
                         <span className="hidden-label">Back to top</span>
-                    </a>
+                    </button>
                 </div>
             </div>
         );

--- a/src/js/components/reviewData/CertificationModal/RevalidateButtons.jsx
+++ b/src/js/components/reviewData/CertificationModal/RevalidateButtons.jsx
@@ -23,12 +23,14 @@ export default class RevalidateButtons extends React.Component {
                 <p>Revalidation cannot be undone and will trigger the following:</p>
                 <ul>
                     <li>You will be redirected to the initial submission phase, where Files A, B, and C will
-                        automatically be revalidated.</li>
+                        automatically be revalidated.
+                    </li>
                     <li>Files D1, D2, E and F must be regenerated.</li>
                     <li>Cross-file validations must be run again.</li>
                 </ul>
                 <p>Revalidation will not alter a previously-certified submission, until and if you certify the
-                    revalidated submission.</p>
+                    revalidated submission.
+                </p>
                 <div className="row">
                     <div className="col-md-6 mb-10">
                         <button


### PR DESCRIPTION
**High level description:**
Implements styling updates to the Release Notes Archive and Technical Notes Archive without having to migrate from markdown to HTML.

**Technical details:**
- Re-introduces the markdown injection that was removed in #1005 
- Styling based on `h4`s for dates (`####` in markdown) and `h5` for nested headings
- Fixes the Back to Top button
- Also fixes linting errors

**Link to JIRA Ticket:**
[DEV-2198](https://federal-spending-transparency.atlassian.net/browse/DEV-2198)

**Mockup**
https://bahdigital.invisionapp.com/share/69IA8EPGPCM#/295997419_BFS_USAS_Broker_DABS-FABS_Help_02A

The following are ALL required for the PR to be merged:
- [x] Code review