### PR TITLE
DEV-3785: agency list api call

### DIFF
--- a/src/js/containers/SharedContainers/AgencyListContainer.jsx
+++ b/src/js/containers/SharedContainers/AgencyListContainer.jsx
@@ -31,26 +31,24 @@ class AgencyListContainer extends React.Component {
     }
 
     loadData() {
-        if (this.props.agencyList.agencies.length === 0) {
-            // we need to populate the list
-            if (this.props.detached) {
-                AgencyHelper.fetchAllAgencies()
-                    .then((agencies) => {
-                        this.props.setAgencyList(agencies);
-                    })
-                    .catch((err) => {
-                        console.error(err);
-                    });
-            }
-            else {
-                AgencyHelper.fetchAgencies()
-                    .then((agencies) => {
-                        this.props.setAgencyList(agencies);
-                    })
-                    .catch((err) => {
-                        console.error(err);
-                    });
-            }
+        // we need to populate the list
+        if (this.props.detached) {
+            AgencyHelper.fetchAllAgencies()
+                .then((agencies) => {
+                    this.props.setAgencyList(agencies);
+                })
+                .catch((err) => {
+                    console.error(err);
+                });
+        }
+        else {
+            AgencyHelper.fetchAgencies()
+                .then((agencies) => {
+                    this.props.setAgencyList(agencies);
+                })
+                .catch((err) => {
+                    console.error(err);
+                });
         }
     }
 

--- a/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
+++ b/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
@@ -41,26 +41,24 @@ class AgencyFilterContainer extends React.Component {
     }
 
     loadData() {
-        if (this.props.agencyList.agencies.length === 0) {
-            // we need to populate the list
-            if (this.props.detached) {
-                AgencyHelper.fetchAllAgencies()
-                    .then((agencies) => {
-                        this.props.setAgencyList(agencies);
-                    })
-                    .catch((err) => {
-                        console.error(err);
-                    });
-            }
-            else {
-                AgencyHelper.fetchAgencies()
-                    .then((agencies) => {
-                        this.props.setAgencyList(agencies);
-                    })
-                    .catch((err) => {
-                        console.error(err);
-                    });
-            }
+        // we need to populate the list
+        if (this.props.detached) {
+            AgencyHelper.fetchAllAgencies()
+                .then((agencies) => {
+                    this.props.setAgencyList(agencies);
+                })
+                .catch((err) => {
+                    console.error(err);
+                });
+        }
+        else {
+            AgencyHelper.fetchAgencies()
+                .then((agencies) => {
+                    this.props.setAgencyList(agencies);
+                })
+                .catch((err) => {
+                    console.error(err);
+                });
         }
     }
 

--- a/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
+++ b/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
@@ -40,7 +40,7 @@ class AgencyFilterContainer extends React.Component {
 
     loadData() {
         // we need to populate the list
-       AgencyHelper.fetchAgencies()
+        AgencyHelper.fetchAgencies()
             .then((agencies) => {
                 this.props.setAgencyList(agencies);
             })

--- a/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
+++ b/src/js/containers/submissionsTable/AgencyFilterContainer.jsx
@@ -16,7 +16,6 @@ import Typeahead from '../../components/SharedComponents/Typeahead';
 const propTypes = {
     setAgencyList: PropTypes.func,
     agencyList: PropTypes.object,
-    detached: PropTypes.bool,
     selectedFilters: PropTypes.object,
     type: PropTypes.string,
     table: PropTypes.string,
@@ -27,7 +26,6 @@ const propTypes = {
 const defaultProps = {
     setAgencyList: () => {},
     agencyList: {},
-    detached: true,
     selectedFilters: [],
     table: '',
     type: '',
@@ -42,24 +40,13 @@ class AgencyFilterContainer extends React.Component {
 
     loadData() {
         // we need to populate the list
-        if (this.props.detached) {
-            AgencyHelper.fetchAllAgencies()
-                .then((agencies) => {
-                    this.props.setAgencyList(agencies);
-                })
-                .catch((err) => {
-                    console.error(err);
-                });
-        }
-        else {
-            AgencyHelper.fetchAgencies()
-                .then((agencies) => {
-                    this.props.setAgencyList(agencies);
-                })
-                .catch((err) => {
-                    console.error(err);
-                });
-        }
+       AgencyHelper.fetchAgencies()
+            .then((agencies) => {
+                this.props.setAgencyList(agencies);
+            })
+            .catch((err) => {
+                console.error(err);
+            });
     }
 
     dataFormatter(item) {


### PR DESCRIPTION
**High level description:**

Fixing a bug where all agencies would sometimes be displayed instead of the permission-based list. Also removing all agencies from the filter list (per discussion) and only listing agencies the user has access to.

**Technical details:**

We were using the cached version of the agency list, which wasn't great because we called `list_all_agencies` in a couple places. This meant that when users went to make a submission after being on one of these pages they would see every agency instead of just the ones they had access to.

**Link to JIRA Ticket:**

[DEV-3785](https://federal-spending-transparency.atlassian.net/browse/DEV-3785)

**Mockup**
N/A

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- Tagged Designer in `#br-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket