### PR TITLE
[DEV-2334] Fixing SubmissionID is not valid error

### DIFF
--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -53,7 +53,6 @@ export class UploadFabsFileValidation extends React.Component {
 
         this.state = {
             agency: "",
-            submissionID: this.props.params.submissionID ? this.props.params.submissionID : 0,
             fabsFile: {},
             cgac_code: "",
             jobResults: { fabs: {} },
@@ -75,19 +74,16 @@ export class UploadFabsFileValidation extends React.Component {
 
     componentDidMount() {
         this.isUnmounted = false;
-        if (this.state.submissionID) {
-            this.setSubmissionMetadata(this.state.submissionID);
-            this.checkFileStatus(this.state.submissionID);
+        if (this.props.params.submissionID) {
+            this.setSubmissionMetadata(this.props.params.submissionID);
+            this.checkFileStatus(this.props.params.submissionID);
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.params.submissionID !== this.state.submissionID) {
-            this.setState({
-                submissionID: nextProps.params.submissionID
-            });
-            this.setSubmissionMetadata(nextProps.params.submissionID);
-            this.checkFileStatus(nextProps.params.submissionID);
+    componentDidUpdate(prevProps) {
+        if (prevProps.params.submissionID !== this.props.params.submissionID && this.props.params.submissionID) {
+            this.setSubmissionMetadata(this.props.params.submissionID);
+            this.checkFileStatus(this.props.params.submissionID);
         }
     }
 
@@ -133,9 +129,9 @@ export class UploadFabsFileValidation extends React.Component {
     }
 
     revalidate() {
-        ReviewHelper.revalidateSubmission(this.state.submissionID, true)
+        ReviewHelper.revalidateSubmission(this.props.params.submissionID, true)
             .then(() => {
-                this.checkFileStatus(this.state.submissionID);
+                this.checkFileStatus(this.props.params.submissionID);
             })
             .catch((error) => {
                 const errMsg = error.message || "An error occurred while attempting to revalidate the submission. " +
@@ -523,7 +519,7 @@ export class UploadFabsFileValidation extends React.Component {
                 <PublishModal
                     rows={this.state.fabs_meta}
                     submit={this.submitFabs.bind(this)}
-                    submissionID={this.state.submissionID}
+                    submissionID={this.props.params.submissionID}
                     closeModal={this.closeModal.bind(this)}
                     isOpen={this.state.showPublish}
                     published={this.state.published} />


### PR DESCRIPTION
**High level description:**
Hotfix for staging where uploading new file in FABS, then going to "Upload and Validate New Submission" throws an error about the submission id.

**Technical details:**
1. Refactored `componentWillReceiveProps` to `componentDidUpdate`
2. Removed redundant `this.state.submissionID` in favor of just using `this.props.params.submissionID`
3. Added conditional to lifecycle method `componentDidUpdate` to only invoke class methods that depend on submission id when submissionID is truthy.

**Link to JIRA Ticket:**

[DEV-2334](https://federal-spending-transparency.atlassian.net/browse/DEV-2334)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
