### PR TITLE
[local-dev-config] adding config to bypass max.gov locally

### DIFF
--- a/src/js/GlobalConstants.js
+++ b/src/js/GlobalConstants.js
@@ -4,7 +4,7 @@ export const kGlobalConstants = {
     AUTH_CALLBACK: process.env.BROKER_CALLBACK,
     PUBLIC_FILES: "",
     GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-    LOCAL: false,
+    LOCAL: (process.env.IS_LOCAL === 'true'),
     DEV: (process.env.IS_DEV === 'true'),
     PROD: (process.env.IS_DEV === 'false')
 };

--- a/webpack/webpack.dev.config.js
+++ b/webpack/webpack.dev.config.js
@@ -51,7 +51,10 @@ module.exports = merge(common, {
                     ? JSON.stringify(process.env.GA_TRACKING_ID)
                     : JSON.stringify(""),
                 CAS_ROOT: JSON.stringify("https://login.test.max.gov"),
-                IS_DEV: JSON.stringify('true')
+                IS_DEV: JSON.stringify('true'),
+                IS_LOCAL: process.env.IS_LOCAL && process.env.IS_LOCAL === 'true'
+                    ? JSON.stringify('true')
+                    : JSON.stringify('false')
             }
         })
     ]

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -76,7 +76,10 @@ module.exports = merge(common, {
                     ? JSON.stringify(process.env.GA_TRACKING_ID)
                     : JSON.stringify(""),
                 CAS_ROOT: JSON.stringify("https://login.max.gov"),
-                IS_DEV: JSON.stringify('false')
+                IS_DEV: JSON.stringify('false'),
+                IS_LOCAL: process.env.IS_LOCAL && process.env.IS_LOCAL === 'true'
+                    ? JSON.stringify('true')
+                    : JSON.stringify('false')
             }
         })
     ]


### PR DESCRIPTION
**High level description:**
Adds config for devs to use local api and bypass max.gov locally

**Technical details:**
Sets `GlobalConstants.IS_LOCAL` to env_var

**Mockup**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] @dpb-bah confirmed this works with local API
- [x] updated shell script distributed
