### PR TITLE
[dev-2334] Resetting submission state on unmount

### DIFF
--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -25,6 +25,7 @@ import * as Icons from '../SharedComponents/icons/Icons';
 
 const propTypes = {
     setSubmissionState: PropTypes.func,
+    resetSubmission: PropTypes.func,
     item: PropTypes.object,
     params: PropTypes.object,
     route: PropTypes.object,
@@ -90,6 +91,7 @@ class UploadFabsFileValidation extends React.Component {
     }
 
     componentWillUnmount() {
+        this.props.resetSubmission();
         this.isUnmounted = true;
     }
 


### PR DESCRIPTION
**High level description:**
When uploading a file and navigating back to initial page to upload another one, the previous file populated in the drag & drop area.
**Technical details:**
This was occurring because the relevant `reduxStore.submission` state was not updated on `unMount`

**Link to JIRA Ticket:**

[DEV-2334](https://federal-spending-transparency.atlassian.net/browse/DEV-2334)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [ ] Unit tests added (if applicable)
- [ ] Passes linter
