### PR TITLE
Dashboard redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7185,6 +7185,11 @@
       "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
       "dev": true
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "file-loader": "^3.0.1",
     "git-revision-webpack-plugin": "^3.0.3",
     "html-webpack-plugin": "^3.2.0",
+    "immutable": "^3.8.1",
     "jquery": "^3.3.1",
     "js-cookie": "^2.1.0",
     "lodash": "^4.17.15",

--- a/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
+++ b/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
@@ -101,7 +101,7 @@ AgencyFilterContainer.defaultProps = defaultProps;
 export default connect(
     (state) => ({
         agencyList: state.agencyList,
-        selectedFilters: state.dashboardFilters
+        selectedFilters: state.submissionsTableFilters
     }),
     (dispatch) => bindActionCreators(agencyActions, dispatch),
 )(AgencyFilterContainer);

--- a/src/js/containers/submissionsTable/CreatedByContainer.jsx
+++ b/src/js/containers/submissionsTable/CreatedByContainer.jsx
@@ -88,7 +88,7 @@ CreatedByContainer.defaultProps = defaultProps;
 export default connect(
     (state) => ({
         createdByList: state.createdByList,
-        selectedFilters: state.dashboardFilters
+        selectedFilters: state.submissionsTableFilters
     }),
     (dispatch) => bindActionCreators(createdByActions, dispatch),
 )(CreatedByContainer);

--- a/src/js/containers/submissionsTable/LastDateModifiedContainer.jsx
+++ b/src/js/containers/submissionsTable/LastDateModifiedContainer.jsx
@@ -58,7 +58,7 @@ LastDateModifiedContainer.defaultProps = defaultProps;
 export default connect(
     (state) => ({
         lastDateModifiedList: state.lastDateModifiedList,
-        selectedFilters: state.dashboardFilters
+        selectedFilters: state.submissionsTableFilters
     }),
     (dispatch) => bindActionCreators(lastDateModifiedActions, dispatch),
 )(LastDateModifiedContainer);

--- a/src/js/containers/submissionsTable/SubmissionsTableContainer.jsx
+++ b/src/js/containers/submissionsTable/SubmissionsTableContainer.jsx
@@ -140,8 +140,8 @@ SubmissionsTableContainer.defaultProps = defaultProps;
 export default connect(
     (state) => ({
         session: state.session,
-        stagedFilters: state.dashboardFilters,
-        appliedFilters: state.appliedDashboardFilters
+        stagedFilters: state.submissionsTableFilters,
+        appliedFilters: state.appliedSubmissionsTableFilters
     }),
     (dispatch) => bindActionCreators(combinedActions, dispatch),
 )(SubmissionsTableContainer);

--- a/src/js/redux/actions/dashboard/appliedFilterActions.js
+++ b/src/js/redux/actions/dashboard/appliedFilterActions.js
@@ -1,0 +1,23 @@
+/**
+ * appliedFilterActions.js
+ * Created by Lizzie Salita 10/02/19
+ */
+
+export const setAppliedFilterCompletion = (complete) => ({
+    complete,
+    type: 'SET_APPLIED_FILTER_COMPLETION'
+});
+
+export const setAppliedFilterEmptiness = (empty) => ({
+    empty,
+    type: 'SET_APPLIED_FILTER_EMPTINESS'
+});
+
+export const applyStagedFilters = (filters) => ({
+    filters,
+    type: 'APPLY_STAGED_FILTERS'
+});
+
+export const resetAppliedFilters = () => ({
+    type: 'CLEAR_APPLIED_FILTERS'
+});

--- a/src/js/redux/actions/dashboard/dashboardFilterActions.js
+++ b/src/js/redux/actions/dashboard/dashboardFilterActions.js
@@ -1,0 +1,19 @@
+/**
+  * dashboardFilterActions.js
+  * Created by Lizzie Salita 10/02/19
+  **/
+
+export const updateGenericFilter = (state) => ({
+    type: 'UPDATE_FILTER_SET',
+    filterType: state.type,
+    filterValue: state.value
+});
+
+export const updateFileFilter = (file) => ({
+    type: 'UPDATE_FILE_FILTER',
+    file
+});
+
+export const clearAllFilters = () => ({
+    type: 'CLEAR_FILTER_ALL'
+});

--- a/src/js/redux/actions/dashboard/dashboardFilterActions.js
+++ b/src/js/redux/actions/dashboard/dashboardFilterActions.js
@@ -15,5 +15,5 @@ export const updateFileFilter = (file) => ({
 });
 
 export const clearAllFilters = () => ({
-    type: 'CLEAR_FILTER_ALL'
+    type: 'CLEAR_DASHBOARD_FILTERS'
 });

--- a/src/js/redux/reducers/dashboard/appliedFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/appliedFiltersReducer.js
@@ -1,0 +1,33 @@
+/**
+ * appliedFiltersReducer.js
+ * Created by Lizzie Salita 10/02/19
+ */
+
+import { initialState as defaultFilters } from './dashboardFiltersReducer';
+
+export const initialState = {
+    filters: defaultFilters,
+    _empty: true,
+    _complete: true
+};
+
+export const appliedDashboardFiltersReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case 'APPLY_STAGED_FILTERS':
+            return Object.assign({}, state, {
+                filters: action.filters
+            });
+        case 'CLEAR_APPLIED_FILTERS':
+            return Object.assign({}, initialState);
+        case 'SET_APPLIED_FILTER_EMPTINESS':
+            return Object.assign({}, state, {
+                _empty: action.empty
+            });
+        case 'SET_APPLIED_FILTER_COMPLETION':
+            return Object.assign({}, state, {
+                _complete: action.complete
+            });
+        default:
+            return state;
+    }
+};

--- a/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
@@ -1,0 +1,48 @@
+/**
+ * dashboardFiltersReducer.js
+ * Created by Lizzie Salita 10/02/19
+ **/
+
+import { Set } from 'immutable';
+
+export const initialState = {
+    quarters: Set,
+    fy: Set,
+    file: 'A',
+    rules: Set
+};
+
+export const dashboardFiltersReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case 'UPDATE_FILTER_SET': {
+            let updatedSet = state[action.filterType];
+
+            const value = action.filterValue;
+
+            if (updatedSet.has(value)) {
+                updatedSet = updatedSet.delete(value);
+            }
+            else {
+                // adds the value to the set if it does not already exist
+                updatedSet = updatedSet.add(value);
+            }
+            return Object.assign({}, state, {
+                [action.filterType]: updatedSet
+            });
+        }
+
+        case 'UPDATE_FILE_FILTER': {
+            return Object.assign({}, state, {
+                file: action.file
+            });
+        }
+
+        case 'CLEAR_SEARCH_FILTER_ALL': {
+            return Object.assign({}, initialState);
+        }
+
+        default:
+            return state;
+    }
+};
+

--- a/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
@@ -6,10 +6,10 @@
 import { Set } from 'immutable';
 
 export const initialState = {
-    quarters: Set,
-    fy: Set,
+    quarters: new Set(),
+    fy: new Set(),
     file: 'A',
-    rules: Set
+    rules: new Set()
 };
 
 export const dashboardFiltersReducer = (state = initialState, action) => {
@@ -37,7 +37,7 @@ export const dashboardFiltersReducer = (state = initialState, action) => {
             });
         }
 
-        case 'CLEAR_SEARCH_FILTER_ALL': {
+        case 'CLEAR_DASHBOARD_FILTERS': {
             return Object.assign({}, initialState);
         }
 

--- a/src/js/redux/reducers/index.js
+++ b/src/js/redux/reducers/index.js
@@ -6,8 +6,10 @@ import { agencyReducer } from './agencyReducer';
 import { createdByReducer } from './createdByReducer';
 import { lastDateModifiedReducer } from './lastDateModifiedReducer';
 import { subTierAgencyReducer } from './subTierAgencyReducer';
-import { dashboardFilterReducer } from './submissionsTable/stagedFiltersReducer';
-import { appliedFiltersReducer } from './submissionsTable/appliedFiltersReducer';
+import { submissionsTableFiltersReducer } from './submissionsTable/submissionsTableFiltersReducer';
+import { appliedSubmissionsTableFiltersReducer } from './submissionsTable/appliedFiltersReducer';
+import { dashboardFiltersReducer } from './dashboard/dashboardFiltersReducer';
+import { appliedDashboardFiltersReducer } from './dashboard/appliedFiltersReducer';
 
 const appReducer = combineReducers({
     session: sessionReducer,
@@ -16,8 +18,10 @@ const appReducer = combineReducers({
     createdByList: createdByReducer,
     lastDateModifiedList: lastDateModifiedReducer,
     subTierAgencyList: subTierAgencyReducer,
-    dashboardFilters: dashboardFilterReducer,
-    appliedDashboardFilters: appliedFiltersReducer
+    submissionsTableFilters: submissionsTableFiltersReducer,
+    appliedSubmissionsTableFilters: appliedSubmissionsTableFiltersReducer,
+    dashboardFilters: dashboardFiltersReducer,
+    appliedDashboardFilters: appliedDashboardFiltersReducer
 });
 
 export default appReducer;

--- a/src/js/redux/reducers/submissionsTable/appliedFiltersReducer.js
+++ b/src/js/redux/reducers/submissionsTable/appliedFiltersReducer.js
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 8/14/18
  */
 
-import { initialState as defaultFilters } from './stagedFiltersReducer';
+import { initialState as defaultFilters } from './submissionsTableFiltersReducer';
 
 export const initialState = {
     dabs: {
@@ -16,7 +16,7 @@ export const initialState = {
     }
 };
 
-export const appliedFiltersReducer = (state = initialState, action) => {
+export const appliedSubmissionsTableFiltersReducer = (state = initialState, action) => {
     switch (action.type) {
         case 'APPLY_STAGED_FILTERS': {
             const dashboard = Object.assign({}, state[action.dashboard], {

--- a/src/js/redux/reducers/submissionsTable/submissionsTableFiltersReducer.js
+++ b/src/js/redux/reducers/submissionsTable/submissionsTableFiltersReducer.js
@@ -1,5 +1,5 @@
 /**
- * dashboardFilterReducer.js
+ * submissionsTableReducer.js
  * Created by Lizzie Salita 8/10/18
  */
 
@@ -83,7 +83,7 @@ const defaultObjectValues = {
     }
 };
 
-export const dashboardFilterReducer = (state = initialState, action) => {
+export const submissionsTableFiltersReducer = (state = initialState, action) => {
     switch (action.type) {
         case 'UPDATE_DASHBOARD_FILTER': {
             let filterObject;

--- a/tests/redux/dashboard/appliedFiltersReducer-test.js
+++ b/tests/redux/dashboard/appliedFiltersReducer-test.js
@@ -1,0 +1,84 @@
+/**
+ * appliedFiltersReducer-test.js
+ * Created by Lizzie Salita 10/3/19
+ */
+
+
+import { Set } from 'immutable';
+
+import { appliedDashboardFiltersReducer, initialState } from 'redux/reducers/dashboard/appliedFiltersReducer';
+
+describe('appliedDashboardFiltersReducer', () => {
+    it('should return the initial state by default', () => {
+        expect(
+            appliedDashboardFiltersReducer(undefined, {})
+        ).toEqual(initialState);
+    });
+
+    describe('APPLY_STAGED_FILTERS', () => {
+        it('should set the filter object to the provided object', () => {
+            const newFilters = Object.assign({}, initialState.filters, {
+                fy: new Set(['1990'])
+            });
+
+            const action = {
+                type: 'APPLY_STAGED_FILTERS',
+                filters: newFilters
+            };
+
+            const newState = appliedDashboardFiltersReducer(undefined, action);
+            expect(newState.filters.fy).toEqual(new Set(['1990']));
+        });
+    });
+
+    describe('CLEAR_APPLIED_FILTERS', () => {
+        it('should should return the initial state', () => {
+            const newFilters = Object.assign({}, initialState.filters, {
+                fy: new Set(['1990'])
+            });
+
+            const modifiedState = {
+                filters: newFilters,
+                _empty: false,
+                _complete: false
+            };
+
+            expect(modifiedState).not.toEqual(initialState);
+
+            const action = {
+                type: 'CLEAR_APPLIED_FILTERS'
+            };
+
+            const restoredState = appliedDashboardFiltersReducer(modifiedState, action);
+            expect(restoredState).toEqual(initialState);
+        });
+    });
+
+    describe('SET_APPLIED_FILTER_EMPTINESS', () => {
+        it('should set the _empty value', () => {
+            let state = appliedDashboardFiltersReducer(undefined, {});
+            expect(state._empty).toBeTruthy();
+
+            const action = {
+                type: 'SET_APPLIED_FILTER_EMPTINESS',
+                empty: false
+            };
+            state = appliedDashboardFiltersReducer(state, action);
+            expect(state._empty).toBeFalsy();
+        });
+    });
+
+    describe('SET_APPLIED_FILTER_COMPLETION', () => {
+        it('should set the _complete value', () => {
+            let state = appliedDashboardFiltersReducer(undefined, {});
+            expect(state._complete).toBeTruthy();
+
+            const action = {
+                type: 'SET_APPLIED_FILTER_COMPLETION',
+                complete: false
+            };
+            state = appliedDashboardFiltersReducer(state, action);
+            expect(state._complete).toBeFalsy();
+        });
+    });
+});

--- a/tests/redux/dashboard/dashboardFiltersReducer-test.js
+++ b/tests/redux/dashboard/dashboardFiltersReducer-test.js
@@ -1,0 +1,65 @@
+/**
+ * dashboardFiltersReducer-test.js
+ * Created by Lizzie Salita 10/03/19
+ */
+
+import { dashboardFiltersReducer, initialState } from 'redux/reducers/dashboard/dashboardFiltersReducer';
+import { Set } from 'immutable';
+
+describe('dashboardFiltersReducer', () => {
+    describe('UPDATE_FILTER_SET', () => {
+        const action = {
+            type: 'UPDATE_FILTER_SET',
+            filterType: 'quarters',
+            filterValue: 2
+        };
+
+        it('should add the value if it does not currently exist in the filter', () => {
+            const updatedState = dashboardFiltersReducer(undefined, action);
+
+            expect(updatedState.quarters).toEqual(new Set([2]));
+        });
+
+        it('should remove the value if already exists in the filter', () => {
+            const startingState = Object.assign({}, initialState, {
+                quarters: new Set([2])
+            });
+
+            const updatedState = dashboardFiltersReducer(startingState, action);
+            expect(updatedState.quarters).toEqual(new Set());
+        });
+    });
+    describe('UPDATE_FILE_FILTER', () => {
+        it('should update file filter state to the provided value', () => {
+            let state = dashboardFiltersReducer(undefined, {});
+
+            const action = {
+                type: 'UPDATE_FILE_FILTER',
+                file: 'B'
+            };
+
+            state = dashboardFiltersReducer(state, action);
+
+            expect(state.file).toEqual('B');
+        });
+    });
+    describe('CLEAR_DASHBOARD_FILTERS', () => {
+        it('should reset the dashboard filters to their initial state', () => {
+            let state = dashboardFiltersReducer(undefined, {
+                quarters: [1, 3],
+                fy: [2018, 2019],
+                file: 'A',
+                rules: ['X12', 'X34']
+            });
+
+            // Reset the filters
+            const resetAction = {
+                type: 'RESET_DASHBOARD_FILTERS'
+            };
+
+            state = dashboardFiltersReducer(state, resetAction);
+
+            expect(state).toEqual(initialState);
+        });
+    });
+});

--- a/tests/redux/submissionsTable/submissionsTableFiltersReducer-test.js
+++ b/tests/redux/submissionsTable/submissionsTableFiltersReducer-test.js
@@ -1,14 +1,14 @@
 /**
- * dashboardFilterReducer-test.js
+ * submissionsTableFiltersReducer-test.js
  * Created by Lizzie Salita 10/29/18
  */
 
-import { dashboardFilterReducer, initialState } from 'redux/reducers/submissionsTable/stagedFiltersReducer';
+import { submissionsTableFiltersReducer, initialState } from 'redux/reducers/submissionsTable/submissionsTableFiltersReducer';
 
-describe('dashboardFilterReducer', () => {
+describe('submissionsTableFiltersReducer', () => {
     describe('UPDATE_DASHBOARD_FILTER', () => {
         it('should update the filter for the given type and table to the provided value', () => {
-            let state = dashboardFilterReducer(undefined, {});
+            let state = submissionsTableFiltersReducer(undefined, {});
 
             const action = {
                 type: 'UPDATE_DASHBOARD_FILTER',
@@ -21,7 +21,7 @@ describe('dashboardFilterReducer', () => {
                 }
             };
 
-            state = dashboardFilterReducer(state, action);
+            state = submissionsTableFiltersReducer(state, action);
 
             expect(state.dabs.active.lastDateModified.startDate).toEqual("1999-01-02");
             expect(state.dabs.active.lastDateModified.endDate).toEqual("1999-03-04");
@@ -29,7 +29,7 @@ describe('dashboardFilterReducer', () => {
     });
     describe('TOGGLE_DASHBOARD_FILTER', () => {
         it('should add a value to the specified list of filters if it was not already included', () => {
-            let state = dashboardFilterReducer(undefined, {});
+            let state = submissionsTableFiltersReducer(undefined, {});
 
             const action = {
                 type: 'TOGGLE_DASHBOARD_FILTER',
@@ -42,7 +42,7 @@ describe('dashboardFilterReducer', () => {
                 }
             };
 
-            state = dashboardFilterReducer(state, action);
+            state = submissionsTableFiltersReducer(state, action);
 
             expect(state.dabs.active.createdBy).toEqual([{
                 name: 'User',
@@ -50,7 +50,7 @@ describe('dashboardFilterReducer', () => {
             }]);
         });
         it('should remove a value from the specified list of filters if it was already included', () => {
-            let state = dashboardFilterReducer(undefined, {});
+            let state = submissionsTableFiltersReducer(undefined, {});
 
             // Add the value '1'
             const action1 = {
@@ -61,7 +61,7 @@ describe('dashboardFilterReducer', () => {
                 value: '1'
             };
 
-            state = dashboardFilterReducer(state, action1);
+            state = submissionsTableFiltersReducer(state, action1);
 
             expect(state.dabs.active.submissionIds).toEqual(['1']);
 
@@ -74,7 +74,7 @@ describe('dashboardFilterReducer', () => {
                 value: '2'
             };
 
-            state = dashboardFilterReducer(state, action2);
+            state = submissionsTableFiltersReducer(state, action2);
 
             expect(state.dabs.active.submissionIds).toEqual(['1', '2']);
 
@@ -87,14 +87,14 @@ describe('dashboardFilterReducer', () => {
                 value: '1'
             };
 
-            state = dashboardFilterReducer(state, action3);
+            state = submissionsTableFiltersReducer(state, action3);
 
             expect(state.dabs.active.submissionIds).toEqual(['2']);
         });
     });
     describe('RESET_DASHBOARD_FILTERS', () => {
         it('should reset the dashboard filters to their initial state', () => {
-            let state = dashboardFilterReducer(undefined, {
+            let state = submissionsTableFiltersReducer(undefined, {
                 dabs: {
                     active: {
                         agencies: [],
@@ -116,7 +116,7 @@ describe('dashboardFilterReducer', () => {
                 type: 'RESET_DASHBOARD_FILTERS'
             };
 
-            state = dashboardFilterReducer(state, resetAction);
+            state = submissionsTableFiltersReducer(state, resetAction);
 
             expect(state).toEqual(initialState);
         });


### PR DESCRIPTION
**High level description:**
"Behind the scenes" setup for maintaining the current state of staged and applied dashboard filters. No impact to end user (yet). 

**Technical details:**
- Implements dashboard staged & applied filters Redux state, actions, and reducers
- Adds unit tests for the new reducers
- Renames Submissions Table files and functions (formerly called Submissions Dashboard) 

**Link to JIRA Ticket:**
Tangential to [DEV-3609](https://federal-spending-transparency.atlassian.net/browse/DEV-3609) /  prep work for the filter stories [DEV-3657](https://federal-spending-transparency.atlassian.net/browse/DEV-3657) through [DEV-3661](https://federal-spending-transparency.atlassian.net/browse/DEV-3661)

The following are ALL required for the PR to be merged:
- [x] #1142 merged (branched off of `ftr/dev-3609-dashboard-page`)
- [ ] Frontend review completed
- N/A Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- N/A Link to this PR in JIRA ticket