### PR TITLE
DEV-3657 dashboard quarter filter

### DIFF
--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -3,6 +3,7 @@
         color: $color-gray;
         padding: rem(20);
         border-bottom: solid rem(2) $color-gray-lighter;
+        @import './filters/quarterPicker';
         .filter-sidebar__option-heading {
             font-weight: $font-bold;
             font-size: $h3-font-size;

--- a/src/_scss/pages/dashboard/filters/_quarterPicker.scss
+++ b/src/_scss/pages/dashboard/filters/_quarterPicker.scss
@@ -8,7 +8,7 @@
         padding: rem(5) 0;
 
         li.quarter-picker__list-item {
-            margin-right: rem(1);
+            margin-right: rem(2);
             margin-left: rem(1);
 
             &:first-child {

--- a/src/_scss/pages/dashboard/filters/_quarterPicker.scss
+++ b/src/_scss/pages/dashboard/filters/_quarterPicker.scss
@@ -9,6 +9,11 @@
 
         li.quarter-picker__list-item {
             margin-right: rem(1);
+            margin-left: rem(1);
+
+            &:first-child {
+                margin-left: 0;
+            }
 
             &:last-child {
                 margin-right: 0;
@@ -32,8 +37,13 @@
                     border-radius: 0 rem(30) rem(30) 0;
                 }
 
-                &:hover, &:active, &.quarter-picker__quarter_active {
+                &:active, &.quarter-picker__quarter_active {
                     background-color: $color-primary;
+                    color: $color-white;
+                }
+
+                &:hover{
+                    background-color: $color-primary-darker;
                     color: $color-white;
                 }
 

--- a/src/_scss/pages/dashboard/filters/_quarterPicker.scss
+++ b/src/_scss/pages/dashboard/filters/_quarterPicker.scss
@@ -1,0 +1,49 @@
+.quarter-picker {
+    ul.quarter-picker__list {
+        @include unstyled-list;
+        @include display(flex);
+        @include align-items(center);
+        @include flex(1 1 auto);
+
+        padding: rem(5) 0;
+
+        li.quarter-picker__list-item {
+            margin-right: rem(1);
+
+            &:last-child {
+                margin-right: 0;
+            }
+
+            button.quarter-picker__quarter {
+                @include button-unstyled;
+
+                color: $color-gray;
+                text-align: center;
+                line-height: rem(22);
+                font-weight: $font-bold;
+                background-color: $color-gray-light;
+                padding: rem(3) rem(18);
+
+                &.quarter-picker__quarter_first {
+                    border-radius: rem(30) 0 0 rem(30);
+                }
+
+                &.quarter-picker__quarter_last {
+                    border-radius: 0 rem(30) rem(30) 0;
+                }
+
+                &:hover, &:active, &.quarter-picker__quarter_active {
+                    background-color: $color-primary;
+                    color: $color-white;
+                }
+
+                &[disabled] {
+                    background-color: $color-gray-lightest;
+                    cursor: not-allowed;
+                    color: $color-gray-light;
+                    opacity: 0.90;
+                }
+            }
+        }
+    }
+}

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -12,16 +12,16 @@ import FilterSidebar from './FilterSidebar';
 
 const filters = [
     {
-        name: 'Quarter',
-        required: true,
-        component: QuarterFilterContainer,
-        description: 'Select the applicable quarter(s).'
-    },
-    {
         name: 'Fiscal Year',
         required: true,
         component: null,
         description: 'Select the applicable fiscal year(s).'
+    },
+    {
+        name: 'Quarter',
+        required: true,
+        component: QuarterFilterContainer,
+        description: 'Select the applicable quarter(s).'
     },
     {
         name: 'Files',

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import Navbar from 'components/SharedComponents/navigation/NavigationComponent';
 import Footer from 'components/SharedComponents/FooterComponent';
+import QuarterFilterContainer from 'containers/dashboard/filters/QuarterFilterContainer';
 import DashboardTab from './DashboardTab';
 import FilterSidebar from './FilterSidebar';
 
@@ -13,7 +14,7 @@ const filters = [
     {
         name: 'Quarter',
         required: true,
-        component: null,
+        component: QuarterFilterContainer,
         description: 'Select the applicable quarter(s).'
     },
     {

--- a/src/js/components/dashboard/FilterOption.jsx
+++ b/src/js/components/dashboard/FilterOption.jsx
@@ -9,8 +9,8 @@ import PropTypes from 'prop-types';
 const propTypes = {
     name: PropTypes.string,
     description: PropTypes.string,
-    required: PropTypes.bool
-    // TODO- Lizzie: add the component prop
+    required: PropTypes.bool,
+    component: PropTypes.func
 };
 
 export default class FilterOption extends React.Component {
@@ -18,6 +18,11 @@ export default class FilterOption extends React.Component {
         const required = this.props.required ? (
             <span className="filter-sidebar__option-required">Required</span>
         ) : null;
+        let component = null;
+        if (this.props.component) {
+            const Component = this.props.component;
+            component = <Component />;
+        }
         return (
             <div className="filter-sidebar__option">
                 <span className="filter-sidebar__option-name">
@@ -26,6 +31,7 @@ export default class FilterOption extends React.Component {
                 <div>
                     {this.props.description}
                 </div>
+                {component}
             </div>
         );
     }

--- a/src/js/components/dashboard/filters/QuarterButton.jsx
+++ b/src/js/components/dashboard/filters/QuarterButton.jsx
@@ -1,0 +1,46 @@
+/**
+ * QuarterButton.jsx
+ * Created by Lizzie Salita 10/15/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    disabled: PropTypes.bool,
+    active: PropTypes.bool,
+    quarter: PropTypes.number,
+    pickedQuarter: PropTypes.func
+};
+
+const QuarterButton = (props) => {
+    const clickedQuarter = (e) => {
+        e.preventDefault();
+        props.pickedQuarter(props.quarter);
+    };
+
+    let additionalClasses = '';
+    if (props.quarter === 1) {
+        additionalClasses += 'quarter-picker__quarter_first';
+    }
+    else if (props.quarter === 4) {
+        additionalClasses += 'quarter-picker__quarter_last';
+    }
+
+    if (!props.disabled && props.active) {
+        additionalClasses += ' quarter-picker__quarter_active';
+    }
+
+    return (
+        <button
+            className={`quarter-picker__quarter ${additionalClasses}`}
+            disabled={props.disabled}
+            onClick={clickedQuarter}>
+            Q{props.quarter}
+        </button>
+    );
+};
+
+
+QuarterButton.propTypes = propTypes;
+export default QuarterButton;

--- a/src/js/components/dashboard/filters/QuarterPicker.jsx
+++ b/src/js/components/dashboard/filters/QuarterPicker.jsx
@@ -18,7 +18,9 @@ export default class QuarterPicker extends React.Component {
         const quarters = [];
         for (let i = 1; i <= 4; i++) {
             quarters.push(
-                <li key={i}>
+                <li
+                    className="quarter-picker__list-item"
+                    key={i}>
                     <QuarterButton
                         quarter={i}
                         active={this.props.selectedQuarters.includes(i)}

--- a/src/js/components/dashboard/filters/QuarterPicker.jsx
+++ b/src/js/components/dashboard/filters/QuarterPicker.jsx
@@ -1,0 +1,43 @@
+/**
+ * QuarterPicker.jsx
+ * Created by Lizzie Salita 10/15/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import QuarterButton from './QuarterButton';
+
+const propTypes = {
+    selectedQuarters: PropTypes.array,
+    pickedQuarter: PropTypes.func
+};
+
+export default class QuarterPicker extends React.Component {
+    generateQuarters() {
+        const quarters = [];
+        for (let i = 1; i <= 4; i++) {
+            quarters.push(
+                <li key={i}>
+                    <QuarterButton
+                        quarter={i}
+                        active={this.props.selectedQuarters.includes(i)}
+                        pickedQuarter={this.props.pickedQuarter} />
+                </li>
+            );
+        }
+        return quarters;
+    }
+
+    render() {
+        return (
+            <div className="quarter-picker">
+                <ul className="quarter-picker__list">
+                    {this.generateQuarters()}
+                </ul>
+            </div>
+        );
+    }
+}
+
+QuarterPicker.propTypes = propTypes;

--- a/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
@@ -17,11 +17,7 @@ const propTypes = {
     selectedQuarters: PropTypes.object
 };
 
-const defaultProps = {
-    selectedQuarters: []
-};
-
-class QuarterFilterContainer extends React.Component {
+export class QuarterFilterContainer extends React.Component {
     constructor(props) {
         super(props);
 
@@ -42,7 +38,6 @@ class QuarterFilterContainer extends React.Component {
 }
 
 QuarterFilterContainer.propTypes = propTypes;
-QuarterFilterContainer.defaultProps = defaultProps;
 
 export default connect(
     (state) => ({

--- a/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
@@ -1,0 +1,52 @@
+/**
+ * QuarterFilterContainer.jsx
+ * Created by Lizzie Salita 10/15/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import * as filterActions from 'redux/actions/dashboard/dashboardFilterActions';
+
+import QuarterPicker from 'components/dashboard/filters/QuarterPicker';
+
+const propTypes = {
+    updateGenericFilter: PropTypes.func,
+    selectedQuarters: PropTypes.object
+};
+
+const defaultProps = {
+    selectedQuarters: []
+};
+
+class QuarterFilterContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.pickedQuarter = this.pickedQuarter.bind(this);
+    }
+
+    pickedQuarter(quarter) {
+        this.props.updateGenericFilter('quarters', quarter);
+    }
+
+    render() {
+        return (
+            <QuarterPicker
+                pickedQuarter={this.pickedQuarter}
+                selectedQuarters={this.props.selectedQuarters.toArray()} />
+        );
+    }
+}
+
+QuarterFilterContainer.propTypes = propTypes;
+QuarterFilterContainer.defaultProps = defaultProps;
+
+export default connect(
+    (state) => ({
+        selectedQuarters: state.dashboardFilters.quarters
+    }),
+    (dispatch) => bindActionCreators(filterActions, dispatch),
+)(QuarterFilterContainer);

--- a/src/js/redux/actions/dashboard/dashboardFilterActions.js
+++ b/src/js/redux/actions/dashboard/dashboardFilterActions.js
@@ -3,10 +3,10 @@
   * Created by Lizzie Salita 10/02/19
   **/
 
-export const updateGenericFilter = (state) => ({
+export const updateGenericFilter = (filterType, filterValue) => ({
     type: 'UPDATE_FILTER_SET',
-    filterType: state.type,
-    filterValue: state.value
+    filterType,
+    filterValue
 });
 
 export const updateFileFilter = (file) => ({

--- a/tests/containers/dashboard/filters/QuarterFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/QuarterFilterContainer-test.jsx
@@ -1,0 +1,28 @@
+/**
+ * QuarterFilterContainer-test.jsx
+ * Created by Lizzie Salita 10/16/19
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { QuarterFilterContainer } from 'containers/dashboard/filters/QuarterFilterContainer';
+import { mockActions, mockRedux } from './mockFilters';
+
+// mock the child component by replacing it with a function that returns a null element
+jest.mock('components/dashboard/filters/QuarterPicker', () => jest.fn(() => null));
+
+describe('QuarterFilterContainer', () => {
+    describe('pickedQuarter', () => {
+        it('should call the updateGenericFilter action', () => {
+            const container = shallow(<QuarterFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+
+            container.instance().pickedQuarter(4);
+
+            expect(mockActions.updateGenericFilter).toHaveBeenCalledWith('quarters', 4);
+        });
+    });
+});

--- a/tests/containers/dashboard/filters/mockFilters.js
+++ b/tests/containers/dashboard/filters/mockFilters.js
@@ -1,0 +1,9 @@
+import { initialState } from 'redux/reducers/dashboard/dashboardFiltersReducer';
+
+export const mockActions = {
+    updateGenericFilter: jest.fn()
+};
+
+export const mockRedux = {
+    selectedQuarters: initialState.quarters
+};


### PR DESCRIPTION
**High level description:**
Adds quarter picker UI to the dashboard page.

**Technical details:**
I will implement the logic to disable some quarters based on the fiscal as part of the FY filter implementation (DEV-3658)

**Link to JIRA Ticket:**
[DEV-3657](https://federal-spending-transparency.atlassian.net/browse/DEV-3657)

**Mockup**
https://bahdigital.invisionapp.com/share/7GIABMNX8MV#/296021489_Historical-Search-Monthly-Single-Data

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- N/A Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA - will demo along with FY filter
- [x] Tagged Designer in `#br-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket