### PR TITLE
Hotfix Dev-3117 Broker Redirect

### DIFF
--- a/src/js/containers/submission/SubmissionContainer.jsx
+++ b/src/js/containers/submission/SubmissionContainer.jsx
@@ -84,10 +84,6 @@ export class SubmissionContainer extends React.Component {
             .then((res) => {
                 let stepNumber = parseInt(res.step, 10);
                 stepNumber -= 1;
-                // check for route :type param
-                // since users can use a different type
-                // than the submissions current step
-                stepNumber = this.validateCurrentStepAndRouteType(stepNumber);
                 return this.setState({
                     isLoading: false,
                     isError: false,
@@ -100,8 +96,8 @@ export class SubmissionContainer extends React.Component {
                 this.setState({ isError: true, errorMessage: message });
             });
     }
-    // validate a user did not send a different step
-    // than the submission's current step
+    // since users can navigate via the url eg. /validateCrossFile
+    // we need to verify a user's submission has completed a step
     validateCurrentStepAndRouteType(currentStepNumber) {
         // let theStep = currentStepNumber;
         // FABs dont check anything


### PR DESCRIPTION
**High level description:**

Alisa found a bug in the broker submission page when refreshing the browser on a submission that is already completed will navigate the submission back to the first step.

**Technical details:**

Removed `validateCurrentStepAndRouteType` when getting a submission. This was useful in earlier iterations when I was still calling `getSubmission` when a user was making updates to the submission. However, once I added the `completedSteps` in state and the logic there is no reason to validate the current step in `getSubmission` considering it is only called on page load.

**Link to JIRA Ticket:**

[DEV-3117](https://federal-spending-transparency.atlassian.net/browse/DEV-3117)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
