### PR TITLE
Fix DEV-3658 de-select years & quarters when they become disabled

### DIFF
--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -68,7 +68,7 @@ export default class FiscalYear extends React.Component {
                             className="fy-option__checkbox"
                             id={`fy${this.props.year}`}
                             value={`FY ${this.props.year}`}
-                            checked={this.props.checked}
+                            checked={!this.props.disabled && this.props.checked}
                             onChange={this.saveYear}
                             disabled={this.props.disabled} />
                         <span className="fy-option__label">

--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -49,7 +49,8 @@ export default class FiscalYear extends React.Component {
                             id={`fy${this.props.year}`}
                             value="All Fiscal Years"
                             checked={this.props.checked}
-                            onChange={this.allYears} />
+                            onChange={this.allYears}
+                            disabled={this.props.disabled} />
                         <span className="fy-option__label">
                             All Fiscal Years
                         </span>

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -43,6 +43,7 @@ export default class FiscalYearFilter extends React.Component {
     render() {
         let allFY = true;
         const leftCount = Math.ceil(this.props.allFy.length / 2);
+        let disableAllFy = false;
 
         const leftFY = [];
         const rightFY = [];
@@ -54,6 +55,10 @@ export default class FiscalYearFilter extends React.Component {
 
             if (!checked) {
                 allFY = false;
+            }
+
+            if (fy.disabled) {
+                disableAllFy = true;
             }
 
             const checkbox = (<FiscalYear
@@ -78,6 +83,7 @@ export default class FiscalYearFilter extends React.Component {
                         checked={allFY}
                         year="all"
                         key="filter-fy-all"
+                        disabled={disableAllFy}
                         saveAllYears={this.saveAllYears} />
                     <span className="fiscal-years__wrapper">
                         <div className="fiscal-years__left">

--- a/src/js/containers/dashboard/filters/FyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/FyFilterContainer.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
@@ -37,6 +38,7 @@ export class FyFilterContainer extends React.Component {
     componentDidUpdate(prevProps) {
         if (this.props.selectedFilters.quarters !== prevProps.selectedFilters.quarters) {
             this.generateAllFy();
+            this.removeDisabledSelections();
         }
     }
 
@@ -80,6 +82,24 @@ export class FyFilterContainer extends React.Component {
         this.setState({
             allFy
         });
+    }
+
+    removeDisabledSelections() {
+        // remove FY 2017 if Q1 is the only quarter selected
+        const selectedQuarters = this.props.selectedFilters.quarters.toArray();
+        const justQ1 = (selectedQuarters.length === 1 && selectedQuarters[0] === 1);
+        const fy17Selected = this.props.selectedFilters.fy.includes(2017);
+        if (justQ1 && fy17Selected) {
+            this.pickedFy(2017);
+        }
+
+        // remove the current FY if only future quarters are selected
+        const selectedFutureQuarters = selectedQuarters.filter((quarter) => quarter > this.state.latestQuarter);
+        const justFutureQuarters = _.isEqual(selectedQuarters, selectedFutureQuarters);
+        const currentFySelected = this.props.selectedFilters.fy.includes(this.state.latestYear);
+        if (justFutureQuarters && currentFySelected) {
+            this.pickedFy(this.state.latestYear);
+        }
     }
 
     render() {

--- a/src/js/containers/dashboard/filters/FyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/FyFilterContainer.jsx
@@ -95,7 +95,7 @@ export class FyFilterContainer extends React.Component {
 
         // remove the current FY if only future quarters are selected
         const selectedFutureQuarters = selectedQuarters.filter((quarter) => quarter > this.state.latestQuarter);
-        const justFutureQuarters = _.isEqual(selectedQuarters, selectedFutureQuarters);
+        const justFutureQuarters = _.isEqual(selectedQuarters, selectedFutureQuarters) && selectedQuarters.length > 0;
         const currentFySelected = this.props.selectedFilters.fy.includes(this.state.latestYear);
         if (justFutureQuarters && currentFySelected) {
             this.pickedFy(this.state.latestYear);

--- a/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/QuarterFilterContainer.jsx
@@ -37,6 +37,7 @@ export class QuarterFilterContainer extends React.Component {
     componentDidUpdate(prevProps) {
         if (this.props.selectedFilters.fy !== prevProps.selectedFilters.fy) {
             this.getDisabledStatus();
+            this.removeDisabledSelections();
         }
     }
 
@@ -79,6 +80,26 @@ export class QuarterFilterContainer extends React.Component {
         else {
             this.setState({
                 disabledQuarters: [false, false, false, false]
+            });
+        }
+    }
+
+    removeDisabledSelections() {
+        // Remove Q1 if FY 2017 is the only FY selected
+        const selectedFy = this.props.selectedFilters.fy.toArray();
+        const justFy17 = selectedFy.length === 1 && selectedFy[0] === 2017;
+        const q1Selected = this.props.selectedFilters.quarters.includes(1);
+        if (justFy17 && q1Selected) {
+            this.pickedQuarter(1);
+        }
+
+        // Remove future quarters if only the current FY is selected
+        const justCurrentFy = selectedFy.length === 1 && selectedFy[0] === this.state.latestYear;
+        if (justCurrentFy) {
+            this.props.selectedFilters.quarters.forEach((quarter) => {
+                if (quarter > this.state.latestQuarter) {
+                    this.pickedQuarter(quarter);
+                }
             });
         }
     }

--- a/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
@@ -115,6 +115,8 @@ describe('FyFilterContainer', () => {
             newProps.selectedFilters.fy = newProps.selectedFilters.fy.add(2017);
             container.setProps({ ...newProps });
 
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2017]);
+            expect(container.instance().props.selectedFilters.quarters.toArray()).toEqual([1]);
             container.instance().removeDisabledSelections();
             expect(pickedFy).toHaveBeenCalledWith(2017);
         });
@@ -139,6 +141,8 @@ describe('FyFilterContainer', () => {
             newProps.selectedFilters.fy = fy.add(2020);
             container.setProps({ ...newProps });
 
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2020]);
+            expect(container.instance().props.selectedFilters.quarters.toArray()).toEqual([4]);
             container.instance().removeDisabledSelections();
             expect(pickedFy).toHaveBeenCalledWith(2020);
         });

--- a/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/FyFilterContainer-test.jsx
@@ -38,6 +38,18 @@ describe('FyFilterContainer', () => {
 
         expect(generateAllFy).toHaveBeenCalled();
     });
+    it('should call removeDisabledSelections when the selected quarters change', () => {
+        const container = shallow(<FyFilterContainer
+            {...mockActions}
+            {...mockRedux} />
+        );
+        const removeDisabledSelections = jest.fn();
+        container.instance().removeDisabledSelections = removeDisabledSelections;
+
+        container.instance().componentDidUpdate({ selectedFilters: { quarters: [3, 4] } });
+
+        expect(removeDisabledSelections).toHaveBeenCalled();
+    });
     describe('pickedFy', () => {
         it('should call the updateGenericFilter action', () => {
             const container = shallow(<FyFilterContainer
@@ -85,6 +97,50 @@ describe('FyFilterContainer', () => {
             container.instance().generateAllFy();
             // Check element at index 0 for 2020
             expect(container.instance().state.allFy[0].disabled).toBeTruthy();
+        });
+    });
+    describe('removeDisabledSelections', () => {
+        it('should remove FY 2017 if Q1 is the only quarter selected', () => {
+            const container = shallow(<FyFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            const pickedFy = jest.fn();
+            container.instance().pickedFy = pickedFy;
+            
+            // Set the props to FY 2017 and Q1
+            const newProps = { ...container.instance().props };
+            const quarters = newProps.selectedFilters.quarters.delete(4);
+            newProps.selectedFilters.quarters = quarters.add(1);
+            newProps.selectedFilters.fy = newProps.selectedFilters.fy.add(2017);
+            container.setProps({ ...newProps });
+
+            container.instance().removeDisabledSelections();
+            expect(pickedFy).toHaveBeenCalledWith(2017);
+        });
+        it('should remove the current FY if only future quarters are selected', () => {
+            const container = shallow(<FyFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            const pickedFy = jest.fn();
+            container.instance().pickedFy = pickedFy;
+            // Mock the latest FY and quarter
+            container.instance().setState({
+                latestYear: 2020,
+                latestQuarter: 1
+            });
+
+            // Set the props to FY 2020 and Q4
+            const newProps = { ...container.instance().props };
+            const quarters = newProps.selectedFilters.quarters.delete(1);
+            newProps.selectedFilters.quarters = quarters.add(4);
+            const fy = newProps.selectedFilters.fy.delete(2017);
+            newProps.selectedFilters.fy = fy.add(2020);
+            container.setProps({ ...newProps });
+
+            container.instance().removeDisabledSelections();
+            expect(pickedFy).toHaveBeenCalledWith(2020);
         });
     });
 });

--- a/tests/containers/dashboard/filters/QuarterFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/QuarterFilterContainer-test.jsx
@@ -14,7 +14,7 @@ jest.mock('components/dashboard/filters/QuarterPicker', () => jest.fn(() => null
 
 describe('QuarterFilterContainer', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
+        jest.restoreAllMocks();
     });
     it('should make an API call for the latest quarter on mount', async () => {
         const container = shallow(<QuarterFilterContainer
@@ -37,6 +37,18 @@ describe('QuarterFilterContainer', () => {
         container.instance().componentDidUpdate({ selectedFilters: { fy: [2018, 2019] } });
 
         expect(getDisabledStatus).toHaveBeenCalled();
+    });
+    it('should call removeDisabledSelections when the selected FYs change', () => {
+        const container = shallow(<QuarterFilterContainer
+            {...mockActions}
+            {...mockRedux} />
+        );
+        const removeDisabledSelections = jest.fn();
+        container.instance().removeDisabledSelections = removeDisabledSelections;
+
+        container.instance().componentDidUpdate({ selectedFilters: { fy: [2019, 2020] } });
+
+        expect(removeDisabledSelections).toHaveBeenCalled();
     });
     describe('pickedQuarter', () => {
         it('should call the updateGenericFilter action', () => {
@@ -107,6 +119,56 @@ describe('QuarterFilterContainer', () => {
             expect(container.instance().state.disabledQuarters[1]).toBeFalsy();
             expect(container.instance().state.disabledQuarters[2]).toBeFalsy();
             expect(container.instance().state.disabledQuarters[3]).toBeFalsy();
+        });
+    });
+    describe('removeDisabledSelections', () => {
+        it('should remove Q1 if FY 17 is the only year selected', () => {
+            const container = shallow(<QuarterFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            const pickedQuarter = jest.fn();
+            container.instance().pickedQuarter = pickedQuarter;
+            
+            // Set the props to FY 2017 and Q1
+            const newProps = { ...container.instance().props };
+            let fy = newProps.selectedFilters.fy.delete(2018);
+            fy = fy.delete(2020);
+            fy = fy.delete(2018);
+            newProps.selectedFilters.fy = fy.add(2017);
+            newProps.selectedFilters.quarters = newProps.selectedFilters.quarters.add(1);
+            container.setProps({ ...newProps });
+
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2017]);
+            expect(container.instance().props.selectedFilters.quarters.toArray()).toEqual([1]);
+            container.instance().removeDisabledSelections();
+            expect(pickedQuarter).toHaveBeenCalledWith(1);
+        });
+        it('should remove the current FY if only future quarters are selected', () => {
+            const container = shallow(<QuarterFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+            const pickedQuarter = jest.fn();
+            container.instance().pickedQuarter = pickedQuarter;
+            // Mock the latest FY and quarter
+            container.instance().setState({
+                latestYear: 2020,
+                latestQuarter: 1
+            });
+
+            // Set the props to FY 2020 and Q4
+            const newProps = { ...container.instance().props };
+            const quarters = newProps.selectedFilters.quarters.delete(1);
+            newProps.selectedFilters.quarters = quarters.add(4);
+            const fy = newProps.selectedFilters.fy.delete(2017);
+            newProps.selectedFilters.fy = fy.add(2020);
+            container.setProps({ ...newProps });
+
+            expect(container.instance().props.selectedFilters.fy.toArray()).toEqual([2020]);
+            expect(container.instance().props.selectedFilters.quarters.toArray()).toEqual([4]);
+            container.instance().removeDisabledSelections();
+            expect(pickedQuarter).toHaveBeenCalledWith(4);
         });
     });
 });


### PR DESCRIPTION
**High level description:**
- Unchecks and clears fiscal years when they become disabled.
- Deselects and clears quarters when they become disabled.
- Disables the "All Fiscal Years" checkbox when any FY is disabled

**Link to JIRA Ticket:**

[DEV-3658](https://federal-spending-transparency.atlassian.net/browse/DEV-3658) (Failed test)

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Link to this PR in JIRA ticket