### PR TITLE
Dev-2014 FABS Error Messaging

### DIFF
--- a/src/js/components/uploadFabsFile/UploadFabsFilePage.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFilePage.jsx
@@ -59,8 +59,8 @@ export default class UploadFabsFilePage extends React.Component {
         let showMeta = false;
         const { params } = this.props;
         if (params.submissionID !== prevProps.params.submissionID) {
-            this.props.setSubmissionId(params.submissionID);
             this.removeError();
+            this.props.setSubmissionId(params.submissionID);
         }
         if (params.submissionID && this.state.showMeta) {
             this.props.setSubmissionId(params.submissionID);


### PR DESCRIPTION
**High level description:**

Fixes a bug that will not show an error message when a user navigates from and existing FABS submission to a non existent FABS submission.

**Technical details:**

move removeError method call to before getSubmission method call in component update when ids do not match

**Link to JIRA Ticket:**

[DEV-2014](https://federal-spending-transparency.atlassian.net/browse/DEV-2014)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
