### PR TITLE
DEV-3561: Agency typeahead mistype error

### DIFF
--- a/src/js/components/SharedComponents/Typeahead.jsx
+++ b/src/js/components/SharedComponents/Typeahead.jsx
@@ -229,18 +229,20 @@ export default class Typeahead extends React.Component {
 
         return (
             <div className={`usa-da-typeahead${disabledClass}`}>
-                <input
-                    className={this.props.customClass}
-                    ref={(c) => {
-                        this.awesomplete = c;
-                    }}
-                    type="text"
-                    placeholder={placeholder}
-                    value={this.state.value}
-                    onChange={this.changedText.bind(this)}
-                    tabIndex={this.props.tabIndex}
-                    disabled={disabled}
-                    aria-required={this.props.isRequired} />
+                <div>
+                    <input
+                        className={this.props.customClass}
+                        ref={(c) => {
+                            this.awesomplete = c;
+                        }}
+                        type="text"
+                        placeholder={placeholder}
+                        value={this.state.value}
+                        onChange={this.changedText.bind(this)}
+                        tabIndex={this.props.tabIndex}
+                        disabled={disabled}
+                        aria-required={this.props.isRequired} />
+                </div>
                 {warning}
             </div>
         );


### PR DESCRIPTION
**High level description:**

When an agency is mistyped it doesn't break the page anymore

**Technical details:**

Surrounding the input with a div to stop it from confusing the DOM.

**Link to JIRA Ticket:**

[DEV-3561](https://federal-spending-transparency.atlassian.net/browse/DEV-3561)

**Mockup**
N/A

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- Tagged Designer in `#br-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket