### PR TITLE
DEV-3757 warning tooltips

### DIFF
--- a/src/_scss/components/tooltip/_warningTooltip.scss
+++ b/src/_scss/components/tooltip/_warningTooltip.scss
@@ -1,0 +1,54 @@
+.warning-tooltip {
+    position: absolute;
+    width: rem(400);
+    margin-left: rem(35);
+    margin-top: rem(-40);
+
+    .warning-content {
+        @include display(flex);
+        @include justify-content(center);
+        @include align-items(center);
+        position: relative;
+
+        background-color: $color-secondary-lightest;
+        border: 1px solid $color-secondary-light;
+        box-shadow: $box-shadow;
+
+        padding: rem(10);
+
+        .icon {
+            @include flex(0 0 auto);
+            width: rem(30);
+            height: rem(30);
+            margin-right: rem(10);
+
+            svg {
+                fill: $color-secondary;
+                width: rem(30);
+                height: rem(30);                
+            }
+        }
+
+        .message {
+            @include flex(1 1 auto);
+            text-align: left;
+            color: $color-base;
+            font-size: $small-font-size;
+            font-weight: normal;
+        }
+
+        // inherit from the standard tooltip arrow style
+        $color-tooltip-border: $color-secondary-light;
+        @import "components/tooltip/_arrow";
+        .tooltip-pointer {
+            // override the coloring
+            &:after {
+                background: $color-secondary-lightest;
+            }
+
+            &.left {
+                top: rem(20);
+            }
+        }
+    }
+}

--- a/src/_scss/pages/dashboard/dashboard.scss
+++ b/src/_scss/pages/dashboard/dashboard.scss
@@ -1,5 +1,6 @@
 .usa-da-dashboard-page {
-    @import "../../layouts/content/content";
+    @import '../../layouts/content/content';
+    @import '../../components/tooltip/warningTooltip';
     @include contentLayout;
     .display-2 {
         padding-top: rem(24);

--- a/src/_scss/pages/dashboard/filters/_fiscalYears.scss
+++ b/src/_scss/pages/dashboard/filters/_fiscalYears.scss
@@ -1,29 +1,36 @@
-ul.fiscal-years {
-    @include unstyled-list;
-    font-weight: $font-normal;
-    padding-top: rem(15);
-    .fiscal-years__wrapper {
-        @include display(flex);
-    }
-    .fiscal-years__left {
-        padding-right: rem(4);
-    }
-    .fiscal-years__right {
-        padding-left: rem(4);
-    }
-    li.fy-option {
-        &:before {
-            display: none;
+.fiscal-years {
+    ul.fiscal-years-list {
+        @include unstyled-list;
+        font-weight: $font-normal;
+        padding-top: rem(15);
+        .fiscal-years__wrapper {
+            @include display(flex);
         }
-        &:after {
-            display: none;
+        .fiscal-years__left {
+            padding-right: rem(4);
         }
-        list-style-type: none;
-        .fy-option__label {
-            font-weight: $font-normal;
-            font-size: $small-font-size;
-            line-height: rem(26);
-            padding-left: rem(5);
+        .fiscal-years__right {
+            padding-left: rem(4);
         }
+        li.fy-option {
+            &:before {
+                display: none;
+            }
+            &:after {
+                display: none;
+            }
+            list-style-type: none;
+            .fy-option__label {
+                font-weight: $font-normal;
+                font-size: $small-font-size;
+                line-height: rem(26);
+                padding-left: rem(5);
+            }
+        }
+    }
+    .warning-tooltip {
+        // space the tooltip to the right of the FY checkboxes
+        margin-left: rem(125);
+        margin-top: rem(-60);
     }
 }

--- a/src/_scss/pages/dashboard/filters/_quarterPicker.scss
+++ b/src/_scss/pages/dashboard/filters/_quarterPicker.scss
@@ -1,4 +1,9 @@
 .quarter-picker {
+    .warning-tooltip {
+        // space the tooltip to the right of the quarter buttons
+        margin-left: rem(230);
+        margin-top: rem(-50);
+    }
     ul.quarter-picker__list {
         @include unstyled-list;
         @include display(flex);
@@ -47,7 +52,7 @@
                     color: $color-white;
                 }
 
-                &[disabled] {
+                &.quarter-picker__quarter_disabled {
                     background-color: $color-gray-lightest;
                     cursor: not-allowed;
                     color: $color-gray-light;

--- a/src/js/components/SharedComponents/WarningTooltip.jsx
+++ b/src/js/components/SharedComponents/WarningTooltip.jsx
@@ -1,0 +1,30 @@
+/**
+ * WarningTooltip.jsx
+ * Created by Lizzie Salita 10/26/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ExclamationTriangle } from 'components/SharedComponents/icons/Icons';
+
+
+const propTypes = {
+    message: PropTypes.string
+};
+
+const WarningTooltip = (props) => (
+    <div className="warning-tooltip">
+        <div className="warning-content">
+            <div className="tooltip-pointer left" />
+            <div className="icon">
+                <ExclamationTriangle alt="Warning" />
+            </div>
+            <div className="message">
+                {props.message}
+            </div>
+        </div>
+    </div>
+);
+
+WarningTooltip.propTypes = propTypes;
+export default WarningTooltip;

--- a/src/js/components/SharedComponents/WarningTooltip.jsx
+++ b/src/js/components/SharedComponents/WarningTooltip.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ExclamationTriangle } from 'components/SharedComponents/icons/Icons';
 
-
 const propTypes = {
     message: PropTypes.string
 };

--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -11,7 +11,8 @@ const propTypes = {
     saveSelectedYear: PropTypes.func,
     checked: PropTypes.bool,
     saveAllYears: PropTypes.func,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    toggleTooltip: PropTypes.func
 };
 
 const defaultProps = {
@@ -24,6 +25,18 @@ export default class FiscalYear extends React.Component {
 
         this.allYears = this.allYears.bind(this);
         this.saveYear = this.saveYear.bind(this);
+        this.onMouseLeave = this.onMouseLeave.bind(this);
+        this.onMouseEnter = this.onMouseEnter.bind(this);
+    }
+
+    onMouseEnter() {
+        if (this.props.disabled) {
+            this.props.toggleTooltip(this.props.year);
+        }
+    }
+
+    onMouseLeave() {
+        this.props.toggleTooltip('');
     }
 
     saveYear() {
@@ -70,7 +83,11 @@ export default class FiscalYear extends React.Component {
                             value={`FY ${this.props.year}`}
                             checked={this.props.checked}
                             onChange={this.saveYear}
-                            disabled={this.props.disabled} />
+                            disabled={this.props.disabled}
+                            onMouseEnter={this.onMouseEnter}
+                            onFocus={this.onMouseEnter}
+                            onMouseLeave={this.onMouseLeave}
+                            onBlur={this.onMouseLeave} />
                         <span className="fy-option__label">
                             {`FY ${this.props.year - 2000}`}
                         </span>

--- a/src/js/components/dashboard/filters/FiscalYear.jsx
+++ b/src/js/components/dashboard/filters/FiscalYear.jsx
@@ -72,7 +72,10 @@ export default class FiscalYear extends React.Component {
         }
         else {
             yearOption = (
-                <li className="fy-option">
+                <li
+                    className="fy-option"
+                    onMouseEnter={this.onMouseEnter}
+                    onMouseLeave={this.onMouseLeave}>
                     <label
                         className="fy-option__wrapper"
                         htmlFor={`fy${this.props.year}`}>
@@ -83,11 +86,7 @@ export default class FiscalYear extends React.Component {
                             value={`FY ${this.props.year}`}
                             checked={this.props.checked}
                             onChange={this.saveYear}
-                            disabled={this.props.disabled}
-                            onMouseEnter={this.onMouseEnter}
-                            onFocus={this.onMouseEnter}
-                            onMouseLeave={this.onMouseLeave}
-                            onBlur={this.onMouseLeave} />
+                            disabled={this.props.disabled} />
                         <span className="fy-option__label">
                             {`FY ${this.props.year - 2000}`}
                         </span>

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -25,11 +25,13 @@ export default class FiscalYearFilter extends React.Component {
         this.saveAllYears = this.saveAllYears.bind(this);
         this.toggleTooltip = this.toggleTooltip.bind(this);
     }
+
     componentDidUpdate(prevProps) {
         if (this.props.selectedFY !== prevProps.selectedFY) {
             this.toggleTooltip('');
         }
     }
+
     saveAllYears() {
         if (this.props.selectedFY.length !== this.props.allFy.length) {
             // Add years that are not yet selected
@@ -48,6 +50,7 @@ export default class FiscalYearFilter extends React.Component {
             });
         }
     }
+
     toggleTooltip(showTooltip) {
         if (showTooltip !== this.state.showTooltip) {
             this.setState({

--- a/src/js/components/dashboard/filters/FiscalYearFilter.jsx
+++ b/src/js/components/dashboard/filters/FiscalYearFilter.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import WarningTooltip from 'components/SharedComponents/WarningTooltip';
 import FiscalYear from './FiscalYear';
 
 const propTypes = {
@@ -18,9 +18,18 @@ export default class FiscalYearFilter extends React.Component {
     constructor(props) {
         super(props);
 
-        this.saveAllYears = this.saveAllYears.bind(this);
-    }
+        this.state = {
+            showTooltip: ''
+        };
 
+        this.saveAllYears = this.saveAllYears.bind(this);
+        this.toggleTooltip = this.toggleTooltip.bind(this);
+    }
+    componentDidUpdate(prevProps) {
+        if (this.props.selectedFY !== prevProps.selectedFY) {
+            this.toggleTooltip('');
+        }
+    }
     saveAllYears() {
         if (this.props.selectedFY.length !== this.props.allFy.length) {
             // Add years that are not yet selected
@@ -36,6 +45,13 @@ export default class FiscalYearFilter extends React.Component {
                 if (this.props.selectedFY.includes(fy.year)) {
                     this.props.pickedFy(fy.year);
                 }
+            });
+        }
+    }
+    toggleTooltip(showTooltip) {
+        if (showTooltip !== this.state.showTooltip) {
+            this.setState({
+                showTooltip
             });
         }
     }
@@ -61,7 +77,8 @@ export default class FiscalYearFilter extends React.Component {
                 year={`${fy.year}`}
                 key={`filter-fy-${fy.year}`}
                 disabled={fy.disabled}
-                saveSelectedYear={this.props.pickedFy} />);
+                saveSelectedYear={this.props.pickedFy}
+                toggleTooltip={this.toggleTooltip} />);
 
             if (i + 1 <= leftCount) {
                 leftFY.push(checkbox);
@@ -71,14 +88,19 @@ export default class FiscalYearFilter extends React.Component {
             }
         });
 
+        let message = 'The submission period has yet to open. Please search for a submission period that has closed.';
+        if (this.state.showTooltip === '2017') {
+            message = 'There is no data available for this year. We began recording data in Q2 of FY 17.';
+        }
         return (
-            <div>
-                <ul className="fiscal-years">
+            <div className="fiscal-years">
+                <ul className="fiscal-years-list">
                     <FiscalYear
                         checked={allFY}
                         year="all"
                         key="filter-fy-all"
-                        saveAllYears={this.saveAllYears} />
+                        saveAllYears={this.saveAllYears}
+                        toggleTooltip={this.toggleTooltip} />
                     <span className="fiscal-years__wrapper">
                         <div className="fiscal-years__left">
                             {leftFY}
@@ -88,6 +110,7 @@ export default class FiscalYearFilter extends React.Component {
                         </div>
                     </span>
                 </ul>
+                {this.state.showTooltip && <WarningTooltip message={message} />}
             </div>
         );
     }

--- a/src/js/components/dashboard/filters/QuarterButton.jsx
+++ b/src/js/components/dashboard/filters/QuarterButton.jsx
@@ -5,54 +5,45 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Tooltip from 'components/SharedComponents/WarningTooltip';
 
 const propTypes = {
     disabled: PropTypes.bool,
     active: PropTypes.bool,
     quarter: PropTypes.number,
-    pickedQuarter: PropTypes.func
+    pickedQuarter: PropTypes.func,
+    toggleTooltip: PropTypes.func
 };
 
 export default class QuarterButton extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = {
-            showTooltip: false
-        };
-
         this.onMouseLeave = this.onMouseLeave.bind(this);
         this.onMouseEnter = this.onMouseEnter.bind(this);
+        this.clickedQuarter = this.clickedQuarter.bind(this);
     }
 
     onMouseEnter() {
         if (this.props.disabled) {
-            this.setState({
-                showTooltip: true
-            });
+            this.props.toggleTooltip(this.props.quarter);
         }
     }
 
     onMouseLeave() {
-        if (this.state.showTooltip) {
-            this.setState({
-                showTooltip: false
-            });
-        }
+        this.props.toggleTooltip(0);
     }
 
     clickedQuarter(e) {
         e.preventDefault();
-        this.props.pickedQuarter(this.props.quarter);
+        if (!this.props.disabled) {
+            this.props.pickedQuarter(this.props.quarter);
+        }
     }
 
     render() {
-        let additionalClasses = '';
-        let tooltipMessage = 'The submission period has yet to open. Please search for a submission period that has closed.';
+        let additionalClasses = this.props.disabled ? 'quarter-picker__quarter_disabled ' : '';
         if (this.props.quarter === 1) {
             additionalClasses += 'quarter-picker__quarter_first';
-            tooltipMessage = 'There is no data available for this quarter. We began recording data in Q2 of FY 17.';
         }
         else if (this.props.quarter === 4) {
             additionalClasses += 'quarter-picker__quarter_last';
@@ -63,16 +54,18 @@ export default class QuarterButton extends React.Component {
         }
 
         return (
+            // Use CSS class and aria-disabled rather than disabled html property
+            // so that the disabled buttons are still focusable to display
+            // the warning tooltip
             <button
                 className={`quarter-picker__quarter ${additionalClasses}`}
-                disabled={this.props.disabled}
                 onClick={this.clickedQuarter}
                 onMouseEnter={this.onMouseEnter}
                 onFocus={this.onMouseEnter}
                 onMouseLeave={this.onMouseLeave}
-                onBlur={this.onMouseLeave}>
+                onBlur={this.onMouseLeave}
+                aria-disabled={this.props.disabled}>
                 Q{this.props.quarter}
-                {this.state.showTooltip && <Tooltip message={tooltipMessage} />}
             </button>
         );
     }

--- a/src/js/components/dashboard/filters/QuarterButton.jsx
+++ b/src/js/components/dashboard/filters/QuarterButton.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from 'components/SharedComponents/WarningTooltip';
 
 const propTypes = {
     disabled: PropTypes.bool,
@@ -13,34 +14,69 @@ const propTypes = {
     pickedQuarter: PropTypes.func
 };
 
-const QuarterButton = (props) => {
-    const clickedQuarter = (e) => {
+export default class QuarterButton extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showTooltip: false
+        };
+
+        this.onMouseLeave = this.onMouseLeave.bind(this);
+        this.onMouseEnter = this.onMouseEnter.bind(this);
+    }
+
+    onMouseEnter() {
+        if (this.props.disabled) {
+            this.setState({
+                showTooltip: true
+            });
+        }
+    }
+
+    onMouseLeave() {
+        if (this.state.showTooltip) {
+            this.setState({
+                showTooltip: false
+            });
+        }
+    }
+
+    clickedQuarter(e) {
         e.preventDefault();
-        props.pickedQuarter(props.quarter);
-    };
-
-    let additionalClasses = '';
-    if (props.quarter === 1) {
-        additionalClasses += 'quarter-picker__quarter_first';
-    }
-    else if (props.quarter === 4) {
-        additionalClasses += 'quarter-picker__quarter_last';
+        this.props.pickedQuarter(this.props.quarter);
     }
 
-    if (!props.disabled && props.active) {
-        additionalClasses += ' quarter-picker__quarter_active';
-    }
+    render() {
+        let additionalClasses = '';
+        let tooltipMessage = 'The submission period has yet to open. Please search for a submission period that has closed.';
+        if (this.props.quarter === 1) {
+            additionalClasses += 'quarter-picker__quarter_first';
+            tooltipMessage = 'There is no data available for this quarter. We began recording data in Q2 of FY 17.';
+        }
+        else if (this.props.quarter === 4) {
+            additionalClasses += 'quarter-picker__quarter_last';
+        }
 
-    return (
-        <button
-            className={`quarter-picker__quarter ${additionalClasses}`}
-            disabled={props.disabled}
-            onClick={clickedQuarter}>
-            Q{props.quarter}
-        </button>
-    );
-};
+        if (!this.props.disabled && this.props.active) {
+            additionalClasses += ' quarter-picker__quarter_active';
+        }
+
+        return (
+            <button
+                className={`quarter-picker__quarter ${additionalClasses}`}
+                disabled={this.props.disabled}
+                onClick={this.clickedQuarter}
+                onMouseEnter={this.onMouseEnter}
+                onFocus={this.onMouseEnter}
+                onMouseLeave={this.onMouseLeave}
+                onBlur={this.onMouseLeave}>
+                Q{this.props.quarter}
+                {this.state.showTooltip && <Tooltip message={tooltipMessage} />}
+            </button>
+        );
+    }
+}
 
 
 QuarterButton.propTypes = propTypes;
-export default QuarterButton;

--- a/src/js/components/dashboard/filters/QuarterPicker.jsx
+++ b/src/js/components/dashboard/filters/QuarterPicker.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import WarningTooltip from 'components/SharedComponents/WarningTooltip';
 import QuarterButton from './QuarterButton';
 
 const propTypes = {
@@ -15,6 +15,27 @@ const propTypes = {
 };
 
 export default class QuarterPicker extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showTooltip: 0
+        };
+
+        this.toggleTooltip = this.toggleTooltip.bind(this);
+    }
+    componentDidUpdate(prevProps) {
+        if (this.props.selectedQuarters !== prevProps.selectedQuarters) {
+            this.toggleTooltip(0);
+        }
+    }
+    toggleTooltip(showTooltip) {
+        if (showTooltip !== this.state.showTooltip) {
+            this.setState({
+                showTooltip
+            });
+        }
+    }
     generateQuarters() {
         const quarters = [];
         for (let i = 1; i <= 4; i++) {
@@ -26,7 +47,8 @@ export default class QuarterPicker extends React.Component {
                         quarter={i}
                         disabled={this.props.disabledQuarters[i - 1]}
                         active={this.props.selectedQuarters.includes(i)}
-                        pickedQuarter={this.props.pickedQuarter} />
+                        pickedQuarter={this.props.pickedQuarter}
+                        toggleTooltip={this.toggleTooltip} />
                 </li>
             );
         }
@@ -34,11 +56,16 @@ export default class QuarterPicker extends React.Component {
     }
 
     render() {
+        let message = 'The submission period has yet to open. Please search for a submission period that has closed.';
+        if (this.state.showTooltip === 1) {
+            message = 'There is no data available for this quarter. We began recording data in Q2 of FY 17.';
+        }
         return (
             <div className="quarter-picker">
                 <ul className="quarter-picker__list">
                     {this.generateQuarters()}
                 </ul>
+                {this.state.showTooltip !== 0 && <WarningTooltip message={message} />}
             </div>
         );
     }

--- a/src/js/components/dashboard/filters/QuarterPicker.jsx
+++ b/src/js/components/dashboard/filters/QuarterPicker.jsx
@@ -24,11 +24,13 @@ export default class QuarterPicker extends React.Component {
 
         this.toggleTooltip = this.toggleTooltip.bind(this);
     }
+
     componentDidUpdate(prevProps) {
         if (this.props.selectedQuarters !== prevProps.selectedQuarters) {
             this.toggleTooltip(0);
         }
     }
+
     toggleTooltip(showTooltip) {
         if (showTooltip !== this.state.showTooltip) {
             this.setState({
@@ -36,6 +38,7 @@ export default class QuarterPicker extends React.Component {
             });
         }
     }
+
     generateQuarters() {
         const quarters = [];
         for (let i = 1; i <= 4; i++) {


### PR DESCRIPTION
**High level description:**
Adds warning tooltips to the quarter selector for disabled quarters and fiscal years

**Technical details:**
- Adds a single warning tooltip instance to the quarter filter, and one to the fiscal year filter (this approach ensures only one tooltip will display at a time, even when there are multiple disabled quarters/years). 
- The message depends on which quarter/year triggered the tooltip (stored in state). `0` indicates that the tooltip should be hidden or has not yet been triggered. 
- The quarter buttons are pseudo-disabled, so they are still focusable, which allows keyboard users to trigger the warning tooltip  

**Link to JIRA Ticket:**
[DEV-3757](https://federal-spending-transparency.atlassian.net/browse/DEV-3757)

**Mockup**
https://bahdigital.invisionapp.com/share/YNIABRH3MJZ#/screens

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Design review complete
- [x] Verified cross-browser compatibility
- [x] Link to this PR in JIRA ticket