### PR TITLE
DEV-3658 dashboard fiscal year filter

### DIFF
--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -1,7 +1,7 @@
 .filter-sidebar {
     .filter-sidebar__option {
         color: $color-gray;
-        padding: rem(20);
+        padding: rem(12) rem(20);
         border-bottom: solid rem(2) $color-gray-lighter;
         @import './filters/quarterPicker';
         @import './filters/fiscalYears';

--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -4,6 +4,7 @@
         padding: rem(20);
         border-bottom: solid rem(2) $color-gray-lighter;
         @import './filters/quarterPicker';
+        @import './filters/fiscalYears';
         .filter-sidebar__option-heading {
             font-weight: $font-bold;
             font-size: $h3-font-size;

--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -9,6 +9,9 @@
             font-weight: $font-bold;
             font-size: $h3-font-size;
         }
+        .filter-sidebar__option-description {
+            font-size: rem(12);
+        }
         .filter-sidebar__option-name {
             font-size: rem(18);
             font-weight: $font-semibold;

--- a/src/_scss/pages/dashboard/dashboard.scss
+++ b/src/_scss/pages/dashboard/dashboard.scss
@@ -23,11 +23,14 @@
             margin-left: rem(15);
             border-radius: rem(5);
             h2 {
-                padding: 0 rem(20);
+                padding: rem(10) rem(16) rem(3);
                 font-size: $h2-font-size;
+                margin: 0;
+                line-height: rem(38);      
             }
             hr {
-                border-top: solid rem(2) $color-gray-light;
+                border-top: solid rem(2) $color-gray-lighter;
+                margin: 0;
             }
         }
     }

--- a/src/_scss/pages/dashboard/filters/_fiscalYears.scss
+++ b/src/_scss/pages/dashboard/filters/_fiscalYears.scss
@@ -1,8 +1,10 @@
 ul.fiscal-years {
     @include unstyled-list;
-    @include display(flex);
     font-weight: $font-normal;
     padding-top: rem(15);
+    .fiscal-years__wrapper {
+        @include display(flex);
+    }
     .fiscal-years__left {
         padding-right: rem(4);
     }

--- a/src/_scss/pages/dashboard/filters/_fiscalYears.scss
+++ b/src/_scss/pages/dashboard/filters/_fiscalYears.scss
@@ -1,0 +1,3 @@
+ul.fiscal-years {
+    @include unstyled-list;
+}

--- a/src/_scss/pages/dashboard/filters/_fiscalYears.scss
+++ b/src/_scss/pages/dashboard/filters/_fiscalYears.scss
@@ -1,3 +1,27 @@
 ul.fiscal-years {
     @include unstyled-list;
+    @include display(flex);
+    font-weight: $font-normal;
+    padding-top: rem(15);
+    .fiscal-years__left {
+        padding-right: rem(4);
+    }
+    .fiscal-years__right {
+        padding-left: rem(4);
+    }
+    li.fy-option {
+        &:before {
+            display: none;
+        }
+        &:after {
+            display: none;
+        }
+        list-style-type: none;
+        .fy-option__label {
+            font-weight: $font-normal;
+            font-size: $small-font-size;
+            line-height: rem(26);
+            padding-left: rem(5);
+        }
+    }
 }

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import Navbar from 'components/SharedComponents/navigation/NavigationComponent';
 import Footer from 'components/SharedComponents/FooterComponent';
 import QuarterFilterContainer from 'containers/dashboard/filters/QuarterFilterContainer';
+import FyFilterContainer from 'containers/dashboard/filters/FyFilterContainer';
 import DashboardTab from './DashboardTab';
 import FilterSidebar from './FilterSidebar';
 
@@ -14,7 +15,7 @@ const filters = [
     {
         name: 'Fiscal Year',
         required: true,
-        component: null,
+        component: FyFilterContainer,
         description: 'Select the applicable fiscal year(s).'
     },
     {

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -31,7 +31,7 @@ const filters = [
         description: 'Select one file or cross-file.'
     },
     {
-        name: 'Rule',
+        name: 'Rules',
         required: false,
         component: null,
         description: 'Enter specific codes to filter your search.'

--- a/src/js/components/dashboard/FilterOption.jsx
+++ b/src/js/components/dashboard/FilterOption.jsx
@@ -28,7 +28,7 @@ export default class FilterOption extends React.Component {
                 <span className="filter-sidebar__option-name">
                     {this.props.name}{required}
                 </span>
-                <div>
+                <div className="filter-sidebar__option-description">
                     {this.props.description}
                 </div>
                 {component}

--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -10,7 +10,8 @@ const propTypes = {
     year: PropTypes.string,
     saveSelectedYear: PropTypes.func,
     checked: PropTypes.bool,
-    saveAllYears: PropTypes.func
+    saveAllYears: PropTypes.func,
+    disabled: PropTypes.bool
 };
 
 const defaultProps = {
@@ -68,7 +69,8 @@ export default class FiscalYear extends React.Component {
                             id={`fy${this.props.year}`}
                             value={`FY ${this.props.year}`}
                             checked={this.props.checked}
-                            onChange={this.saveYear} />
+                            onChange={this.saveYear}
+                            disabled={this.props.disabled} />
                         <span className="fy-option__label">
                             {`FY ${this.props.year - 2000}`}
                         </span>

--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -38,18 +38,18 @@ export default class FiscalYear extends React.Component {
 
         if (this.props.year === "all") {
             yearOption = (
-                <li className="fiscal-year-option-all">
+                <li className="fy-option fy-option_all">
                     <label
-                        className="fy-option-wrapper"
+                        className="fy-option__wrapper"
                         htmlFor={`fy${this.props.year}`}>
                         <input
                             type="checkbox"
-                            className="fy-option-checkbox"
+                            className="fy-option__checkbox"
                             id={`fy${this.props.year}`}
                             value="All Fiscal Years"
                             checked={this.props.checked}
                             onChange={this.allYears} />
-                        <span className="fy-option-label">
+                        <span className="fy-option__label">
                             All Fiscal Years
                         </span>
                     </label>
@@ -58,19 +58,19 @@ export default class FiscalYear extends React.Component {
         }
         else {
             yearOption = (
-                <li className="fiscal-year-option">
+                <li className="fy-option">
                     <label
-                        className="fy-option-wrapper"
+                        className="fy-option__wrapper"
                         htmlFor={`fy${this.props.year}`}>
                         <input
                             type="checkbox"
-                            className="fy-option-checkbox"
+                            className="fy-option__checkbox"
                             id={`fy${this.props.year}`}
                             value={`FY ${this.props.year}`}
                             checked={this.props.checked}
                             onChange={this.saveYear} />
-                        <span className="fy-option-label">
-                            {`FY ${this.props.year}`}
+                        <span className="fy-option__label">
+                            {`FY ${this.props.year - 2000}`}
                         </span>
                     </label>
                 </li>

--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -1,0 +1,85 @@
+/**
+ * FiscalYear.jsx
+ * Created by Lizzie Salita 10/16/19
+ **/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    year: PropTypes.string,
+    saveSelectedYear: PropTypes.func,
+    checked: PropTypes.bool,
+    saveAllYears: PropTypes.func
+};
+
+const defaultProps = {
+    checked: false
+};
+
+export default class FiscalYear extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.allYears = this.allYears.bind(this);
+        this.saveYear = this.saveYear.bind(this);
+    }
+
+    saveYear() {
+        this.props.saveSelectedYear(parseInt(this.props.year, 10));
+    }
+
+    allYears() {
+        this.props.saveAllYears();
+    }
+
+    render() {
+        let yearOption = null;
+
+        if (this.props.year === "all") {
+            yearOption = (
+                <li className="fiscal-year-option-all">
+                    <label
+                        className="fy-option-wrapper"
+                        htmlFor={`fy${this.props.year}`}>
+                        <input
+                            type="checkbox"
+                            className="fy-option-checkbox"
+                            id={`fy${this.props.year}`}
+                            value="All Fiscal Years"
+                            checked={this.props.checked}
+                            onChange={this.allYears} />
+                        <span className="fy-option-label">
+                            All Fiscal Years
+                        </span>
+                    </label>
+                </li>
+            );
+        }
+        else {
+            yearOption = (
+                <li className="fiscal-year-option">
+                    <label
+                        className="fy-option-wrapper"
+                        htmlFor={`fy${this.props.year}`}>
+                        <input
+                            type="checkbox"
+                            className="fy-option-checkbox"
+                            id={`fy${this.props.year}`}
+                            value={`FY ${this.props.year}`}
+                            checked={this.props.checked}
+                            onChange={this.saveYear} />
+                        <span className="fy-option-label">
+                            {`FY ${this.props.year}`}
+                        </span>
+                    </label>
+                </li>
+            );
+        }
+        return (
+            <div>{ yearOption }</div>
+        );
+    }
+}
+FiscalYear.propTypes = propTypes;
+FiscalYear.defaultProps = defaultProps;

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -24,17 +24,17 @@ export default class FiscalYearFilter extends React.Component {
     saveAllYears() {
         if (this.props.selectedFY.length !== this.props.allFy.length) {
             // Add years that are not yet selected
-            this.props.allFy.forEach((year) => {
-                if (!this.props.selectedFY.includes(year)) {
-                    this.props.pickedFy(year);
+            this.props.allFy.forEach((fy) => {
+                if (!this.props.selectedFY.includes(fy.year)) {
+                    this.props.pickedFy(fy.year);
                 }
             });
         }
         else {
             // Remove years that are still selected
-            this.props.allFy.forEach((year) => {
-                if (this.props.selectedFY.includes(year)) {
-                    this.props.pickedFy(year);
+            this.props.allFy.forEach((fy) => {
+                if (this.props.selectedFY.includes(fy.year)) {
+                    this.props.pickedFy(fy.year);
                 }
             });
         }
@@ -47,26 +47,27 @@ export default class FiscalYearFilter extends React.Component {
         const leftFY = [];
         const rightFY = [];
 
-        this.props.allFy.forEach((year, i) => {
+        this.props.allFy.forEach((fy, i) => {
             // determine if the checkbox should be selected based on whether the filter is already
             // staged
-            const checked = this.props.selectedFY.includes(year);
+            const checked = this.props.selectedFY.includes(fy.year);
 
             if (!checked) {
                 allFY = false;
             }
 
-            const fy = (<FiscalYear
+            const checkbox = (<FiscalYear
                 checked={checked}
-                year={`${year}`}
-                key={`filter-fy-${year}`}
+                year={`${fy.year}`}
+                key={`filter-fy-${fy.year}`}
+                disabled={fy.disabled}
                 saveSelectedYear={this.props.pickedFy} />);
 
             if (i + 1 <= leftCount) {
-                leftFY.push(fy);
+                leftFY.push(checkbox);
             }
             else {
-                rightFY.push(fy);
+                rightFY.push(checkbox);
             }
         });
 

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -42,7 +42,7 @@ export default class FiscalYearFilter extends React.Component {
 
     render() {
         let allFY = true;
-        const leftCount = Math.floor(this.props.allFy.length / 2);
+        const leftCount = Math.ceil(this.props.allFy.length / 2);
 
         const leftFY = [];
         const rightFY = [];
@@ -72,19 +72,23 @@ export default class FiscalYearFilter extends React.Component {
         });
 
         return (
-            <ul className="fiscal-years">
-                <div className="fiscal-years__left">
+            <div>
+                <ul className="fiscal-years">
                     <FiscalYear
                         checked={allFY}
                         year="all"
                         key="filter-fy-all"
                         saveAllYears={this.saveAllYears} />
-                    {leftFY}
-                </div>
-                <div className="fiscal-years__right">
-                    {rightFY}
-                </div>
-            </ul>
+                    <span className="fiscal-years__wrapper">
+                        <div className="fiscal-years__left">
+                            {leftFY}
+                        </div>
+                        <div className="fiscal-years__right">
+                            {rightFY}
+                        </div>
+                    </span>
+                </ul>
+            </div>
         );
     }
 }

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -42,7 +42,7 @@ export default class FiscalYearFilter extends React.Component {
 
     render() {
         let allFY = true;
-        const leftCount = Math.ceil(this.props.allFy.length / 2);
+        const leftCount = Math.floor(this.props.allFy.length / 2);
 
         const leftFY = [];
         const rightFY = [];
@@ -72,15 +72,15 @@ export default class FiscalYearFilter extends React.Component {
 
         return (
             <ul className="fiscal-years">
-                <FiscalYear
-                    checked={allFY}
-                    year="all"
-                    key="filter-fy-all"
-                    saveAllYears={this.saveAllYears} />
-                <div className="left-fy">
+                <div className="fiscal-years__left">
+                    <FiscalYear
+                        checked={allFY}
+                        year="all"
+                        key="filter-fy-all"
+                        saveAllYears={this.saveAllYears} />
                     {leftFY}
                 </div>
-                <div className="right-fy">
+                <div className="fiscal-years__right">
                     {rightFY}
                 </div>
             </ul>

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -1,0 +1,91 @@
+/**
+ * FiscalYearFilter.jsx
+ * Created by Lizzie Salita 10/16/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import FiscalYear from './FiscalYear';
+
+const propTypes = {
+    selectedFY: PropTypes.array,
+    pickedFy: PropTypes.func,
+    allFy: PropTypes.array
+};
+
+export default class FiscalYearFilter extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.saveAllYears = this.saveAllYears.bind(this);
+    }
+
+    saveAllYears() {
+        if (this.props.selectedFY.length !== this.props.allFy.length) {
+            // Add years that are not yet selected
+            this.props.allFy.forEach((year) => {
+                if (!this.props.selectedFY.includes(year)) {
+                    this.props.pickedFy(year);
+                }
+            });
+        }
+        else {
+            // Remove years that are still selected
+            this.props.allFy.forEach((year) => {
+                if (this.props.selectedFY.includes(year)) {
+                    this.props.pickedFy(year);
+                }
+            });
+        }
+    }
+
+    render() {
+        let allFY = true;
+        const leftCount = Math.ceil(this.props.allFy.length / 2);
+
+        const leftFY = [];
+        const rightFY = [];
+
+        this.props.allFy.forEach((year, i) => {
+            // determine if the checkbox should be selected based on whether the filter is already
+            // staged
+            const checked = this.props.selectedFY.includes(year);
+
+            if (!checked) {
+                allFY = false;
+            }
+
+            const fy = (<FiscalYear
+                checked={checked}
+                year={`${year}`}
+                key={`filter-fy-${year}`}
+                saveSelectedYear={this.props.pickedFy} />);
+
+            if (i + 1 <= leftCount) {
+                leftFY.push(fy);
+            }
+            else {
+                rightFY.push(fy);
+            }
+        });
+
+        return (
+            <ul className="fiscal-years">
+                <FiscalYear
+                    checked={allFY}
+                    year="all"
+                    key="filter-fy-all"
+                    saveAllYears={this.saveAllYears} />
+                <div className="left-fy">
+                    {leftFY}
+                </div>
+                <div className="right-fy">
+                    {rightFY}
+                </div>
+            </ul>
+        );
+    }
+}
+
+FiscalYearFilter.propTypes = propTypes;

--- a/src/js/components/dashboard/filters/QuarterPicker.jsx
+++ b/src/js/components/dashboard/filters/QuarterPicker.jsx
@@ -10,7 +10,8 @@ import QuarterButton from './QuarterButton';
 
 const propTypes = {
     selectedQuarters: PropTypes.array,
-    pickedQuarter: PropTypes.func
+    pickedQuarter: PropTypes.func,
+    disabledQuarters: PropTypes.array
 };
 
 export default class QuarterPicker extends React.Component {
@@ -23,6 +24,7 @@ export default class QuarterPicker extends React.Component {
                     key={i}>
                     <QuarterButton
                         quarter={i}
+                        disabled={this.props.disabledQuarters[i - 1]}
                         active={this.props.selectedQuarters.includes(i)}
                         pickedQuarter={this.props.pickedQuarter} />
                 </li>

--- a/src/js/containers/dashboard/filters/FyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/FyFilterContainer.jsx
@@ -38,7 +38,7 @@ export class FyFilterContainer extends React.Component {
         DashboardHelper.fetchQuarterlyRevalidationThreshold()
             .then((data) => {
                 const allFy = [];
-                for (let i = 2017; i <= data.year; i++) {
+                for (let i = data.year; i >= 2017; i--) {
                     allFy.push(i);
                 }
                 this.setState({

--- a/src/js/containers/dashboard/filters/FyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/FyFilterContainer.jsx
@@ -1,0 +1,76 @@
+/**
+ * FyFilterContainer.jsx
+ * Created by Lizzie Salita 10/16/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import * as filterActions from 'redux/actions/dashboard/dashboardFilterActions';
+import * as DashboardHelper from 'helpers/dashboardHelper';
+import FiscalYearFilter from 'components/dashboard/filters/FiscalYearFilter';
+
+const propTypes = {
+    updateGenericFilter: PropTypes.func,
+    selectedFiscalYears: PropTypes.object
+};
+
+export class FyFilterContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            quarter: 0,
+            year: 0,
+            allFy: []
+        };
+
+        this.pickedFy = this.pickedFy.bind(this);
+    }
+
+    componentDidMount() {
+        this.getLatestQuarter();
+    }
+
+    getLatestQuarter() {
+        DashboardHelper.fetchQuarterlyRevalidationThreshold()
+            .then((data) => {
+                const allFy = [];
+                for (let i = 2017; i <= data.year; i++) {
+                    allFy.push(i);
+                }
+                this.setState({
+                    quarter: data.quarter,
+                    year: data.year,
+                    allFy
+                });
+            })
+            .catch((err) => {
+                console.error(err);
+            });
+    }
+
+    pickedFy(year) {
+        this.props.updateGenericFilter('fy', year);
+    }
+
+    render() {
+        return (
+            <FiscalYearFilter
+                pickedFy={this.pickedFy}
+                selectedFY={this.props.selectedFiscalYears.toArray()}
+                allFy={this.state.allFy} />
+        );
+    }
+}
+
+FyFilterContainer.propTypes = propTypes;
+
+export default connect(
+    (state) => ({
+        selectedFiscalYears: state.dashboardFilters.fy
+    }),
+    (dispatch) => bindActionCreators(filterActions, dispatch),
+)(FyFilterContainer);

--- a/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
@@ -8,20 +8,71 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
+import * as DashboardHelper from 'helpers/dashboardHelper';
 import * as filterActions from 'redux/actions/dashboard/dashboardFilterActions';
-
 import QuarterPicker from 'components/dashboard/filters/QuarterPicker';
 
 const propTypes = {
     updateGenericFilter: PropTypes.func,
-    selectedQuarters: PropTypes.object
+    selectedFilters: PropTypes.object
 };
 
 export class QuarterFilterContainer extends React.Component {
     constructor(props) {
         super(props);
 
+        this.state = {
+            quarter: 0,
+            year: 0,
+            disabledQuarters: [false, false, false, false]
+        };
+
         this.pickedQuarter = this.pickedQuarter.bind(this);
+    }
+
+    componentDidMount() {
+        this.getLatestQuarter();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.selectedFilters.fy !== prevProps.selectedFilters.fy) {
+            this.getDisabledStatus();
+        }
+    }
+
+    getLatestQuarter() {
+        DashboardHelper.fetchQuarterlyRevalidationThreshold()
+            .then((data) => {
+                const allFy = [];
+                for (let i = data.year; i >= 2017; i--) {
+                    allFy.push(i);
+                }
+                this.setState({
+                    quarter: data.quarter,
+                    year: data.year,
+                    allFy
+                });
+            })
+            .catch((err) => {
+                console.error(err);
+            });
+    }
+
+    getDisabledStatus() {
+        const selectedFy = this.props.selectedFilters.fy.toArray();
+        if (selectedFy.length === 1) {
+            if (selectedFy[0] === 2017) {
+                this.setState({
+                    disabledQuarters: [true, false, false, false]
+                });
+            }
+            else if (selectedFy[0] === this.state.year) {
+                const disabledQuarters = this.state.disabledQuarters.map((quarter, i) => i + 1 > this.state.quarter);
+                this.setState({
+                    disabledQuarters
+                });
+            }
+        }
     }
 
     pickedQuarter(quarter) {
@@ -32,7 +83,8 @@ export class QuarterFilterContainer extends React.Component {
         return (
             <QuarterPicker
                 pickedQuarter={this.pickedQuarter}
-                selectedQuarters={this.props.selectedQuarters.toArray()} />
+                selectedQuarters={this.props.selectedFilters.quarters.toArray()}
+                disabledQuarters={this.state.disabledQuarters} />
         );
     }
 }
@@ -41,7 +93,7 @@ QuarterFilterContainer.propTypes = propTypes;
 
 export default connect(
     (state) => ({
-        selectedQuarters: state.dashboardFilters.quarters
+        selectedFilters: state.dashboardFilters
     }),
     (dispatch) => bindActionCreators(filterActions, dispatch),
 )(QuarterFilterContainer);

--- a/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
@@ -61,20 +61,25 @@ export class QuarterFilterContainer extends React.Component {
     getDisabledStatus() {
         const selectedFy = this.props.selectedFilters.fy.toArray();
         if (selectedFy.length === 1) {
-            // Reporting began Q2 2017, so disable Q1 if 2017 is the only FY selected
-            if (selectedFy[0] === 2017) {
-                this.setState({
-                    disabledQuarters: [true, false, false, false]
-                });
-            }
             // If only the current FY is selected, disable any quarters after the latest
             // possible quarter that could have been certified in the current year
-            else if (selectedFy[0] === this.state.latestYear) {
+            if (selectedFy[0] === this.state.latestYear) {
                 const disabledQuarters = this.state.disabledQuarters.map((quarter, i) => i + 1 > this.state.latestQuarter);
                 this.setState({
                     disabledQuarters
                 });
             }
+            else {
+                // Reporting began Q2 2017, so disable Q1 if 2017 is the only FY selected
+                this.setState({
+                    disabledQuarters: [selectedFy[0] === 2017, false, false, false]
+                });
+            }
+        }
+        else {
+            this.setState({
+                disabledQuarters: [false, false, false, false]
+            });
         }
     }
 

--- a/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
@@ -22,8 +22,8 @@ export class QuarterFilterContainer extends React.Component {
         super(props);
 
         this.state = {
-            quarter: 0,
-            year: 0,
+            latestQuarter: 0,
+            latestYear: 0,
             disabledQuarters: [false, false, false, false]
         };
 
@@ -48,8 +48,8 @@ export class QuarterFilterContainer extends React.Component {
                     allFy.push(i);
                 }
                 this.setState({
-                    quarter: data.quarter,
-                    year: data.year,
+                    latestQuarter: data.quarter,
+                    latestYear: data.year,
                     allFy
                 });
             })
@@ -61,13 +61,16 @@ export class QuarterFilterContainer extends React.Component {
     getDisabledStatus() {
         const selectedFy = this.props.selectedFilters.fy.toArray();
         if (selectedFy.length === 1) {
+            // Reporting began Q2 2017, so disable Q1 if 2017 is the only FY selected
             if (selectedFy[0] === 2017) {
                 this.setState({
                     disabledQuarters: [true, false, false, false]
                 });
             }
-            else if (selectedFy[0] === this.state.year) {
-                const disabledQuarters = this.state.disabledQuarters.map((quarter, i) => i + 1 > this.state.quarter);
+            // If only the current FY is selected, disable any quarters after the latest
+            // possible quarter that could have been certified in the current year
+            else if (selectedFy[0] === this.state.latestYear) {
+                const disabledQuarters = this.state.disabledQuarters.map((quarter, i) => i + 1 > this.state.latestQuarter);
                 this.setState({
                     disabledQuarters
                 });

--- a/src/js/helpers/dashboardHelper.js
+++ b/src/js/helpers/dashboardHelper.js
@@ -1,0 +1,21 @@
+import Q from 'q';
+import Request from './sessionSuperagent';
+
+import { kGlobalConstants } from '../GlobalConstants';
+
+export const fetchQuarterlyRevalidationThreshold = () => {
+    const deferred = Q.defer();
+
+    Request.get(`${kGlobalConstants.API}latest_certification_period/`)
+        .send()
+        .end((err, res) => {
+            if (err) {
+                deferred.reject(err);
+            }
+            else {
+                deferred.resolve(res.body);
+            }
+        });
+
+    return deferred.promise;
+};

--- a/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
@@ -1,0 +1,80 @@
+/**
+ * FyFilterContainer-test.jsx
+ * Created by Lizzie Salita 10/18/19
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { FyFilterContainer } from 'containers/dashboard/filters/FyFilterContainer';
+import { mockActions, mockRedux } from './mockFilters';
+
+// mock the child component by replacing it with a function that returns a null element
+jest.mock('components/dashboard/filters/FiscalYearFilter', () => jest.fn(() => null));
+
+describe('FyFilterContainer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it('should call generateAllFy when the selected quarters change', () => {
+        const container = shallow(<FyFilterContainer
+            {...mockActions}
+            {...mockRedux} />
+        );
+        const generateAllFy = jest.fn();
+        container.instance().generateAllFy = generateAllFy;
+
+        container.instance().componentDidUpdate({ selectedFilters: { quarters: [2, 3] } });
+
+        expect(generateAllFy).toHaveBeenCalled();
+    });
+    describe('pickedFy', () => {
+        it('should call the updateGenericFilter action', () => {
+            const container = shallow(<FyFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+
+            container.instance().pickedFy(2018);
+
+            expect(mockActions.updateGenericFilter).toHaveBeenCalledWith('fy', 2018);
+        });
+    });
+    describe('generateAllFy', () => {
+        it('should disable 2017 when Q1 is the only quarter selected', () => {
+            const container = shallow(<FyFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            container.instance().setState({
+                latestYear: 2019,
+                latestQuarter: 4,
+                allFy: []
+            });
+            const newProps = { ...container.instance().props };
+            newProps.selectedFilters.quarters = newProps.selectedFilters.quarters.add(1);
+            container.setProps({ ...newProps });
+            container.instance().generateAllFy();
+            // Check element at index 2 for 2017
+            expect(container.instance().state.allFy[2].disabled).toBeTruthy();
+        });
+        it('should disable the current FY when every quarter selected is in the future', () => {
+            const container = shallow(<FyFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            container.instance().setState({
+                latestYear: 2020,
+                latestQuarter: 1,
+                allFy: []
+            });
+            const newProps = { ...container.instance().props };
+            const quarters = newProps.selectedFilters.quarters.delete(1);
+            newProps.selectedFilters.quarters = quarters.add(4);
+            container.setProps({ ...newProps });
+            container.instance().generateAllFy();
+            // Check element at index 0 for 2020
+            expect(container.instance().state.allFy[0].disabled).toBeTruthy();
+        });
+    });
+});

--- a/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
@@ -16,6 +16,16 @@ describe('FyFilterContainer', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
+    it('should make an API call for the latest quarter on mount', async () => {
+        const container = shallow(<FyFilterContainer
+            {...mockActions}
+            {...mockRedux} />
+        );
+        const getLatestQuarter = jest.fn();
+        container.instance().getLatestQuarter = getLatestQuarter;
+        container.instance().componentDidMount();
+        expect(getLatestQuarter).toHaveBeenCalled();
+    });
     it('should call generateAllFy when the selected quarters change', () => {
         const container = shallow(<FyFilterContainer
             {...mockActions}

--- a/tests/containers/dashboard/filters/QuarterFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/QuarterFilterContainer-test.jsx
@@ -13,6 +13,31 @@ import { mockActions, mockRedux } from './mockFilters';
 jest.mock('components/dashboard/filters/QuarterPicker', () => jest.fn(() => null));
 
 describe('QuarterFilterContainer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it('should make an API call for the latest quarter on mount', async () => {
+        const container = shallow(<QuarterFilterContainer
+            {...mockActions}
+            {...mockRedux} />
+        );
+        const getLatestQuarter = jest.fn();
+        container.instance().getLatestQuarter = getLatestQuarter;
+        container.instance().componentDidMount();
+        expect(getLatestQuarter).toHaveBeenCalled();
+    });
+    it('should call getDisabledStatus when the selected FYs change', () => {
+        const container = shallow(<QuarterFilterContainer
+            {...mockActions}
+            {...mockRedux} />
+        );
+        const getDisabledStatus = jest.fn();
+        container.instance().getDisabledStatus = getDisabledStatus;
+
+        container.instance().componentDidUpdate({ selectedFilters: { fy: [2018, 2019] } });
+
+        expect(getDisabledStatus).toHaveBeenCalled();
+    });
     describe('pickedQuarter', () => {
         it('should call the updateGenericFilter action', () => {
             const container = shallow(<QuarterFilterContainer
@@ -23,6 +48,65 @@ describe('QuarterFilterContainer', () => {
             container.instance().pickedQuarter(4);
 
             expect(mockActions.updateGenericFilter).toHaveBeenCalledWith('quarters', 4);
+        });
+    });
+    describe('getDisabledStatus', () => {
+        it('should disable Q1 when 2017 is the only FY selected', () => {
+            const container = shallow(<QuarterFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            container.instance().setState({
+                latestYear: 2019,
+                latestQuarter: 4
+            });
+            const newProps = { ...container.instance().props };
+            newProps.selectedFilters.fy = newProps.selectedFilters.fy.add(2017);
+            container.setProps({ ...newProps });
+            container.instance().getDisabledStatus();
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2017]);
+            expect(container.instance().state.disabledQuarters[0]).toBeTruthy();
+        });
+        it('should disabled future quarters when the current FY is the only FY selected', () => {
+            const container = shallow(<QuarterFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            container.instance().setState({
+                latestYear: 2020,
+                latestQuarter: 1
+            });
+            const newProps = { ...container.instance().props };
+            const fy = newProps.selectedFilters.fy.delete(2017);
+            newProps.selectedFilters.fy = fy.add(2020);
+            container.setProps({ ...newProps });
+            container.instance().getDisabledStatus();
+
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2020]);
+            expect(container.instance().state.disabledQuarters[0]).toBeFalsy();
+            expect(container.instance().state.disabledQuarters[1]).toBeTruthy();
+            expect(container.instance().state.disabledQuarters[2]).toBeTruthy();
+            expect(container.instance().state.disabledQuarters[3]).toBeTruthy();
+        });
+        it('should enable all quarters when more than one FY is selected', () => {
+            const container = shallow(<QuarterFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            container.instance().setState({
+                latestYear: 2020,
+                latestQuarter: 1
+            });
+            const newProps = { ...container.instance().props };
+            newProps.selectedFilters.fy = newProps.selectedFilters.fy.add(2018);
+            container.setProps({ ...newProps });
+            container.instance().getDisabledStatus();
+
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2020, 2018]);
+            expect(container.instance().state.disabledQuarters[0]).toBeFalsy();
+            expect(container.instance().state.disabledQuarters[1]).toBeFalsy();
+            expect(container.instance().state.disabledQuarters[2]).toBeFalsy();
+            expect(container.instance().state.disabledQuarters[3]).toBeFalsy();
         });
     });
 });

--- a/tests/containers/dashboard/filters/mockFilters.js
+++ b/tests/containers/dashboard/filters/mockFilters.js
@@ -5,5 +5,5 @@ export const mockActions = {
 };
 
 export const mockRedux = {
-    selectedQuarters: initialState.quarters
+    selectedFilters: initialState
 };


### PR DESCRIPTION
**High level description:**
Adds a fiscal year filter to the dashboard page. 

**Technical details:**
- Makes an API call to `/latest_certification_period` endpoint from both quarter filter and fiscal year filter containers to determine how many FY checkboxes to render and to support the following logic: 
  - Disable future quarters if the current fiscal year is the only FY selected
  - Disable Q1 button if 2017 is the only FY selected
  - Disable the current fiscal year checkbox if the only quarters selected are greater than the latest quarter that could have been certified for the current FY
   - Disable FY 17 if Q1 is the only quarter currently selected

**Link to JIRA Ticket:**
[DEV-3658](https://federal-spending-transparency.atlassian.net/browse/DEV-3658)

**Mockup**
https://bahdigital.invisionapp.com/share/7GIABMNX8MV#/296021489_Historical-Search-Monthly-Single-Data

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Design review
- [x] Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Merged concurrently with [Backend #1703](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1703)
- [x] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket