### PR TITLE
DEV-3659 files filter

### DIFF
--- a/src/_scss/sharedComponents/_radioGroup.scss
+++ b/src/_scss/sharedComponents/_radioGroup.scss
@@ -1,0 +1,18 @@
+.radio-group {
+    @include display(flex);
+    .radio-group__column {
+        padding-right: rem(20);
+        padding-top: rem(10);
+        &:last-child {
+            padding-right: 0;
+        }
+        .radio-option {
+            .radio-option__input {
+                margin-right: rem(5);
+            }
+            .radio-option__label {
+                font-weight: $font-normal;
+            }
+        }
+    }
+}

--- a/src/_scss/sharedComponents/sharedComponents.scss
+++ b/src/_scss/sharedComponents/sharedComponents.scss
@@ -1,2 +1,3 @@
 @import './loadingBars';
 @import './loadingMessage';
+@import './radioGroup';

--- a/src/js/components/SharedComponents/RadioGroup.jsx
+++ b/src/js/components/SharedComponents/RadioGroup.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-    options: PropTypes.array,
+    columns: PropTypes.array,
     onChange: PropTypes.func,
     currentValue: PropTypes.string
 };
@@ -23,8 +23,18 @@ export default class RadioGroup extends React.Component {
         this.props.onChange(e.target.value);
     }
 
-    generateOptions() {
-        return this.props.options.map((option) => (
+    generateColumns() {
+        return this.props.columns.map((column, i) => (
+            <div
+                className="radio-group__column"
+                key={`radio-group-col-${i}`}>
+                {this.generateOptions(column)}
+            </div>
+        ));
+    }
+
+    generateOptions(options) {
+        return options.map((option) => (
             <div className="radio-option" key={option.value}>
                 <input
                     id={option.value}
@@ -43,7 +53,7 @@ export default class RadioGroup extends React.Component {
     render() {
         return (
             <div className="radio-group">
-                {this.generateOptions()}
+                {this.generateColumns()}
             </div>
         );
     }

--- a/src/js/components/SharedComponents/RadioGroup.jsx
+++ b/src/js/components/SharedComponents/RadioGroup.jsx
@@ -1,0 +1,52 @@
+/**
+ * RadioGroup.jsx
+ * Created by Lizzie Salita 10/30/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    options: PropTypes.array,
+    onChange: PropTypes.func,
+    currentValue: PropTypes.string
+};
+
+export default class RadioGroup extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.pickedOption = this.pickedOption.bind(this);
+    }
+
+    pickedOption(e) {
+        this.props.onChange(e.target.value);
+    }
+
+    generateOptions() {
+        return this.props.options.map((option) => (
+            <div className="radio-option" key={option.value}>
+                <input
+                    id={option.value}
+                    className="radio-option__input"
+                    type="radio"
+                    value={option.value}
+                    checked={option.value === this.props.currentValue}
+                    onChange={this.pickedOption} />
+                <label className="radio-option__label" htmlFor={option.value}>
+                    {option.label}
+                </label>
+            </div>
+        ));
+    }
+
+    render() {
+        return (
+            <div className="radio-group">
+                {this.generateOptions()}
+            </div>
+        );
+    }
+}
+
+RadioGroup.propTypes = propTypes;

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -14,13 +14,13 @@ import FilterSidebar from './FilterSidebar';
 
 const filters = [
     {
-        name: 'Fiscal Year',
+        name: 'Fiscal Years',
         required: true,
         component: FyFilterContainer,
         description: 'Select the applicable fiscal year(s).'
     },
     {
-        name: 'Quarter',
+        name: 'Quarters',
         required: true,
         component: QuarterFilterContainer,
         description: 'Select the applicable quarter(s).'

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -8,6 +8,7 @@ import Navbar from 'components/SharedComponents/navigation/NavigationComponent';
 import Footer from 'components/SharedComponents/FooterComponent';
 import QuarterFilterContainer from 'containers/dashboard/filters/QuarterFilterContainer';
 import FyFilterContainer from 'containers/dashboard/filters/FyFilterContainer';
+import FileFilterContainer from 'containers/dashboard/filters/FileFilterContainer';
 import DashboardTab from './DashboardTab';
 import FilterSidebar from './FilterSidebar';
 
@@ -27,7 +28,7 @@ const filters = [
     {
         name: 'Files',
         required: true,
-        component: null,
+        component: FileFilterContainer,
         description: 'Select one file or cross-file.'
     },
     {

--- a/src/js/containers/dashboard/filters/FileFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/FileFilterContainer.jsx
@@ -1,0 +1,66 @@
+/**
+ * FileFilterContainer.jsx
+ * Created by Lizzie Salita 10/30/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import * as filterActions from 'redux/actions/dashboard/dashboardFilterActions';
+import RadioGroup from 'components/SharedComponents/RadioGroup';
+
+const propTypes = {
+    updateFileFilter: PropTypes.func,
+    selectedFilters: PropTypes.object
+};
+
+const options = [
+    {
+        value: 'A',
+        label: 'File A'
+    },
+    {
+        value: 'B',
+        label: 'File B'
+    },
+    {
+        value: 'C',
+        label: 'File C'
+    },
+    {
+        value: 'cross-AB',
+        label: 'Cross A/B'
+    },
+    {
+        value: 'cross-BC',
+        label: 'Cross B/C'
+    },
+    {
+        value: 'cross-CD1',
+        label: 'Cross C/D1'
+    },
+    {
+        value: 'cross-CD2',
+        label: 'Cross C/D2'
+    }
+];
+
+const FileFilterContainer = (props) => (
+    <div className="file-options">
+        <RadioGroup
+            onChange={props.updateFileFilter}
+            currentValue={props.selectedFilters.file}
+            options={options} />
+    </div>
+);
+
+FileFilterContainer.propTypes = propTypes;
+
+export default connect(
+    (state) => ({
+        selectedFilters: state.dashboardFilters
+    }),
+    (dispatch) => bindActionCreators(filterActions, dispatch),
+)(FileFilterContainer);

--- a/src/js/containers/dashboard/filters/FileFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/FileFilterContainer.jsx
@@ -16,35 +16,39 @@ const propTypes = {
     selectedFilters: PropTypes.object
 };
 
-const options = [
-    {
-        value: 'A',
-        label: 'File A'
-    },
-    {
-        value: 'B',
-        label: 'File B'
-    },
-    {
-        value: 'C',
-        label: 'File C'
-    },
-    {
-        value: 'cross-AB',
-        label: 'Cross A/B'
-    },
-    {
-        value: 'cross-BC',
-        label: 'Cross B/C'
-    },
-    {
-        value: 'cross-CD1',
-        label: 'Cross C/D1'
-    },
-    {
-        value: 'cross-CD2',
-        label: 'Cross C/D2'
-    }
+const columns = [
+    [
+        {
+            value: 'A',
+            label: 'File A'
+        },
+        {
+            value: 'B',
+            label: 'File B'
+        },
+        {
+            value: 'C',
+            label: 'File C'
+        }
+    ],
+    [
+        {
+            value: 'cross-AB',
+            label: 'Cross A/B'
+        },
+        {
+            value: 'cross-BC',
+            label: 'Cross B/C'
+        },
+        {
+            value: 'cross-CD1',
+            label: 'Cross C/D1'
+        },
+        {
+            value: 'cross-CD2',
+            label: 'Cross C/D2'
+        }
+    ]
 ];
 
 const FileFilterContainer = (props) => (
@@ -52,7 +56,7 @@ const FileFilterContainer = (props) => (
         <RadioGroup
             onChange={props.updateFileFilter}
             currentValue={props.selectedFilters.file}
-            options={options} />
+            columns={columns} />
     </div>
 );
 

--- a/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
@@ -8,7 +8,7 @@ import { Set } from 'immutable';
 export const initialState = {
     quarters: new Set(),
     fy: new Set(),
-    file: 'A',
+    file: '',
     rules: new Set()
 };
 


### PR DESCRIPTION
**High level description:**
Adds the file radio buttons to the dashboard page.

**Technical details:**

- JSX does not support `<radiogroup>` so I've implemented a reusable radio group component that accepts multiple columns of options, each option with a `value` and a `label`.
- When a new option is selected, the Redux `dashboardFilters.file` state is updated
- This PR also updates all filter labels to be plural (`Quarter` -> `Quarters`, `Fiscal Year` -> `Fiscal Years`)

**Link to JIRA Ticket:**

[DEV-3659](https://federal-spending-transparency.atlassian.net/browse/DEV-3659)

**Mockup**
https://bahdigital.invisionapp.com/share/7GIABMNX8MV#/296021489_Historical-Search-Monthly-Single-Data

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Design review complete
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket