### PR TITLE
DEV-3676: Page title alignment

### DIFF
--- a/src/_scss/layouts/default/header/_titleBar.scss
+++ b/src/_scss/layouts/default/header/_titleBar.scss
@@ -10,4 +10,10 @@
 	& .display-1, .display-2, h1, h2, h3, h4, h5, h6, ul{
 		color: $color-white;
 	}
+
+	.usa-da-page-title {
+		* {
+			padding-left: 0;
+		}
+	}
 }

--- a/src/_scss/layouts/default/header/header.scss
+++ b/src/_scss/layouts/default/header/header.scss
@@ -25,7 +25,7 @@
 	}
 
 	.usa-da-content-dark {
-		@include headerTitleBar;		
+		@include headerTitleBar;
 	}
 
 	.usa-da-content-teal {

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -60,7 +60,7 @@ export default class DashboardPage extends React.Component {
                     <Navbar type="dabs" activeTab="dashboard" />
                     <div className="usa-da-content-dark">
                         <div className="container">
-                            <div className="row">
+                            <div className="row usa-da-page-title">
                                 <div className="col-md-12">
                                     <h1 className="display-2">DABS Dashboard</h1>
                                 </div>

--- a/src/js/components/help/helpPage.jsx
+++ b/src/js/components/help/helpPage.jsx
@@ -87,7 +87,7 @@ export default class HelpPage extends React.Component {
                     <Navbar activeTab={help} type={this.props.type} logoOnly={this.props.helpOnly} />
                     <div className={`usa-da-content-${color} mb-60`}>
                         <div className="container">
-                            <div className="row">
+                            <div className="row usa-da-page-title">
                                 <div className="col-md-12 mt-40 mb-20">
                                     <div className="display-2" data-contentstart="start" tabIndex={-1}>
                                         {this.props.type.toUpperCase()} | Help

--- a/src/js/components/help/resourcesPage.jsx
+++ b/src/js/components/help/resourcesPage.jsx
@@ -58,7 +58,7 @@ export default class ResourcesPage extends React.Component {
                     <Navbar activeTab={activeTab} type={this.props.type} logoOnly={this.props.helpOnly} />
                     <div className={`usa-da-content-${color} mb-60`}>
                         <div className="container">
-                            <div className="row">
+                            <div className="row usa-da-page-title">
                                 <div className="col-md-12 mt-40 mb-20">
                                     <div className="display-2" data-contentstart="start" tabIndex={-1}>
                                         {this.props.type.toUpperCase()} | Resources

--- a/src/js/components/history/HistoryPage.jsx
+++ b/src/js/components/history/HistoryPage.jsx
@@ -28,7 +28,7 @@ export default class HistoryPage extends React.Component {
                     <Navbar activeTab="dashboard" type={this.props.type} />
                     <div className="usa-da-content-dark">
                         <div className="container">
-                            <div className="row">
+                            <div className="row usa-da-page-title">
                                 <div className="col-md-12 mt-40 mb-20">
                                     <div className="display-2" data-contentstart="start">
                                         Submission History

--- a/src/js/components/submissionsTable/SubmissionsTablePage.jsx
+++ b/src/js/components/submissionsTable/SubmissionsTablePage.jsx
@@ -26,7 +26,7 @@ export default class SubmissionsTablePage extends React.Component {
                     <Navbar activeTab={activeTab} type={this.props.route.type} />
                     <div className={`usa-da-content-${color}`}>
                         <div className="container">
-                            <div className="row">
+                            <div className="row usa-da-page-title">
                                 <div className="col-md-12 mt-40 mb-20">
                                     <div className="display-2" data-contentstart="start" tabIndex={-1}>
                                         {header}


### PR DESCRIPTION
**High level description:**

Aligning the page titles with the top bar

**Technical details:**

Adding CSS to remove padding from the page title. Also adding the page title class to page titles that didn't have it

**Link to JIRA Ticket:**

[DEV-3676](https://federal-spending-transparency.atlassian.net/browse/DEV-3676)

**Mockup**
N/A

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Tagged Designer in `#br-frontend` Slack Channel in the thread under the Post from Github for their SA (showed in person instead)
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket