### PR TITLE
OPS-651: Resolving Open Redirection

### DIFF
--- a/src/js/components/crossFile/CrossFileOverlay.jsx
+++ b/src/js/components/crossFile/CrossFileOverlay.jsx
@@ -137,9 +137,7 @@ export default class CrossFileOverlay extends React.Component {
             overlay.hideButtons = true;
             overlay.detail = (
                 <div>
-                    You can return to this page at any time to check the validation status by using this link:
-                    <br />
-                    <a href={window.location.href}>{window.location.href}</a>
+                    You can return to this URL at any time to check the validation status.
                 </div>
             );
         }

--- a/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
+++ b/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
@@ -20,20 +20,19 @@ const defaultProps = {
 export default class ValidateDataInProgressOverlay extends React.Component {
     render() {
         let title = 'Your files are being validated.';
-        let description = 'You can return to this page at any time to check the validation status by using this link: ';
+        let description = 'You can return to this URL at any time to check the validation status.';
 
         let icon = <LoadingBauble />;
         let iconClass = 'overlay-animation';
 
         if (this.props.hasFailed) {
             title = 'An error has occurred while validating your files.';
-            description = 'Contact the Service Desk for assistance. Provide this URL when describing the issue: ';
+            description = 'Contact the Service Desk for assistance. Provide this URL when describing the issue.';
             icon = <Icons.ExclamationCircle />;
             iconClass = 'usa-da-errorRed';
         }
-
-        const detail = <div>{description}<br /><a href={window.location.href}>{window.location.href}</a></div>;
-
+        
+        const detail = <div>{description}</div>;
 
         return (
             <CommonOverlay

--- a/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
+++ b/src/js/components/validateData/ValidateDataInProgressOverlay.jsx
@@ -31,7 +31,7 @@ export default class ValidateDataInProgressOverlay extends React.Component {
             icon = <Icons.ExclamationCircle />;
             iconClass = 'usa-da-errorRed';
         }
-        
+
         const detail = <div>{description}</div>;
 
         return (

--- a/src/js/containers/router/RouterRoutes.jsx
+++ b/src/js/containers/router/RouterRoutes.jsx
@@ -38,13 +38,13 @@ const performAutoLogin = (location, replace) => {
     const whiteListPaths = [];
     listRoutes.forEach((route) => {
         if (route !== '*') {
-            whiteListPaths.push(route.replace(':submissionID', '\\d+').replace(':type', '[a-zA-Z]+'));
+            whiteListPaths.push(route.toLowerCase().replace(':submissionid', '\\d+').replace(':type', '[a-z]+'));
         }
     });
     let validPath = false;
     for (let i = 0; i < whiteListPaths.length; i++) {
         const regexPath = new RegExp(whiteListPaths[i]);
-        validPath = regexPath.test(path.substring(1));
+        validPath = regexPath.test(path.substring(1).toLowerCase());
         if (validPath) {
             break;
         }

--- a/src/js/containers/router/RouterRoutes.jsx
+++ b/src/js/containers/router/RouterRoutes.jsx
@@ -17,6 +17,7 @@ import { checkFabsPermissions } from 'helpers/permissionsHelper';
 
 let instance = null;
 let store = new StoreSingleton().store;
+const listRoutes = [];
 
 const getStore = () => {
     if (!store) {
@@ -34,23 +35,23 @@ const performAutoLogin = (location, replace) => {
 
     // Check path against list of whitelisted paths
     // TODO: use matchPath in later react versions, it can simply use whiteListPaths we're already building
-    const whiteListRoutes = getRoutes();
     const whiteListPaths = [];
-    for (let i=0; i<whiteListRoutes.length; i++){
-        if (whiteListRoutes[i]['path'] !== '*')
-            whiteListPaths[i] = whiteListRoutes[i]['path'].replace(':submissionID', '/d+').replace(':type', '[a-zA-Z]+');
+    for (let i = 0; i < listRoutes.length; i++) {
+        if (listRoutes[i] !== '*') {
+            whiteListPaths[i] = listRoutes[i].replace(':submissionID', '\\d+').replace(':type', '[a-zA-Z]+');
+        }
     }
     let validPath = false;
-    for (let i=0; i<whiteListPaths.length; i++){
+    for (let i = 0; i < whiteListPaths.length; i++) {
         const regexPath = new RegExp(whiteListPaths[i]);
         validPath = regexPath.test(path.substring(1));
-        if (validPath){
+        if (validPath) {
             break;
         }
     }
-    if (!validPath){
-        console.log('Path invalid (' + path + '). Resetting.');
-        path = ""
+    // Setting path to blank if it doesn't match up with the valid paths
+    if (!validPath) {
+        path = "";
     }
 
     const search = location.search;
@@ -323,6 +324,9 @@ const getRoutes = () => {
             },
             type: 'home'
         });
+    for (let i = 0; i < returnRoutes.length; i++) {
+        listRoutes[i] = returnRoutes[i].path;
+    }
     return returnRoutes;
 };
 

--- a/src/js/containers/router/RouterRoutes.jsx
+++ b/src/js/containers/router/RouterRoutes.jsx
@@ -30,7 +30,29 @@ const performAutoLogin = (location, replace) => {
 
     const session = store.getState().session;
 
-    const path = location.pathname;
+    let path = location.pathname;
+
+    // Check path against list of whitelisted paths
+    // TODO: use matchPath in later react versions, it can simply use whiteListPaths we're already building
+    const whiteListRoutes = getRoutes();
+    const whiteListPaths = [];
+    for (let i=0; i<whiteListRoutes.length; i++){
+        if (whiteListRoutes[i]['path'] !== '*')
+            whiteListPaths[i] = whiteListRoutes[i]['path'].replace(':submissionID', '/d+').replace(':type', '[a-zA-Z]+');
+    }
+    let validPath = false;
+    for (let i=0; i<whiteListPaths.length; i++){
+        const regexPath = new RegExp(whiteListPaths[i]);
+        validPath = regexPath.test(path.substring(1));
+        if (validPath){
+            break;
+        }
+    }
+    if (!validPath){
+        console.log('Path invalid (' + path + '). Resetting.');
+        path = ""
+    }
+
     const search = location.search;
     const query = location.query;
 

--- a/src/js/containers/router/RouterRoutes.jsx
+++ b/src/js/containers/router/RouterRoutes.jsx
@@ -17,7 +17,7 @@ import { checkFabsPermissions } from 'helpers/permissionsHelper';
 
 let instance = null;
 let store = new StoreSingleton().store;
-const listRoutes = [];
+let listRoutes = [];
 
 const getStore = () => {
     if (!store) {
@@ -36,11 +36,11 @@ const performAutoLogin = (location, replace) => {
     // Check path against list of whitelisted paths
     // TODO: use matchPath in later react versions, it can simply use whiteListPaths we're already building
     const whiteListPaths = [];
-    for (let i = 0; i < listRoutes.length; i++) {
-        if (listRoutes[i] !== '*') {
-            whiteListPaths[i] = listRoutes[i].replace(':submissionID', '\\d+').replace(':type', '[a-zA-Z]+');
+    listRoutes.forEach((route) => {
+        if (route !== '*') {
+            whiteListPaths.push(route.replace(':submissionID', '\\d+').replace(':type', '[a-zA-Z]+'));
         }
-    }
+    });
     let validPath = false;
     for (let i = 0; i < whiteListPaths.length; i++) {
         const regexPath = new RegExp(whiteListPaths[i]);
@@ -324,9 +324,7 @@ const getRoutes = () => {
             },
             type: 'home'
         });
-    for (let i = 0; i < returnRoutes.length; i++) {
-        listRoutes[i] = returnRoutes[i].path;
-    }
+    listRoutes = returnRoutes.map((route) => route.path);
     return returnRoutes;
 };
 


### PR DESCRIPTION
**High level description:**

After running a burp scan, it was discovered open redirection issues were possible. This aims to fix that.

**Technical details:**

- When logging out, the redirect path that's provided via the URL is whitelisted against valid routes. If the path is invalid, it resets it to an empty string and the user would log back into the front page.
- Also removed a couple instances where we were basing our links off of `location.href`

**Link to JIRA Ticket:**

[OPS-651](https://federal-spending-transparency.atlassian.net/browse/OPS-651)

**Mockup**
N/A

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- Tagged Designer in `#br-frontend` Slack Channel in the thread under the Post from Github for their SA
- Merged concurrently with [Backend#1234](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1234)
- [x] Verified cross-browser compatibility
- All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket
- [x] Tested logging out on valid pages and relogging back in to the previous page. Then logging out with a invalid URL and relogging back into the home page.
- [x] Reran burp scan to confirm it's fixed.