### PR TITLE
Dev-2850 clean up tests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,6 @@
 exclude_paths:
 - node_modules/
 - tests/
-- test/
 - public/
 - coverage/
 - cache/

--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
         // closing brackets should be aligned with the final prop (props.. />)
         "react/jsx-closing-bracket-location": [2, "after-props"],
         // downgrading to warning when using props purely within componentWillReceiveProps
-        "react/no-unused-prop-types": [1],
+        "react/no-unused-prop-types": [2],
         // also set the tab width for the max line width with a max length of 120
         "max-len": [1, 120, {"tabWidth": 4}],
         // do not allow dangling commas at the end of arrays, objects, etc.
@@ -88,7 +88,7 @@
         "no-restricted-globals": [0],
         // default prop types not required
         "react/require-default-props": [0],
-        "react/default-props-match-prop-types": [0],
+        "react/default-props-match-prop-types": [1],
         // allow object prop-type
         "react/forbid-prop-types": [1, {
             "forbid": ["any"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,6 @@
         "react/jsx-indent-props": [2, 4],
         // closing brackets should be aligned with the final prop (props.. />)
         "react/jsx-closing-bracket-location": [2, "after-props"],
-        // downgrading to warning when using props purely within componentWillReceiveProps
         "react/no-unused-prop-types": [2],
         // also set the tab width for the max line width with a max length of 120
         "max-len": [1, 120, {"tabWidth": 4}],

--- a/.gitignore
+++ b/.gitignore
@@ -32,16 +32,6 @@ build
 public
 .tern-port
 
-# Ignore Nightwatch globals and results
-test/globals.js
-test/reports
-
-# Ignore test files
-test/uploads
-
-# Ignore test bin
-test/bin
-
 *.DS_Store
 
 # Ignore Babel build cache
@@ -49,3 +39,5 @@ cache/
 
 # bash script
 broker.sh
+
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7852,23 +7852,6 @@
         }
       }
     },
-    "jasmine-reporters": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-1.1.0.tgz",
-      "integrity": "sha1-8zUIhYkMntqtEqCHxi8swZ3PZsA=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "~0.3.5"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        }
-      }
-    },
     "jest": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eventemitter2": "^1.0.3",
     "harmonize": "^1.4.4",
     "identity-obj-proxy": "^3.0.0",
-    "jasmine-reporters": "^1.0.0",
     "jest": "^24.8.0",
     "jest-cli": "^24.8.0",
     "jsdom": "^8.1.0",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -18,5 +18,4 @@ The following are ALL required for the PR to be merged:
 - [ ] Design review (if applicable)
 - [ ] Merged concurrently with [Backend#1234](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1234)
 - [ ] Unit tests added (if applicable)
-- [ ] Passes linter
 - [ ] Verified cross-browser compatibility

--- a/setup-jasmine-env.js
+++ b/setup-jasmine-env.js
@@ -1,5 +1,0 @@
-jasmine.VERBOSE = true;
-
-require('jasmine-reporters');
-var reporter = new jasmine.JUnitXmlReporter("__tests__/test-results/");
-jasmine.getEnv().addReporter(reporter);

--- a/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
@@ -4,17 +4,10 @@
 */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import * as utils from '../../helpers/util';
 
-const propTypes = {
-    active: PropTypes.bool
-};
-
-const defaultProps = {
-    active: false
-};
-
+// TODO - Lizzie: after upgrading to React 16, change this to a functional component
+// with useState
 export default class PeriodButtonWithTooltip extends React.Component {
     constructor(props) {
         super(props);
@@ -72,9 +65,5 @@ export default class PeriodButtonWithTooltip extends React.Component {
                 {tooltip}
             </li>
         );
-    };
+    }
 }
-
-
-PeriodButtonWithTooltip.propTypes = propTypes;
-PeriodButtonWithTooltip.defaultProps = defaultProps;


### PR DESCRIPTION
**High level description:**

Most of the work for this ticket was accomplished by #1111. This cleans up remaining references to the obsolete `/test` directory and updates our linter.

**Technical details:**

Upgrades the lint rule `no-unused-prop-types` from warning to error and fixes the resulting error.

**Link to JIRA Ticket:**

[DEV-2850](https://federal-spending-transparency.atlassian.net/browse/DEV-2850)

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- N/A Unit tests added
- N/A Verified cross-browser compatibility
