### PR TITLE
DEV-3525 Fix FABS permissions

### DIFF
--- a/src/_scss/pages/uploadFabsFile/uploadFabsFile.scss
+++ b/src/_scss/pages/uploadFabsFile/uploadFabsFile.scss
@@ -186,7 +186,7 @@
     }
 }
 
-.us-da-disabled-button {
+button:disabled.us-da-disabled-button {
 	color: #5b616b;
 	background: #d6d7d9;
 	padding: 1rem 2rem;

--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -488,7 +488,7 @@ export class UploadFabsFileValidation extends React.Component {
                     );
                 }
             }
-            else if (PermissionsHelper.checkFabsPermissions(this.props.session)) {
+            else if (PermissionsHelper.checkFabsPublishPermissions(this.props.session)) {
                 // User has permissions to publish this unpublished submission
                 validationButton = (
                     <button className="pull-right col-xs-3 us-da-button" onClick={this.openModal.bind(this)}>

--- a/src/js/containers/router/RouterRoutes.jsx
+++ b/src/js/containers/router/RouterRoutes.jsx
@@ -13,6 +13,8 @@ import DetachedFileAContainer
 import StoreSingleton from 'redux/storeSingleton';
 import Dashboard from 'components/dashboard/DashboardPage';
 
+import { checkFabsPermissions } from 'helpers/permissionsHelper';
+
 let instance = null;
 let store = new StoreSingleton().store;
 
@@ -95,12 +97,8 @@ const checkFabsUploadPermissions = (nextState, replace) => {
     if (session.login !== "loggedIn") {
         performAutoLogin(nextState.location, replace);
     }
-    else if (!session.admin) {
-        for (let i = 0; i < session.user.affiliations.length; i++) {
-            if (session.user.affiliations[i].permission === 'fabs') {
-                return;
-            }
-        }
+    const fabsPermissions = checkFabsPermissions(session);
+    if (!fabsPermissions) {
         // if no permissions, bounce to landing
         replace('/FABSLanding');
     }

--- a/src/js/helpers/permissionsHelper.js
+++ b/src/js/helpers/permissionsHelper.js
@@ -21,13 +21,19 @@ export const checkFabsPermissions = (session) => {
     if (!session.user.affiliations || session.user.affiliations.length === 0) {
         return false;
     }
-    const aff = session.user.affiliations;
-    for (let i = 0; i < aff.length; i++) {
-        if (aff[i].permission === 'fabs') {
-            return true;
-        }
+    const { affiliations } = session.user;
+    return !!(affiliations.find((affiliation) => affiliation.permission === 'fabs' || affiliation.permission === 'editfabs'));
+};
+
+export const checkFabsPublishPermissions = (session) => {
+    if (session.admin) {
+        return true;
     }
-    return false;
+    if (!session.user.affiliations || session.user.affiliations.length === 0) {
+        return false;
+    }
+    const { affiliations } = session.user;
+    return !!(affiliations.find((affiliation) => affiliation.permission === 'fabs'));
 };
 
 export const checkAgencyPermissions = (session, agencyName) => {

--- a/src/js/helpers/permissionsHelper.js
+++ b/src/js/helpers/permissionsHelper.js
@@ -60,11 +60,8 @@ export const checkFabsAgencyPermissions = (session, agencyName) => {
     if (!session.user.affiliations || session.user.affiliations.length === 0) {
         return false;
     }
-    const aff = session.user.affiliations;
-    for (let i = 0; i < aff.length; i++) {
-        if (aff[i].agency_name === agencyName && aff[i].permission === 'fabs') {
-            return true;
-        }
-    }
-    return false;
+    const { affiliations } = session.user;
+    return !!(affiliations.find((affiliation) =>
+        affiliation.agency_name === agencyName && (affiliation.permission === 'fabs' || affiliation.permission === 'editfabs')
+    ));
 };

--- a/tests/helpers/permissionsHelper-test.js
+++ b/tests/helpers/permissionsHelper-test.js
@@ -124,5 +124,18 @@ describe('permissionsHelper', () => {
             expect(validRoleInvalidAgency).toEqual(false);
             expect(validAgencyInvalidRole).toEqual(false);
         });
+        it('should return true when session.admin is falsy and role is editfabs', () => {
+            const fabsRole = getSession(false, [getRole('test', 'editfabs')]);
+            const unauthorizedSession = getSession(false, [getRole('test', 'test')]);
+
+            const fabsSession = permissionsHelper.checkFabsAgencyPermissions(fabsRole, 'test');
+
+            const validRoleInvalidAgency = permissionsHelper.checkFabsAgencyPermissions(fabsRole, 'invalidAgencyName'); // valid role, invalid agency name
+            const validAgencyInvalidRole = permissionsHelper.checkFabsAgencyPermissions(unauthorizedSession, 'test'); // valid agency name, invalid role
+            
+            expect(fabsSession).toEqual(true);
+            expect(validRoleInvalidAgency).toEqual(false);
+            expect(validAgencyInvalidRole).toEqual(false);
+        });
     });
 });

--- a/tests/helpers/permissionsHelper-test.js
+++ b/tests/helpers/permissionsHelper-test.js
@@ -47,6 +47,42 @@ describe('permissionsHelper', () => {
             expect(fabsSession).toEqual(true);
             expect(invalidSession).toEqual(false);
         });
+        it('returns true when session.admin is falsy but role is editfabs', () => {
+            const authorizedRole = getSession(false, [getRole('test', 'editfabs')]);
+            const unauthorizedRole = getSession(false, [getRole('test', 'test')]);
+
+            const fabsSession = permissionsHelper.checkFabsPermissions(authorizedRole);
+            const invalidSession = permissionsHelper.checkFabsPermissions(unauthorizedRole);
+
+            expect(fabsSession).toEqual(true);
+            expect(invalidSession).toEqual(false);
+        });
+    });
+    describe('checkFabsPublishPermissions', () => {
+        it('should return true when admin is truthy', () => {
+            const admin = permissionsHelper.checkFabsPublishPermissions(getSession(true, []));
+            expect(admin).toEqual(true);
+        });
+        it('should return true when session.admin is falsy but role is fabs', () => {
+            const authorizedRole = getSession(false, [getRole('test', 'fabs')]);
+            const unauthorizedRole = getSession(false, [getRole('test', 'test')]);
+
+            const fabsSession = permissionsHelper.checkFabsPublishPermissions(authorizedRole);
+            const invalidSession = permissionsHelper.checkFabsPublishPermissions(unauthorizedRole);
+
+            expect(fabsSession).toEqual(true);
+            expect(invalidSession).toEqual(false);
+        });
+        it('should return false when session.admin is falsy and role is editfabs', () => {
+            const authorizedRole = getSession(false, [getRole('test', 'editfabs')]);
+            const unauthorizedRole = getSession(false, [getRole('test', 'test')]);
+
+            const fabsSession = permissionsHelper.checkFabsPublishPermissions(authorizedRole);
+            const invalidSession = permissionsHelper.checkFabsPublishPermissions(unauthorizedRole);
+
+            expect(fabsSession).toEqual(false);
+            expect(invalidSession).toEqual(false);
+        });
     });
     describe('checkAgencyPermissions', () => {
         it('returns true when admin is truthy', () => {


### PR DESCRIPTION
**High level description:**
Gives users with `editfabs` permissions the ability to do everything a `fabs` user can do, except publish. 

**Technical details:**
- Added a new helper to determine the status of the Publish button: `checkFabsPublishPermissions`, which checks for `fabs`
- Modified `checkFabsPermissions` and `checkFabsAgencyPermissions` to also accept `editfabs`
- Simplified some of the logic in the helpers by using [Array.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)

**Link to JIRA Ticket:**
[DEV-3525](https://federal-spending-transparency.atlassian.net/browse/DEV-3525)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket