### PR TITLE
Hotfix: Sprint 91 Release Notes (fixing underscores)

### DIFF
--- a/src/help/changelog.md
+++ b/src/help/changelog.md
@@ -5,4 +5,4 @@ In this release of the Broker, we:
 * Fixed a bug on DABS where, in a few cases, the same Warning Code would be displayed on more than one line in the Warning Table and Tree Map.  While the total number of Warnings was correct, it now shows on one line for each Warning Code in all cases. In addition, historical submissions that had this issue also now display each Warning Code as one line. 
 * Fixed calculation on Review & Publish page to show correct Total File Size.
 * Updated API to return error message when attempting to upload a Monthly Submission and a range of months was set in the parameters.   
-* Updated name of Broker table submission_narrative to file_comment for internal consistency.  This resulted in new API endpoints. Previous endpoints were deprecated and scheduled for removal. API users should review API documentation.
+* Updated name of Broker table submission\_narrative to file\_comment for internal consistency.  This resulted in new API endpoints. Previous endpoints were deprecated and scheduled for removal. API users should review API documentation.

--- a/src/help/technicalHistory.md
+++ b/src/help/technicalHistory.md
@@ -2,7 +2,7 @@
 
 In this release, here is a list of technical changes that may require infrastructure or database updates, or represents additional functionality.
 
-* Added endpoint (get_comments_file) which generates a file containing all the comments related to a submission.
+* Added endpoint (get\_comments\_file) which generates a file containing all the comments related to a submission.
 * Updated the Subaward loader to link subawards to awards, specifically taking into account dashes in the award ids.
 
 #### September 6, 2019{section=technical}


### PR DESCRIPTION
Fixing the underscore formatting in the staging release notes