### PR TITLE
DEV-3661: Agency filter

### DIFF
--- a/src/_scss/abstract/variables/shame.scss
+++ b/src/_scss/abstract/variables/shame.scss
@@ -2,5 +2,4 @@
 $border-radius:     rem(3px);
 $button-border-radius: 0;
 $box-shadow:        0 0 2px rgba(#000, .3);
-$focus-shadow:      0 0 3px $color-focus, 0 0 7px $color-focus;
 $button-stroke:		inset 0 0 0 2px;

--- a/src/_scss/components/inputs/_generic.scss
+++ b/src/_scss/components/inputs/_generic.scss
@@ -7,15 +7,8 @@
 	font-size: $base-font-size;
 	margin: .2em 0;
 	width: 100%;
-	outline: none;
 	padding: 1rem .7em;
-	appearance: none;
 	max-width: none;
-
-	&:focus, 
-	&.usa-da-input-focus {
-	box-shadow: $focus-shadow;
-	}
 
 	&.usa-da-input-success {
 	border: 3px solid $color-green-light;

--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -6,6 +6,7 @@
         @import './filters/quarterPicker';
         @import './filters/fiscalYears';
         @import './filters/rulesFilter';
+        @import './filters/dashboardAgencyFilter';
         .filter-sidebar__option-heading {
             font-weight: $font-bold;
             font-size: $h3-font-size;

--- a/src/_scss/pages/dashboard/filters/_dashboardAgencyFilter.scss
+++ b/src/_scss/pages/dashboard/filters/_dashboardAgencyFilter.scss
@@ -11,6 +11,7 @@
 
         .awesomplete ul {
             width: 100%;
+            position: static;
         }
 
         .typeahead-warning {

--- a/src/_scss/pages/dashboard/filters/_dashboardAgencyFilter.scss
+++ b/src/_scss/pages/dashboard/filters/_dashboardAgencyFilter.scss
@@ -1,7 +1,42 @@
 .dashboard-agency-filter {
-    @import '../../../components/autocomplete/autocomplete';
-    @import '../../../components/autocomplete/errorMessage';
     @import './selectedFilters';
+    @import '../../../components/typeahead/typeahead';
+
+    .typeahead-holder {
+        position: relative;
+
+        input {
+            color: #adadad;
+        }
+
+        .awesomplete ul {
+            width: 100%;
+        }
+
+        .typeahead-warning {
+            @include usa-input-error-message;
+            border: 1px solid $color-secondary-dark;
+            padding: rem(15);
+
+            .error-icon svg {
+                width: rem(20);
+                height: rem(20);
+                fill: $color-secondary-dark !important;
+            }
+            .alert-header-text {
+                font-weight: $font-bold;
+                font-size: rem(18);
+                margin: 0;
+                margin-left: rem(28);
+                color: #a94442;
+            }
+            p {
+                font-size: $small-font-size;
+                margin: 0;
+                color: $color-secondary-darkest;
+            }
+        }
+    }
 
     .selected-filters {
         background-color: $color-gray-lightest;

--- a/src/_scss/pages/dashboard/filters/_dashboardAgencyFilter.scss
+++ b/src/_scss/pages/dashboard/filters/_dashboardAgencyFilter.scss
@@ -1,0 +1,24 @@
+.dashboard-agency-filter {
+    @import '../../../components/autocomplete/autocomplete';
+    @import '../../../components/autocomplete/errorMessage';
+    @import './selectedFilters';
+
+    .selected-filters {
+        background-color: $color-gray-lightest;
+        display: inline-block;
+        padding: rem(12);
+
+        .shown-filter-button {
+            font-size: rem(12);
+            max-width: 100%;
+
+            &.no-click {
+                &:hover {
+                    background: $color-white;
+                    border: 1px solid $color-gray-lighter;
+                    cursor: default;
+                }
+            }
+        }
+    }
+}

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import Navbar from 'components/SharedComponents/navigation/NavigationComponent';
 import Footer from 'components/SharedComponents/FooterComponent';
 import QuarterFilterContainer from 'containers/dashboard/filters/QuarterFilterContainer';
+import DashboardAgencyFilterContainer from 'containers/dashboard/filters/DashboardAgencyFilterContainer';
 import FyFilterContainer from 'containers/dashboard/filters/FyFilterContainer';
 import FileFilterContainer from 'containers/dashboard/filters/FileFilterContainer';
 import RulesFilterContainer from 'containers/dashboard/filters/RulesFilterContainer';
@@ -14,6 +15,12 @@ import DashboardTab from './DashboardTab';
 import FilterSidebar from './FilterSidebar';
 
 const filters = [
+    {
+        name: 'Agency',
+        required: true,
+        component: DashboardAgencyFilterContainer,
+        description: 'Select a specific agency to filter your search.'
+    },
     {
         name: 'Fiscal Years',
         required: true,

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -19,31 +19,36 @@ const filters = [
         name: 'Agency',
         required: true,
         component: DashboardAgencyFilterContainer,
-        description: 'Select a specific agency to filter your search.'
+        description: 'Select a specific agency to filter your search.',
+        altDescription: 'The agency to which you are assigned.'
     },
     {
         name: 'Fiscal Years',
         required: true,
         component: FyFilterContainer,
-        description: 'Select the applicable fiscal year(s).'
+        description: 'Select the applicable fiscal year(s).',
+        altDescription: null
     },
     {
         name: 'Quarters',
         required: true,
         component: QuarterFilterContainer,
-        description: 'Select the applicable quarter(s).'
+        description: 'Select the applicable quarter(s).',
+        altDescription: null
     },
     {
         name: 'Files',
         required: true,
         component: FileFilterContainer,
-        description: 'Select one file or cross-file.'
+        description: 'Select one file or cross-file.',
+        altDescription: null
     },
     {
         name: 'Rules',
         required: false,
         component: RulesFilterContainer,
-        description: 'Enter specific codes to filter your search.'
+        description: 'Enter specific codes to filter your search.',
+        altDescription: null
     }
 ];
 

--- a/src/js/components/dashboard/FilterOption.jsx
+++ b/src/js/components/dashboard/FilterOption.jsx
@@ -14,6 +14,22 @@ const propTypes = {
 };
 
 export default class FilterOption extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            useAltText: false
+        };
+
+        this.setDescription = this.setDescription.bind(this);
+    }
+
+    setDescription(useAltText) {
+        this.setState({
+            useAltText
+        });
+    }
+
     render() {
         const required = this.props.required ? (
             <span className="filter-sidebar__option-required">Required</span>
@@ -21,15 +37,16 @@ export default class FilterOption extends React.Component {
         let component = null;
         if (this.props.component) {
             const Component = this.props.component;
-            component = <Component />;
+            component = <Component setDescription={this.setDescription}/>;
         }
+        const description = this.state.useAltText ? this.props.altDescription : this.props.description;
         return (
             <div className="filter-sidebar__option">
                 <span className="filter-sidebar__option-name">
                     {this.props.name}{required}
                 </span>
                 <div className="filter-sidebar__option-description">
-                    {this.props.description}
+                    {description}
                 </div>
                 {component}
             </div>

--- a/src/js/components/dashboard/FilterOption.jsx
+++ b/src/js/components/dashboard/FilterOption.jsx
@@ -10,7 +10,8 @@ const propTypes = {
     name: PropTypes.string,
     description: PropTypes.string,
     required: PropTypes.bool,
-    component: PropTypes.func
+    component: PropTypes.func,
+    altDescription: PropTypes.string
 };
 
 export default class FilterOption extends React.Component {
@@ -37,7 +38,7 @@ export default class FilterOption extends React.Component {
         let component = null;
         if (this.props.component) {
             const Component = this.props.component;
-            component = <Component setDescription={this.setDescription}/>;
+            component = <Component setDescription={this.setDescription} />;
         }
         const description = this.state.useAltText ? this.props.altDescription : this.props.description;
         return (

--- a/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
@@ -30,12 +30,19 @@ export default class DashboardAgencyFilter extends React.Component {
 
     render() {
         let selectedAgency = null;
-        if (Object.keys(this.props.selectedFilters.agency).length > 0) {
+        let filteredList = this.props.results;
+        if (this.props.selectedFilters.agency !== '') {
             const agencyCode = this.props.selectedFilters.agency;
-            // select only the agency we've selected
+            // select only the agency we've selected for clearing and displaying
             const agency = this.props.results.filter((result) => {
                 const code = result.cgac_code || result.frec_code;
                 return code === agencyCode;
+            });
+
+            // make the rest of the items so we don't have the chosen agency in the results list
+            filteredList = filteredList.filter((result) => {
+                const code = result.cgac_code || result.frec_code;
+                return code !== agencyCode;
             });
             // if it's a single agency user, we don't want to remove the value
             const removeVal = this.props.singleAgency ? null : this.props.onSelect.bind(null, agencyCode);
@@ -59,7 +66,7 @@ export default class DashboardAgencyFilter extends React.Component {
                         formatter={this.dataFormatter}
                         onSelect={this.props.onSelect}
                         prioritySort={false}
-                        values={this.props.results}
+                        values={filteredList}
                         clearAfterSelect
                         placeholder="Enter Agency Name" />
                 </div>

--- a/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
@@ -51,16 +51,22 @@ export default class DashboardAgencyFilter extends React.Component {
         let selectedAgency = null;
         if (Object.keys(this.props.selectedFilters.agency).length > 0) {
             const agency = this.props.selectedFilters.agency;
+            const removeVal = this.props.singleAgency ? null : this.props.onSelect.bind(null, { agency })
             selectedAgency = (
                 <div className="selected-filters">
                     <ShownValue
                         label={agency.agency_name}
-                        removeValue={this.props.onSelect.bind(null, { agency })} />
+                        removeValue={removeVal} />
                 </div>
             );
         }
-        return (
-            <div className="rules-filter">
+
+        const fliterContents = this.props.singleAgency ? (
+            <div className="dashboard-agency-filter">
+                {selectedAgency}
+            </div>
+        ) : (
+            <div className="dashboard-agency-filter">
                 <Autocomplete
                     values={this.props.filteredResults}
                     handleTextInput={this.props.handleTextInput}
@@ -79,6 +85,9 @@ export default class DashboardAgencyFilter extends React.Component {
                     toggleTooltip={this.toggleTooltip} />
                 {selectedAgency}
             </div>
+        );
+        return (
+            fliterContents
         );
     }
 }

--- a/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
@@ -21,6 +21,20 @@ const defaultProps = {
 };
 
 export default class DashboardAgencyFilter extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            useAltText: false
+        };
+
+        this.onSelect = this.onSelect.bind(this);
+    }
+
+    onSelect() {
+        this.props.onSelect(this.props.selectedFilters.agency);
+    }
+
     dataFormatter(item) {
         return {
             label: item.agency_name,
@@ -45,7 +59,7 @@ export default class DashboardAgencyFilter extends React.Component {
                 return code !== agencyCode;
             });
             // if it's a single agency user, we don't want to remove the value
-            const removeVal = this.props.singleAgency ? null : this.props.onSelect.bind(null, agencyCode);
+            const removeVal = this.props.singleAgency ? null : this.onSelect;
             selectedAgency = (
                 <div className="selected-filters">
                     <ShownValue
@@ -55,26 +69,22 @@ export default class DashboardAgencyFilter extends React.Component {
             );
         }
 
-        const fliterContents = this.props.singleAgency ? (
-            <div className="dashboard-agency-filter">
-                {selectedAgency}
-            </div>
-        ) : (
-            <div className="dashboard-agency-filter">
-                <div className="typeahead-holder">
-                    <Typeahead
-                        formatter={this.dataFormatter}
-                        onSelect={this.props.onSelect}
-                        prioritySort={false}
-                        values={filteredList}
-                        clearAfterSelect
-                        placeholder="Enter Agency Name" />
-                </div>
-                {selectedAgency}
+        const typeahead = this.props.singleAgency ? null : (
+            <div className="typeahead-holder">
+                <Typeahead
+                    formatter={this.dataFormatter}
+                    onSelect={this.props.onSelect}
+                    prioritySort={false}
+                    values={filteredList}
+                    clearAfterSelect
+                    placeholder="Enter Agency Name" />
             </div>
         );
         return (
-            fliterContents
+            <div className="dashboard-agency-filter">
+                {typeahead}
+                {selectedAgency}
+            </div>
         );
     }
 }

--- a/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
@@ -1,0 +1,74 @@
+/**
+ * DashboardAgencyFilter.jsx
+ * Created by Alisa Burdeyny 11/8/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Autocomplete from 'components/SharedComponents/autocomplete/Autocomplete';
+import SelectedRules from 'components/dashboard/filters/SelectedRules';
+import WarningTooltip from 'components/SharedComponents/WarningTooltip';
+
+const propTypes = {
+    selectedFilters: PropTypes.object.isRequired,
+    noResults: PropTypes.bool,
+    inFlight: PropTypes.bool,
+    onSelect: PropTypes.func.isRequired,
+    filteredResults: PropTypes.array.isRequired,
+    handleTextInput: PropTypes.func.isRequired,
+    clearAutocompleteSuggestions: PropTypes.func.isRequired,
+    minCharsToSearch: PropTypes.number
+};
+
+const defaultProps = {
+    noResults: false,
+    inFlight: false,
+    minCharsToSearch: 0
+};
+
+export default class DashboardAgencyFilter extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showTooltip: false
+        };
+
+        this.toggleTooltip = this.toggleTooltip.bind(this);
+    }
+
+    toggleTooltip(showTooltip) {
+        if (showTooltip !== this.state.showTooltip) {
+            this.setState({
+                showTooltip
+            });
+        }
+    }
+
+    render() {
+        return (
+            <div className="rules-filter">
+                <Autocomplete
+                values={this.props.filteredResults}
+                handleTextInput={this.props.handleTextInput}
+                onSelect={this.props.onSelect}
+                placeholder="Enter Agency Name"
+                errorHeader="Unknown Agency"
+                errorMessage="We were unable to find that Agency based on the current filters."
+                ref={(input) => {
+                    this.agencyList = input;
+                }}
+                clearAutocompleteSuggestions={this.props.clearAutocompleteSuggestions}
+                noResults={this.props.noResults}
+                inFlight={this.props.inFlight}
+                minCharsToSearch={this.props.minCharsToSearch}
+                disabled={this.props.singleAgency}
+                toggleTooltip={this.toggleTooltip} />
+            </div>
+        );
+    }
+}
+
+DashboardAgencyFilter.propTypes = propTypes;
+DashboardAgencyFilter.defaultProps = defaultProps;

--- a/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
+++ b/src/js/components/dashboard/filters/DashboardAgencyFilter.jsx
@@ -7,8 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Autocomplete from 'components/SharedComponents/autocomplete/Autocomplete';
-import SelectedRules from 'components/dashboard/filters/SelectedRules';
-import WarningTooltip from 'components/SharedComponents/WarningTooltip';
+import ShownValue from './ShownValue';
 
 const propTypes = {
     selectedFilters: PropTypes.object.isRequired,
@@ -18,13 +17,15 @@ const propTypes = {
     filteredResults: PropTypes.array.isRequired,
     handleTextInput: PropTypes.func.isRequired,
     clearAutocompleteSuggestions: PropTypes.func.isRequired,
-    minCharsToSearch: PropTypes.number
+    minCharsToSearch: PropTypes.number,
+    singleAgency: PropTypes.bool
 };
 
 const defaultProps = {
     noResults: false,
     inFlight: false,
-    minCharsToSearch: 0
+    minCharsToSearch: 0,
+    singleAgency: true
 };
 
 export default class DashboardAgencyFilter extends React.Component {
@@ -47,24 +48,36 @@ export default class DashboardAgencyFilter extends React.Component {
     }
 
     render() {
+        let selectedAgency = null;
+        if (Object.keys(this.props.selectedFilters.agency).length > 0) {
+            const agency = this.props.selectedFilters.agency;
+            selectedAgency = (
+                <div className="selected-filters">
+                    <ShownValue
+                        label={agency.agency_name}
+                        removeValue={this.props.onSelect.bind(null, { agency })} />
+                </div>
+            );
+        }
         return (
             <div className="rules-filter">
                 <Autocomplete
-                values={this.props.filteredResults}
-                handleTextInput={this.props.handleTextInput}
-                onSelect={this.props.onSelect}
-                placeholder="Enter Agency Name"
-                errorHeader="Unknown Agency"
-                errorMessage="We were unable to find that Agency based on the current filters."
-                ref={(input) => {
-                    this.agencyList = input;
-                }}
-                clearAutocompleteSuggestions={this.props.clearAutocompleteSuggestions}
-                noResults={this.props.noResults}
-                inFlight={this.props.inFlight}
-                minCharsToSearch={this.props.minCharsToSearch}
-                disabled={this.props.singleAgency}
-                toggleTooltip={this.toggleTooltip} />
+                    values={this.props.filteredResults}
+                    handleTextInput={this.props.handleTextInput}
+                    onSelect={this.props.onSelect}
+                    placeholder="Enter Agency Name"
+                    errorHeader="Unknown Agency"
+                    errorMessage="We were unable to find that Agency based on the current filters."
+                    ref={(input) => {
+                        this.agencyList = input;
+                    }}
+                    clearAutocompleteSuggestions={this.props.clearAutocompleteSuggestions}
+                    noResults={this.props.noResults}
+                    inFlight={this.props.inFlight}
+                    minCharsToSearch={this.props.minCharsToSearch}
+                    disabled={this.props.singleAgency}
+                    toggleTooltip={this.toggleTooltip} />
+                {selectedAgency}
             </div>
         );
     }

--- a/src/js/components/dashboard/filters/ShownValue.jsx
+++ b/src/js/components/dashboard/filters/ShownValue.jsx
@@ -14,7 +14,7 @@ const propTypes = {
 
 export default class ShownValue extends React.Component {
     render() {
-        return (
+        const shownVal = (this.props.removeValue !== null) ? (
             <button
                 className="shown-filter-button"
                 value={this.props.label}
@@ -26,6 +26,13 @@ export default class ShownValue extends React.Component {
                     <FontAwesomeIcon icon="times" />
                 </span>
             </button>
+        ) : (
+            <div className="shown-filter-button no-click">
+                <span>{this.props.label}</span>
+            </div>
+        );
+        return (
+            shownVal
         );
     }
 }

--- a/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
@@ -15,7 +15,8 @@ import DashboardAgencyFilter from 'components/dashboard/filters/DashboardAgencyF
 const propTypes = {
     updateAgencyFilter: PropTypes.func.isRequired,
     clearGenericFilter: PropTypes.func.isRequired,
-    selectedFilters: PropTypes.object.isRequired
+    selectedFilters: PropTypes.object.isRequired,
+    setDescription: PropTypes.func.isRequired
 };
 
 const minCharsToSearch = 2;
@@ -53,6 +54,7 @@ export class DashboardAgencyFilterContainer extends React.Component {
                 if (agencies.length === 1) {
                     const code = agencies[0].cgac_code ? agencies[0].cgac_code : agencies[0].frec_code;
                     this.props.updateAgencyFilter(code);
+                    this.props.setDescription(true);
                 }
             })
             .catch((err) => {

--- a/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
@@ -7,8 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import _ from 'lodash';
 
-import * as DashboardHelper from 'helpers/dashboardHelper';
 import * as AgencyHelper from 'helpers/agencyHelper';
 import * as filterActions from 'redux/actions/dashboard/dashboardFilterActions';
 import DashboardAgencyFilter from 'components/dashboard/filters/DashboardAgencyFilter';
@@ -45,6 +45,11 @@ export class DashboardAgencyFilterContainer extends React.Component {
         this.loadData();
     }
 
+    onSelect(selection) {
+        // Add or remove the rule from Redux state
+        this.props.updateAgencyFilter(selection.agency);
+    }
+
     loadData() {
         // we need to populate the list
         AgencyHelper.fetchAgencies()
@@ -68,11 +73,6 @@ export class DashboardAgencyFilterContainer extends React.Component {
             });
     }
 
-    onSelect(selection) {
-        // Add or remove the rule from Redux state
-        this.props.updateAgencyFilter(selection.agency);
-    }
-
     parseAutocomplete(input) {
         let results = this.state.results;
 
@@ -82,11 +82,7 @@ export class DashboardAgencyFilterContainer extends React.Component {
         }
 
         // Exclude agency that has already been selected
-        if (this.props.selectedFilters.agency) {
-            results = results.filter((agency) => {
-                return this.props.selectedFilters.agency.agency_name !== agency.agency_name;
-            });
-        }
+        results = results.filter((agency) => !_.isEqual(this.props.selectedFilters.agency, agency));
 
         // Format the results for display in the dropdown
         const filteredResults = results.map((agency) => ({

--- a/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
@@ -1,0 +1,145 @@
+/**
+ * DashboardAgencyFilterContainer.jsx
+ * Created by Alisa Burdeyny 11/8/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import * as DashboardHelper from 'helpers/dashboardHelper';
+import * as AgencyHelper from 'helpers/agencyHelper';
+import * as filterActions from 'redux/actions/dashboard/dashboardFilterActions';
+import DashboardAgencyFilter from 'components/dashboard/filters/DashboardAgencyFilter';
+
+const propTypes = {
+    updateAgencyFilter: PropTypes.func.isRequired,
+    clearGenericFilter: PropTypes.func.isRequired,
+    selectedFilters: PropTypes.object.isRequired
+};
+
+const minCharsToSearch = 2;
+
+export class DashboardAgencyFilterContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            results: [],
+            filteredResults: [],
+            noResults: false,
+            inFlight: true,
+            singleAgency: true,
+            showTooltip: false
+        };
+
+        this.rulesRequest = null;
+
+        this.handleTextInput = this.handleTextInput.bind(this);
+        this.clearAutocompleteSuggestions = this.clearAutocompleteSuggestions.bind(this);
+        this.onSelect = this.onSelect.bind(this);
+    }
+
+    componentDidMount() {
+        this.loadData();
+    }
+
+    loadData() {
+        // we need to populate the list
+        AgencyHelper.fetchAgencies()
+            .then((agencies) => {
+                if (agencies.length === 1) {
+                    this.props.updateAgencyFilter(agencies[0]);
+                }
+                else {
+                    this.setState({
+                        results: agencies,
+                        singleAgency: false,
+                        inFlight: false
+                    });
+                }
+            })
+            .catch((err) => {
+                console.error(err);
+                this.setState({
+                    inFlight: false
+                });
+            });
+    }
+
+    onSelect(selection) {
+        // Add or remove the rule from Redux state
+        this.props.updateAgencyFilter(selection.agency);
+    }
+
+    parseAutocomplete(input) {
+        let results = this.state.results;
+
+        if (input) {
+            // If the user has entered a search string, only show matching results
+            results = results.filter((agency) => agency.agency_name.toUpperCase().includes(input.toUpperCase()));
+        }
+
+        // Exclude agency that has already been selected
+        if (this.props.selectedFilters.agency) {
+            results = results.filter((agency) => {
+                return this.props.selectedFilters.agency.agency_name !== agency.agency_name;
+            });
+        }
+
+        // Format the results for display in the dropdown
+        const filteredResults = results.map((agency) => ({
+            title: agency.agency_name,
+            subtitle: '',
+            data: { agency }
+        }));
+
+        this.setState({
+            filteredResults,
+            noResults: filteredResults.length === 0,
+            inFlight: false
+        });
+    }
+
+    clearAutocompleteSuggestions() {
+        this.setState({
+            filteredResults: []
+        });
+    }
+
+    handleTextInput(event) {
+        event.persist();
+        const value = event.target.value;
+
+        if (value.length >= minCharsToSearch) {
+            this.setState({
+                filteredResults: [], // Clear any existing results
+                inFlight: true
+            });
+            const input = value;
+            this.parseAutocomplete(input);
+        }
+    }
+
+    render() {
+        return (
+            <DashboardAgencyFilter
+                selectedFilters={this.props.selectedFilters}
+                {...this.state}
+                handleTextInput={this.handleTextInput}
+                clearAutocompleteSuggestions={this.clearAutocompleteSuggestions}
+                onSelect={this.onSelect}
+                minCharsToSearch={minCharsToSearch} />
+        );
+    }
+}
+
+DashboardAgencyFilterContainer.propTypes = propTypes;
+
+export default connect(
+    (state) => ({
+        selectedFilters: state.dashboardFilters
+    }),
+    (dispatch) => bindActionCreators(filterActions, dispatch),
+)(DashboardAgencyFilterContainer);

--- a/src/js/redux/actions/dashboard/dashboardFilterActions.js
+++ b/src/js/redux/actions/dashboard/dashboardFilterActions.js
@@ -19,6 +19,11 @@ export const updateFileFilter = (file) => ({
     file
 });
 
+export const updateAgencyFilter = (agency) => ({
+    type: 'UPDATE_AGENCY_FILTER',
+    agency
+});
+
 export const clearAllFilters = () => ({
     type: 'CLEAR_DASHBOARD_FILTERS'
 });

--- a/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
@@ -4,9 +4,10 @@
  **/
 
 import { Set } from 'immutable';
+import _ from 'lodash';
 
 export const initialState = {
-    agency: new Object,
+    agency: {},
     quarters: new Set(),
     fy: new Set(),
     file: '',
@@ -39,6 +40,11 @@ export const dashboardFiltersReducer = (state = initialState, action) => {
         }
 
         case 'UPDATE_AGENCY_FILTER': {
+            if (_.isEqual(state.agency, action.agency)) {
+                return Object.assign({}, state, {
+                    agency: {}
+                });
+            }
             return Object.assign({}, state, {
                 agency: action.agency
             });

--- a/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
@@ -4,10 +4,9 @@
  **/
 
 import { Set } from 'immutable';
-import _ from 'lodash';
 
 export const initialState = {
-    agency: {},
+    agency: '',
     quarters: new Set(),
     fy: new Set(),
     file: '',
@@ -40,9 +39,9 @@ export const dashboardFiltersReducer = (state = initialState, action) => {
         }
 
         case 'UPDATE_AGENCY_FILTER': {
-            if (_.isEqual(state.agency, action.agency)) {
+            if (state.agency === action.agency) {
                 return Object.assign({}, state, {
-                    agency: {}
+                    agency: ''
                 });
             }
             return Object.assign({}, state, {

--- a/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/dashboardFiltersReducer.js
@@ -6,6 +6,7 @@
 import { Set } from 'immutable';
 
 export const initialState = {
+    agency: new Object,
     quarters: new Set(),
     fy: new Set(),
     file: '',
@@ -34,6 +35,12 @@ export const dashboardFiltersReducer = (state = initialState, action) => {
         case 'UPDATE_FILE_FILTER': {
             return Object.assign({}, state, {
                 file: action.file
+            });
+        }
+
+        case 'UPDATE_AGENCY_FILTER': {
+            return Object.assign({}, state, {
+                agency: action.agency
             });
         }
 

--- a/tests/containers/dashboard/filters/DashboardAgencyFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/DashboardAgencyFilterContainer-test.jsx
@@ -1,0 +1,31 @@
+/**
+ * DashboardAgencyFilterContainer-test.jsx
+ * Created by Alisa Burdeyny 11/12/19
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { DashboardAgencyFilterContainer } from 'containers/dashboard/filters/DashboardAgencyFilterContainer';
+import { mockActions, mockRedux } from './mockFilters';
+
+// mock the child component by replacing it with a function that returns a null element
+jest.mock('components/dashboard/filters/DashboardAgencyFilter', () => jest.fn(() => null));
+
+describe('DashboardAgencyFilterContainer', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+    describe('onSelect', () => {
+        it('should call the updateAgencyFilter action', () => {
+            const container = shallow(<DashboardAgencyFilterContainer
+                {...mockActions}
+                {...mockRedux} />
+            );
+
+            container.instance().onSelect('123');
+
+            expect(mockActions.updateAgencyFilter).toHaveBeenCalledWith('123');
+        });
+    });
+});

--- a/tests/containers/dashboard/filters/mockFilters.js
+++ b/tests/containers/dashboard/filters/mockFilters.js
@@ -2,7 +2,8 @@ import { initialState } from 'redux/reducers/dashboard/dashboardFiltersReducer';
 
 export const mockActions = {
     updateGenericFilter: jest.fn(),
-    clearGenericFilter: jest.fn()
+    clearGenericFilter: jest.fn(),
+    updateAgencyFilter: jest.fn()
 };
 
 export const mockRedux = {

--- a/tests/redux/dashboard/dashboardFiltersReducer-test.js
+++ b/tests/redux/dashboard/dashboardFiltersReducer-test.js
@@ -43,6 +43,29 @@ describe('dashboardFiltersReducer', () => {
             expect(state.file).toEqual('B');
         });
     });
+    describe('UPDATE_AGENCY_FILTER', () => {
+        const action = {
+            type: 'UPDATE_AGENCY_FILTER',
+            agency: '123'
+        };
+
+        it('should change the agency to the one provided', () => {
+            let state = dashboardFiltersReducer(undefined, {});
+
+            state = dashboardFiltersReducer(state, action);
+
+            expect(state.agency).toEqual('123');
+        });
+
+        it('should remove the value if it is the agency already selected', () => {
+            const startingState = Object.assign({}, initialState, {
+                agency: '123'
+            });
+
+            const updatedState = dashboardFiltersReducer(startingState, action);
+            expect(updatedState.agency).toEqual('');
+        });
+    });
     describe('CLEAR_FILTER_SET', () => {
         it('should reset the specified filter to its initial state', () => {
             let state = {


### PR DESCRIPTION
**High level description:**

Adding an agency filter to the dashboard

**Technical details:**

- If the user only has 1 agency, it defaults to it and prevents removing it
- If the user has access to multiple agencies, there's a bar that can be searched (same searching as all other agency searches on the site) and the agency can be removed
- Changed behavior from the ticket to 2 letters typed since that's the default for all other agency searches on the site
- Selecting an agency stages the filter and displays it below the dropdown
- Selecting a different agency overwrites the currently staged one
- The selected agency isn't listed in the dropdown

**Link to JIRA Ticket:**

[DEV-3661](https://federal-spending-transparency.atlassian.net/browse/DEV-3661)

**Mockup**
https://app.zeplin.io/project/5dc58a50c75f4983153212fa/screen/5dc5db415093e423855df2bc

The following are ALL required for the PR to be merged:
- [x] Frontend review completed
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA (if applicable)
- [x] Tagged Designer in `#br-frontend` Slack Channel in the thread under the Post from Github for their SA
- [x] Verified cross-browser compatibility
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket