### PR TITLE
DEV-3598 Retain DABS submission step on refresh

### DIFF
--- a/src/js/containers/submission/SubmissionContainer.jsx
+++ b/src/js/containers/submission/SubmissionContainer.jsx
@@ -45,13 +45,7 @@ export class SubmissionContainer extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.params.type) {
-            // Refreshed the page, stay on the step indicated by the url
-            this.getSubmission(true);
-        }
-        else {
-            this.getSubmission();
-        }
+        this.getSubmission(this.props.params.type);
     }
 
     componentDidUpdate(prevProps) {
@@ -155,7 +149,7 @@ export class SubmissionContainer extends React.Component {
         let step = this.state.step;
         step += 1;
         const completedSteps = [];
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < this.state.completedSteps.length; i++) {
             completedSteps[i] = step >= i;
         }
         this.setState({ step, completedSteps }, this.updateRoute);

--- a/src/js/containers/submission/SubmissionContainer.jsx
+++ b/src/js/containers/submission/SubmissionContainer.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { hashHistory } from 'react-router';
 import { connect } from 'react-redux';
-import { reduce } from 'lodash';
 
 import * as SubmissionGuideHelper from 'helpers/submissionGuideHelper';
 import SubmissionPage from 'components/submission/SubmissionPage';
@@ -31,12 +30,12 @@ export class SubmissionContainer extends React.Component {
             errorMessage: '',
             step: 0,
             originalStep: 0,
-            completedSteps: {
-                0: false,
-                1: false,
-                2: false,
-                3: false
-            }
+            completedSteps: [
+                false,
+                false,
+                false,
+                false
+            ]
         };
 
         this.setStepAndRoute = this.setStepAndRoute.bind(this);
@@ -84,17 +83,19 @@ export class SubmissionContainer extends React.Component {
         this.setState({ isLoading: true, isError: false, errorMessage: '' });
         SubmissionGuideHelper.getSubmissionPage(this.props.params.submissionID)
             .then((res) => {
+                let stepNumber = parseInt(res.step, 10);
+                // Convert to zero-indexed step
+                stepNumber -= 1;
                 if (useCurrentStep) {
                     const step = routes.indexOf(this.props.params.type);
                     return this.setState({
                         isLoading: false,
                         isError: false,
-                        step
+                        step,
+                        originalStep: stepNumber
                     });
                 }
                 // Initial load of this submission, update the route to match the last completed step
-                let stepNumber = parseInt(res.step, 10);
-                stepNumber -= 1;
                 return this.setState({
                     isLoading: false,
                     isError: false,
@@ -111,10 +112,9 @@ export class SubmissionContainer extends React.Component {
     // since users can navigate via the url eg. /validateCrossFile
     // we need to verify a user's submission has completed a step
     validateCurrentStepAndRouteType(currentStepNumber) {
-        // let theStep = currentStepNumber;
         // FABs dont check anything
         if (currentStepNumber === 5) return currentStepNumber;
-        // get submission step from url
+        // get submission step we're tyring to access via url change
         const routeTypeParam = this.props.params.type;
         // current route step name
         const currentStepRouteType = this.currentRoute();
@@ -126,7 +126,7 @@ export class SubmissionContainer extends React.Component {
             if (newRouteIndex > this.state.originalStep) {
                 // verify this step has been completed
                 // which we will then allow the user to navigate to that step
-                if (this.state.completedSteps[newRouteIndex.toString()]) return newRouteIndex;
+                if (this.state.completedSteps[newRouteIndex]) return newRouteIndex;
                 return this.state.originalStep;
             }
             if (newRouteIndex !== -1) return newRouteIndex;
@@ -154,10 +154,10 @@ export class SubmissionContainer extends React.Component {
     nextStep() {
         let step = this.state.step;
         step += 1;
-        const completedSteps = reduce(this.state.completedSteps, (acc, value, key) => {
-            if (step.toString() === key) acc[key] = true;
-            return acc;
-        }, this.state.completedSteps);
+        const completedSteps = [];
+        for (let i = 0; i < 4; i++) {
+            completedSteps[i] = step >= i;
+        }
         this.setState({ step, completedSteps }, this.updateRoute);
     }
 

--- a/tests/containers/dabsSubmissionContainer/SubmissionContainer-test.jsx
+++ b/tests/containers/dabsSubmissionContainer/SubmissionContainer-test.jsx
@@ -24,15 +24,16 @@ describe('SubmissionContainer', () => {
             container.instance().getSubmission = getSubmission;
             await container.instance().componentDidMount();
             expect(getSubmission).toHaveBeenCalled();
+            expect(getSubmission).toHaveBeenCalledWith(undefined);
         });
-        it('should pass true to getSubmission when a step is specified in the url', () => {
+        it('should pass a truthy value to getSubmission when a step is specified in the url', () => {
             const getSubmission = jest.fn();
             container.instance().getSubmission = getSubmission;
             const newProps = { ...container.instance().props };
             newProps.params.type = 'generateEF';
             container.setProps({ ...newProps });
             container.instance().componentDidMount();
-            expect(getSubmission).toHaveBeenCalledWith(true);
+            expect(getSubmission).toHaveBeenCalledWith('generateEF');
         });
     });
     describe('componentDidUpdate', () => {

--- a/tests/containers/dabsSubmissionContainer/SubmissionContainer-test.jsx
+++ b/tests/containers/dabsSubmissionContainer/SubmissionContainer-test.jsx
@@ -15,25 +15,32 @@ jest.mock('helpers/submissionGuideHelper', () => require('./mockSubmissionGuideH
 describe('SubmissionContainer', () => {
     let container;
     beforeEach(() => {
+        jest.clearAllMocks();
         container = shallow(<SubmissionContainer {...mockProps} />);
     });
-    it('componenentDidMount, should call getSubmission on mount', async () => {
-        const getSubmission = jest.fn();
-        container.instance().getSubmission = getSubmission;
-        await container.instance().componentDidMount();
-
-        expect(getSubmission).toHaveBeenCalled();
+    describe('componentDidMount', () => {
+        it('should call getSubmission on mount', async () => {
+            const getSubmission = jest.fn();
+            container.instance().getSubmission = getSubmission;
+            await container.instance().componentDidMount();
+            expect(getSubmission).toHaveBeenCalled();
+        });
+        it('should pass true to getSubmission when a step is specified in the url', () => {
+            const getSubmission = jest.fn();
+            container.instance().getSubmission = getSubmission;
+            const newProps = { ...container.instance().props };
+            newProps.params.type = 'generateEF';
+            container.setProps({ ...newProps });
+            container.instance().componentDidMount();
+            expect(getSubmission).toHaveBeenCalledWith(true);
+        });
     });
-
-    describe('ComponentDidUpdate', () => {
+    describe('componentDidUpdate', () => {
         it('should call getSubmission if ID is updated', () => {
             const getSubmission = jest.fn();
             container.instance().getSubmission = getSubmission;
             const newProps = {
                 params: {
-                    submissionID: "20"
-                },
-                routeParams: {
                     submissionID: "20"
                 }
             };
@@ -48,9 +55,6 @@ describe('SubmissionContainer', () => {
             container.instance().setStepAndRoute = setStepAndRoute;
             const newProps = {
                 params: {
-                    submissionID: "2054"
-                },
-                routeParams: {
                     submissionID: "2054",
                     type: 'generateFiles'
                 }
@@ -81,83 +85,86 @@ describe('SubmissionContainer', () => {
             expect(fabs).toEqual(5);
         });
         it('should allow a user to navigate to a step greater than its current step', () => {
-            const newState = originalState;
+            const newState = { ...originalState }; // make a copy of the original state
             newState.completedSteps[0] = true;
             container.instance().setState(newState);
+            const newProps = { ...container.instance().props };
+            newProps.params.type = 'validateData';
+            container.setProps({ ...newProps });
             const allow = container.instance().validateCurrentStepAndRouteType(1);
             expect(allow).toEqual(1);
         });
-        it('should not allow a user to navigate to a greater step', async () => {
-            const newState = originalState;
+        it('should not allow a user to navigate to a greater step', () => {
+            const newState = { ...originalState }; // make a copy of the original state
             newState.completedSteps[0] = true;
-            const newProps = container.instance().props;
-            newProps.routeParams.type = 'generateEF';
-            await container.instance().setState(newState);
-            await container.setProps({ ...newProps });
+            const newProps = { ...container.instance().props };
+            newProps.params.type = 'generateEF';
+            container.instance().setState(newState);
+            container.setProps({ ...newProps });
             const doNotAllow = container.instance().validateCurrentStepAndRouteType(0);
             expect(doNotAllow).toEqual(0);
         });
-        it('should allow a user to navigate to a previous step', async () => {
-            const newProps = container.instance().props;
-            const newState = container.instance().state;
+        it('should allow a user to navigate to a previous step', () => {
+            const newState = { ...originalState }; // make a copy of the original state
             newState.step = 4;
             newState.originalStep = 4;
-            newProps.routeParams.type = 'generateEF';
-            await container.instance().setState({ newState });
-            container.setProps(newProps);
+            container.instance().setState({ ...newState });
+            const newProps = { ...container.instance().props };
+            newProps.params.type = 'generateEF';
+            container.setProps({ ...newProps });
             const newIndex = container.instance().validateCurrentStepAndRouteType(4);
             expect(newIndex).toEqual(3);
         });
-        it('should just return the current step number if routes are the same', async () => {
-            const newProps = container.instance().props;
-            const newState = container.instance().state;
-            newProps.routeParams.type = 'generateEF';
+        it('should just return the current step number if routes are the same', () => {
+            const newProps = { ...container.instance().props };
+            const newState = { ...container.instance().state };
+            newProps.params.type = 'generateEF';
             newState.step = 3;
             newState.originalStep = 3;
-            await container.instance().setState({ newState });
-            await container.setProps(newProps);
+            container.instance().setState({ ...newState });
+            container.setProps({ ...newProps });
             const sameRoute = container.instance().validateCurrentStepAndRouteType(3);
             expect(sameRoute).toEqual(3);
         });
     });
-
-    it('errorFromStep, should update state with message', () => {
-        const falseStatement = 'Dallas Cowboys are a great team';
-        container.instance().errorFromStep(falseStatement);
-        const { isError, errorMessage } = container.instance().state;
-        expect(isError).toEqual(true);
-        expect(errorMessage).toEqual(falseStatement);
+    describe('errorFromStep', () => {
+        it('should update state with message', () => {
+            const falseStatement = 'Dallas Cowboys are a great team';
+            container.instance().errorFromStep(falseStatement);
+            const { isError, errorMessage } = container.instance().state;
+            expect(isError).toEqual(true);
+            expect(errorMessage).toEqual(falseStatement);
+        });
     });
-    
-    it('currentRoute, should return the current states step route', () => {
-        const currentRoute = container.instance().currentRoute();
-        expect(currentRoute).toEqual('validateData');
+    describe('currentRoute', () => {
+        it('should return the current states step route', () => {
+            const currentRoute = container.instance().currentRoute();
+            expect(currentRoute).toEqual('validateData');
+        });
     });
-
-    // TODO - get this working
-    it('updateRoute, should update the route based on the current step', async () => {
-        const props = {
-            params: {
-                submissionID: "2054"
-            },
-            routeParams: {
-                submissionID: "2054"
-            }
-        };
-        container = shallow(<SubmissionContainer {...props} />);
-        const replace = jest.fn();
-        hashHistory.replace = replace;
-        container.instance().updateRoute();
-        expect(hashHistory.replace).toHaveBeenCalled();
+    describe('updateRoute', () => {
+        it('should update the route based on the current step', async () => {
+            const props = {
+                params: {
+                    submissionID: "2054"
+                }
+            };
+            container = shallow(<SubmissionContainer {...props} />);
+            const replace = jest.fn();
+            hashHistory.replace = replace;
+            container.instance().updateRoute();
+            expect(hashHistory.replace).toHaveBeenCalled();
+        });
     });
-
-    it('nextStep, should update state and call update route', () => {
-        const updateRoute = jest.fn();
-        container.instance().updateRoute = updateRoute;
-        container.instance().nextStep();
-        const { step, completedSteps } = container.instance().state;
-        expect(step).toEqual(1);
-        expect(completedSteps['1']).toEqual(true);
-        expect(updateRoute).toHaveBeenCalled();
+    describe('nextStep', () => {
+        it('should update state and call update route', () => {
+            const updateRoute = jest.fn();
+            container.instance().updateRoute = updateRoute;
+            container.instance().nextStep();
+            const { step, completedSteps } = container.instance().state;
+            expect(step).toEqual(1);
+            expect(completedSteps[1]).toEqual(true);
+            expect(updateRoute).toHaveBeenCalled();
+        });
     });
 });

--- a/tests/containers/dabsSubmissionContainer/mockData.js
+++ b/tests/containers/dabsSubmissionContainer/mockData.js
@@ -1,9 +1,6 @@
 export const mockProps = {
     params: {
         submissionID: "2054"
-    },
-    routeParams: {
-        submissionID: "2054"
     }
 };
 


### PR DESCRIPTION
**High level description:**
Fixes a bug that caused the step to change when refreshing during the DABS submission process. 

**Technical details:**
- We were making a new API call every time the component mounts, which automatically redirected to the last completed step. The solution was to check whether a step is already indicated in the url params when `componentDidMount` is invoked
- Also refactored the state property `completedSteps` into an array of booleans instead of an object keyed by indices
- Removed redundant `routeParams` prop
- Updated unit tests to prevent mutating the mocked state and props, and to account for the changes above

**Link to JIRA Ticket:**
[DEV-3598](https://federal-spending-transparency.atlassian.net/browse/DEV-3598)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket