### PR TITLE
Refactor to remove componentWillMount

### DIFF
--- a/src/js/containers/addData/SubmissionGuideContainer.jsx
+++ b/src/js/containers/addData/SubmissionGuideContainer.jsx
@@ -9,10 +9,9 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { hashHistory } from 'react-router';
 
-import SubmissionGuidePage from '../../components/addData/SubmissionGuidePage';
-import * as sessionActions from '../../redux/actions/sessionActions';
-
-import * as SubmissionGuideHelper from '../../helpers/submissionGuideHelper';
+import SubmissionGuidePage from 'components/addData/SubmissionGuidePage';
+import * as sessionActions from 'redux/actions/sessionActions';
+import { setSkipGuide } from 'helpers/submissionGuideHelper';
 
 const propTypes = {
     setSkipGuide: PropTypes.func,
@@ -27,20 +26,17 @@ const defaultProps = {
 };
 
 class SubmissionGuideContainer extends React.Component {
-    componentWillMount() {
-        let forceDisplay = false;
-        if (Object.prototype.hasOwnProperty.call(this.props.location.query, 'force') &&
-            this.props.location.query.force === 'true') {
-            forceDisplay = true;
-        }
+    componentDidMount() {
+        const forceDisplay = (Object.prototype.hasOwnProperty.call(this.props.location.query, 'force') &&
+            this.props.location.query.force === 'true');
 
-        if (this.props.session.skipGuide === true && forceDisplay !== true) {
+        if (this.props.session.skipGuide && !forceDisplay) {
             this.sendToAddData();
         }
     }
 
     saveSkipGuide(skipGuide) {
-        SubmissionGuideHelper.setSkipGuide(skipGuide)
+        setSkipGuide(skipGuide)
             .then(() => {
                 // update the Redux state
                 this.props.setSkipGuide(skipGuide);

--- a/src/js/containers/help/HelpContainer.jsx
+++ b/src/js/containers/help/HelpContainer.jsx
@@ -8,9 +8,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
-import HelpPage from '../../components/help/helpPage';
-import ResourcesPage from '../../components/help/resourcesPage';
-import HistoryPage from '../../components/help/historyPage';
+import HelpPage from 'components/help/helpPage';
+import ResourcesPage from 'components/help/resourcesPage';
+import HistoryPage from 'components/help/historyPage';
 
 const propTypes = {
     route: PropTypes.object,
@@ -33,37 +33,24 @@ class HelpPageContainer extends React.Component {
         };
     }
 
-    componentWillMount() {
-        this.setHelpRoute(this.props);
-    }
-
     componentDidMount() {
-        this.checkHelpOnly();
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setHelpRoute(nextProps);
+        this.setHelpRoute();
     }
 
     componentDidUpdate(prevProps) {
         if (!_.isEqual(prevProps, this.props)) {
-            this.checkHelpOnly();
+            this.setHelpRoute();
         }
     }
 
-    setHelpRoute(incomingProps) {
-        if (incomingProps.route.type !== this.state.type || incomingProps.route.path !== this.state.path) {
+    setHelpRoute() {
+        if (this.props.route.type !== this.state.type || this.props.route.path !== this.state.path) {
             this.setState({
-                type: incomingProps.route.type,
-                path: incomingProps.route.path.toLowerCase()
+                type: this.props.route.type,
+                path: this.props.route.path.toLowerCase(),
+                helpOnly: this.props.session.user.helpOnly
             });
         }
-    }
-
-    checkHelpOnly() {
-        this.setState({
-            helpOnly: this.props.session.user.helpOnly
-        });
     }
 
     render() {


### PR DESCRIPTION
**High level description:**

Refactored two components to no longer use the deprecated React lifecycle method `componentWillMount`.

**Technical details:**

- Also updated some imports to absolute paths
- Simplified some boolean logic

**Link to JIRA Ticket:**

[DEV-3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- N/A Design review (if applicable)
- N/A Merged concurrently with Backend
- N/A Unit tests added: working on unit tests for `SubmissionGuideContainer` in a separate branch, outside the scope of this story
- [x] Passes linter
- [x] Verified cross-browser compatibility
