### PR TITLE
DEV-3662 dashboard apply & reset filters

### DIFF
--- a/src/_scss/pages/dashboard/_chooseFilters.scss
+++ b/src/_scss/pages/dashboard/_chooseFilters.scss
@@ -12,6 +12,15 @@
         text-align: center;
         color: $color-gray;
 
+        @media(max-width:$medium-screen) {
+            margin: rem(30);
+        }
+
+        @media(max-width:$small-screen) {
+            margin: 0;
+            padding: rem(225) rem(5);
+        }
+
         .dashboard-choose-filters__arrow {
             font-size: rem(46);
         }

--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -1,4 +1,5 @@
 .filter-sidebar {
+    @import './filters/submitButton';
     .filter-sidebar__option {
         color: $color-gray;
         padding: rem(12) rem(20);

--- a/src/_scss/pages/dashboard/_filterSidebar.scss
+++ b/src/_scss/pages/dashboard/_filterSidebar.scss
@@ -1,5 +1,6 @@
 .filter-sidebar {
     @import './filters/submitButton';
+    width: 100%;
     .filter-sidebar__option {
         color: $color-gray;
         padding: rem(12) rem(20);

--- a/src/_scss/pages/dashboard/dashboard.scss
+++ b/src/_scss/pages/dashboard/dashboard.scss
@@ -37,5 +37,16 @@
             }
             @import "./chooseFilters";
         }
+        @media(max-width: $small-screen) {
+            display: block;
+            .dashboard-page__filters {
+                width: 100%;
+                margin-right: 0;
+            }
+            .dashboard-page__content {
+                margin-left: 0;
+                margin-top: rem(15);
+            }
+        }
     }
 }

--- a/src/_scss/pages/dashboard/filters/_submitButton.scss
+++ b/src/_scss/pages/dashboard/filters/_submitButton.scss
@@ -1,0 +1,53 @@
+.sidebar-submit {
+    padding: rem(15) rem(25);
+
+    .submit-button {
+        display: block;
+        width: 100%;
+        color: $color-white;
+        font-weight: $font-bold;
+        transition: opacity 0.15s;
+        opacity: 1;
+        padding: rem(13) 0;
+        border: 0;
+
+        background-color: $color-primary;
+
+        &:hover {
+            background-color: $color-primary-darker;            
+        }
+
+        &[disabled] {
+            opacity: 0.5;
+            cursor: not-allowed;
+            &:hover {
+                background-color: $color-primary;
+            }
+        }
+    }
+    .reset-button {
+        display: block;
+        @include button-unstyled;
+
+        transition: opacity 0.15s;
+        opacity: 1;
+
+        text-align: center;
+
+        color: $color-primary;
+        font-size: $smallest-font-size;
+
+        margin-top: rem(8);
+        margin-left: auto;
+        margin-right: auto;
+
+        &:hover {
+            text-decoration: underline;
+        }
+
+        &[disabled] {
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+    }
+}

--- a/src/js/components/dashboard/FilterSidebar.jsx
+++ b/src/js/components/dashboard/FilterSidebar.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import SubmitButtonContainer from 'containers/dashboard/filters/SubmitButtonContainer';
 import FilterOption from './FilterOption';
 
 const defaultProps = {
@@ -30,6 +31,7 @@ export default class FilterSidebar extends React.Component {
                     <span className="filter-sidebar__option-heading">FILTER</span>
                 </div>
                 {optionsList}
+                <SubmitButtonContainer />
             </div>
         );
     }

--- a/src/js/components/dashboard/filters/SubmitButton.jsx
+++ b/src/js/components/dashboard/filters/SubmitButton.jsx
@@ -9,13 +9,13 @@ import PropTypes from 'prop-types';
 const propTypes = {
     filtersChanged: PropTypes.bool,
     applyStagedFilters: PropTypes.func,
-    resetFilters: PropTypes.func
+    resetFilters: PropTypes.func,
+    validFilters: PropTypes.bool
 };
 
 const SubmitButton = (props) => {
     const disabled = !props.filtersChanged;
     const title = props.filtersChanged ? 'Click to submit your search.' : 'Add or update a filter to submit.';
-
 
     return (
         <div
@@ -26,7 +26,7 @@ const SubmitButton = (props) => {
                 className="submit-button"
                 title={title}
                 aria-label={title}
-                disabled={disabled}
+                disabled={disabled || !props.validFilters}
                 onClick={props.applyStagedFilters}>
                 Apply Filters
             </button>

--- a/src/js/components/dashboard/filters/SubmitButton.jsx
+++ b/src/js/components/dashboard/filters/SubmitButton.jsx
@@ -1,0 +1,50 @@
+/**
+ * SubmitButton.jsx
+ * Created by Lizzie Salita 11/12/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    requestsComplete: PropTypes.bool,
+    filtersChanged: PropTypes.bool,
+    applyStagedFilters: PropTypes.func,
+    resetFilters: PropTypes.func
+};
+
+const SubmitButton = (props) => {
+    let disabled = false;
+    let title = 'Click to submit your search.';
+    if (!props.requestsComplete || !props.filtersChanged) {
+        title = 'Add or update a filter to submit.';
+        disabled = true;
+    }
+
+    return (
+        <div
+            className="sidebar-submit"
+            role="region"
+            aria-label="Submit search">
+            <button
+                className="submit-button"
+                title={title}
+                aria-label={title}
+                disabled={disabled}
+                onClick={props.applyStagedFilters}>
+                Submit Search
+            </button>
+            <button
+                className="reset-button"
+                aria-label="Reset search"
+                disabled={!props.requestsComplete}
+                onClick={props.resetFilters}>
+                Reset search
+            </button>
+        </div>
+    );
+};
+
+SubmitButton.propTypes = propTypes;
+
+export default SubmitButton;

--- a/src/js/components/dashboard/filters/SubmitButton.jsx
+++ b/src/js/components/dashboard/filters/SubmitButton.jsx
@@ -7,19 +7,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-    requestsComplete: PropTypes.bool,
     filtersChanged: PropTypes.bool,
     applyStagedFilters: PropTypes.func,
     resetFilters: PropTypes.func
 };
 
 const SubmitButton = (props) => {
-    let disabled = false;
-    let title = 'Click to submit your search.';
-    if (!props.requestsComplete || !props.filtersChanged) {
-        title = 'Add or update a filter to submit.';
-        disabled = true;
-    }
+    const disabled = !props.filtersChanged;
+    const title = props.filtersChanged ? 'Click to submit your search.' : 'Add or update a filter to submit.';
+
 
     return (
         <div
@@ -37,7 +33,6 @@ const SubmitButton = (props) => {
             <button
                 className="reset-button"
                 aria-label="Reset search"
-                disabled={!props.requestsComplete}
                 onClick={props.resetFilters}>
                 Reset Filters
             </button>

--- a/src/js/components/dashboard/filters/SubmitButton.jsx
+++ b/src/js/components/dashboard/filters/SubmitButton.jsx
@@ -32,14 +32,14 @@ const SubmitButton = (props) => {
                 aria-label={title}
                 disabled={disabled}
                 onClick={props.applyStagedFilters}>
-                Submit Search
+                Apply Filters
             </button>
             <button
                 className="reset-button"
                 aria-label="Reset search"
                 disabled={!props.requestsComplete}
                 onClick={props.resetFilters}>
-                Reset search
+                Reset Filters
             </button>
         </div>
     );

--- a/src/js/containers/dashboard/filters/RulesFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/RulesFilterContainer.jsx
@@ -41,7 +41,7 @@ export class RulesFilterContainer extends React.Component {
 
     componentDidUpdate(prevProps) {
         // Make an API call for the corresponding rule labels when the selected file changes
-        if (prevProps.selectedFilters.file !== this.props.selectedFilters.file) {
+        if (prevProps.selectedFilters.file !== this.props.selectedFilters.file && this.props.selectedFilters.file) {
             this.fetchAutocompleteResults();
             this.props.clearGenericFilter('rules');
         }

--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -99,7 +99,7 @@ export class SubmitButtonContainer extends React.Component {
     render() {
         // Make sure all the required filters have been staged
         const stagedFilters = this.props.stagedFilters;
-        const requiredFields = stagedFilters.file
+        const requiredFields = stagedFilters.file && stagedFilters.agency
             && stagedFilters.quarters.size > 0 && stagedFilters.fy.size > 0;
         return (
             <SubmitButton

--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -47,6 +47,10 @@ export class SubmitButtonContainer extends React.Component {
         }
     }
 
+    componentWillUnmount() {
+        this.resetFilters();
+    }
+
     compareStores() {
         // we need to do a deep equality check by comparing every store key
         const storeKeys = Object.keys(this.props.stagedFilters);

--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -23,7 +23,8 @@ const propTypes = {
     appliedFilters: PropTypes.object,
     applyStagedFilters: PropTypes.func,
     clearStagedFilters: PropTypes.func,
-    resetAppliedFilters: PropTypes.func
+    resetAppliedFilters: PropTypes.func,
+    setAppliedFilterEmptiness: PropTypes.func
 };
 
 export class SubmitButtonContainer extends React.Component {
@@ -86,11 +87,13 @@ export class SubmitButtonContainer extends React.Component {
         this.setState({
             filtersChanged: false
         });
+        this.props.setAppliedFilterEmptiness(false);
     }
 
     resetFilters() {
         this.props.clearStagedFilters();
         this.props.resetAppliedFilters();
+        this.props.setAppliedFilterEmptiness(true);
     }
 
     render() {
@@ -102,7 +105,7 @@ export class SubmitButtonContainer extends React.Component {
             <SubmitButton
                 filtersChanged={this.state.filtersChanged}
                 applyStagedFilters={this.applyStagedFilters}
-                validFilters={requiredFields}
+                validFilters={!!requiredFields}
                 resetFilters={this.resetFilters} />
         );
     }

--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -1,0 +1,116 @@
+/**
+ * SubmitButtonContainer.jsx
+ * Created by Lizzie Salita 11/12/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { is } from 'immutable';
+
+import * as appliedFilterActions from 'redux/actions/dashboard/appliedFilterActions';
+import { clearAllFilters as clearStagedFilters } from 'redux/actions/dashboard/dashboardFilterActions';
+
+import SubmitButton from 'components/dashboard/filters/SubmitButton';
+
+const combinedActions = Object.assign({}, appliedFilterActions, {
+    clearStagedFilters
+});
+
+const propTypes = {
+    stagedFilters: PropTypes.object,
+    appliedFilters: PropTypes.object,
+    requestsComplete: PropTypes.bool,
+    applyStagedFilters: PropTypes.func,
+    clearStagedFilters: PropTypes.func,
+    setAppliedFilterCompletion: PropTypes.func,
+    resetAppliedFilters: PropTypes.func
+};
+
+export class SubmitButtonContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            filtersChanged: false
+        };
+
+        this.resetFilters = this.resetFilters.bind(this);
+        this.applyStagedFilters = this.applyStagedFilters.bind(this);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.stagedFilters !== this.props.stagedFilters) {
+            this.stagingChanged();
+        }
+        else if (prevProps.appliedFilters !== this.props.appliedFilters) {
+            this.stagingChanged();
+        }
+    }
+
+    compareStores() {
+        // we need to do a deep equality check by comparing every store key
+        const storeKeys = Object.keys(this.props.stagedFilters);
+        if (storeKeys.length !== Object.keys(this.props.appliedFilters).length) {
+            // key lengths do not match, there's a difference so fail immediately
+            return false;
+        }
+
+        // check that the key exists in the appliedFilters object and also that it
+        // is equal (using Immutable's equality check utilty function) in both stores
+        return storeKeys.every((key) => (
+            {}.hasOwnProperty.call(this.props.appliedFilters, key) &&
+                is(this.props.appliedFilters[key], this.props.stagedFilters[key])
+        ));
+    }
+
+    stagingChanged() {
+        // do a deep equality check between the staged filters and applied filters
+        if (!this.compareStores()) {
+            this.setState({
+                filtersChanged: true
+            });
+        }
+        else if (this.state.filtersChanged) {
+            this.setState({
+                filtersChanged: false
+            });
+        }
+    }
+
+    applyStagedFilters() {
+        this.props.setAppliedFilterCompletion(false);
+        this.props.applyStagedFilters(this.props.stagedFilters);
+        this.setState({
+            filtersChanged: false
+        });
+    }
+
+    resetFilters() {
+        this.props.clearStagedFilters();
+        this.props.resetAppliedFilters();
+    }
+
+    render() {
+        return (
+            <SubmitButton
+                filtersChanged={this.state.filtersChanged}
+                requestsComplete={this.props.requestsComplete}
+                applyStagedFilters={this.applyStagedFilters}
+                resetFilters={this.resetFilters} />
+        );
+    }
+}
+
+export default connect(
+    (state) => ({
+        requestsComplete: state.appliedDashboardFilters._complete,
+        isEmpty: state.appliedDashboardFilters._empty,
+        stagedFilters: state.dashboardFilters,
+        appliedFilters: state.appliedDashboardFilters.filters
+    }),
+    (dispatch) => bindActionCreators(combinedActions, dispatch)
+)(SubmitButtonContainer);
+
+SubmitButtonContainer.propTypes = propTypes;

--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -90,10 +90,15 @@ export class SubmitButtonContainer extends React.Component {
     }
 
     render() {
+        // Make sure all the required filters have been staged
+        const stagedFilters = this.props.stagedFilters;
+        const requiredFields = stagedFilters.file
+            && stagedFilters.quarters.size > 0 && stagedFilters.fy.size > 0;
         return (
             <SubmitButton
                 filtersChanged={this.state.filtersChanged}
                 applyStagedFilters={this.applyStagedFilters}
+                validFilters={requiredFields}
                 resetFilters={this.resetFilters} />
         );
     }

--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -21,10 +21,8 @@ const combinedActions = Object.assign({}, appliedFilterActions, {
 const propTypes = {
     stagedFilters: PropTypes.object,
     appliedFilters: PropTypes.object,
-    requestsComplete: PropTypes.bool,
     applyStagedFilters: PropTypes.func,
     clearStagedFilters: PropTypes.func,
-    setAppliedFilterCompletion: PropTypes.func,
     resetAppliedFilters: PropTypes.func
 };
 
@@ -80,7 +78,6 @@ export class SubmitButtonContainer extends React.Component {
     }
 
     applyStagedFilters() {
-        this.props.setAppliedFilterCompletion(false);
         this.props.applyStagedFilters(this.props.stagedFilters);
         this.setState({
             filtersChanged: false
@@ -96,7 +93,6 @@ export class SubmitButtonContainer extends React.Component {
         return (
             <SubmitButton
                 filtersChanged={this.state.filtersChanged}
-                requestsComplete={this.props.requestsComplete}
                 applyStagedFilters={this.applyStagedFilters}
                 resetFilters={this.resetFilters} />
         );
@@ -105,7 +101,6 @@ export class SubmitButtonContainer extends React.Component {
 
 export default connect(
     (state) => ({
-        requestsComplete: state.appliedDashboardFilters._complete,
         isEmpty: state.appliedDashboardFilters._empty,
         stagedFilters: state.dashboardFilters,
         appliedFilters: state.appliedDashboardFilters.filters

--- a/src/js/redux/actions/dashboard/appliedFilterActions.js
+++ b/src/js/redux/actions/dashboard/appliedFilterActions.js
@@ -3,11 +3,6 @@
  * Created by Lizzie Salita 10/02/19
  */
 
-export const setAppliedFilterCompletion = (complete) => ({
-    complete,
-    type: 'SET_APPLIED_FILTER_COMPLETION'
-});
-
 export const setAppliedFilterEmptiness = (empty) => ({
     empty,
     type: 'SET_APPLIED_FILTER_EMPTINESS'

--- a/src/js/redux/reducers/dashboard/appliedFiltersReducer.js
+++ b/src/js/redux/reducers/dashboard/appliedFiltersReducer.js
@@ -7,8 +7,7 @@ import { initialState as defaultFilters } from './dashboardFiltersReducer';
 
 export const initialState = {
     filters: defaultFilters,
-    _empty: true,
-    _complete: true
+    _empty: true
 };
 
 export const appliedDashboardFiltersReducer = (state = initialState, action) => {
@@ -22,10 +21,6 @@ export const appliedDashboardFiltersReducer = (state = initialState, action) => 
         case 'SET_APPLIED_FILTER_EMPTINESS':
             return Object.assign({}, state, {
                 _empty: action.empty
-            });
-        case 'SET_APPLIED_FILTER_COMPLETION':
-            return Object.assign({}, state, {
-                _complete: action.complete
             });
         default:
             return state;

--- a/tests/containers/dashboard/filters/RulesFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/RulesFilterContainer-test.jsx
@@ -17,10 +17,14 @@ describe('RulesFilterContainer', () => {
         jest.restoreAllMocks();
     });
     it('should make an API call when the selected file changes', () => {
+        const newRedux = { ...mockRedux };
+        newRedux.selectedFilters.file = 'B';
+
         const container = shallow(<RulesFilterContainer
             {...mockActions}
-            {...mockRedux} />
+            {...newRedux} />
         );
+
         const fetchAutocompleteResults = jest.fn();
         container.instance().fetchAutocompleteResults = fetchAutocompleteResults;
 
@@ -29,9 +33,12 @@ describe('RulesFilterContainer', () => {
         expect(fetchAutocompleteResults).toHaveBeenCalled();
     });
     it('should clear the selected rules when the file changes', () => {
+        const newRedux = { ...mockRedux };
+        newRedux.selectedFilters.file = 'B';
+
         const container = shallow(<RulesFilterContainer
             {...mockActions}
-            {...mockRedux} />
+            {...newRedux} />
         );
         const fetchAutocompleteResults = jest.fn();
         container.instance().fetchAutocompleteResults = fetchAutocompleteResults;

--- a/tests/containers/dashboard/filters/SubmitButtonContainer-test.jsx
+++ b/tests/containers/dashboard/filters/SubmitButtonContainer-test.jsx
@@ -165,4 +165,17 @@ describe('SubmitButtonContainer', () => {
             expect(actions.resetAppliedFilters).toHaveBeenCalledTimes(1);
         });
     });
+    describe('componentWillUnmount', () => {
+        it('should reset staged and applied filters', () => {
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...mockActions} />
+            );
+            const resetFilters = jest.fn();
+            container.instance().resetFilters = resetFilters;
+            container.instance().componentWillUnmount();
+            expect(resetFilters).toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/containers/dashboard/filters/SubmitButtonContainer-test.jsx
+++ b/tests/containers/dashboard/filters/SubmitButtonContainer-test.jsx
@@ -1,0 +1,168 @@
+/**
+ * SubmitButtonContainer-test.jsx
+ * Created by Lizzie Salita 11/12/19
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Set } from 'immutable';
+
+import { initialState as initialApplied } from 'redux/reducers/dashboard/appliedFiltersReducer';
+import { initialState as initialStaged } from 'redux/reducers/dashboard/dashboardFiltersReducer';
+
+import { SubmitButtonContainer } from 'containers/dashboard/filters/SubmitButtonContainer';
+
+import { mockActions, mockSubmitRedux } from './mockFilters';
+
+jest.mock('components/dashboard/filters/SubmitButton', () =>
+    jest.fn(() => null));
+
+describe('SubmitButtonContainer', () => {
+    describe('compareStores', () => {
+        it('should return false if the length of enumerable properties on the applied filter object is different from the length of enumerable properties on the staged filter object', () => {
+            const changedStage = Object.assign({}, initialStaged, {
+                bonusFilter: 'hello'
+            });
+
+            const redux = Object.assign({}, mockSubmitRedux, {
+                stagedFilters: Object.assign({}, mockSubmitRedux.stagedFilters, changedStage)
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...redux}
+                    {...mockActions} />
+            );
+            const compare = container.instance().compareStores();
+            expect(compare).toBeFalsy();
+        });
+
+        it('should return false if any item in the staged filter object does not equal the same key value in the applied filter object', () => {
+            const changedStage = Object.assign({}, initialStaged, {
+                fy: new Set(['1995'])
+            });
+
+            const redux = Object.assign({}, mockSubmitRedux, {
+                stagedFilters: Object.assign({}, mockSubmitRedux.stagedFilters, changedStage)
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...redux}
+                    {...mockActions} />
+            );
+            const compare = container.instance().compareStores();
+            expect(compare).toBeFalsy();
+        });
+
+        it('should return true if all key values are equal in both the staged and applied filter objects', () => {
+            const changedStage = Object.assign({}, initialStaged, {
+                fy: new Set(['1995'])
+            });
+            const changedApplied = Object.assign({}, initialApplied.filters, {
+                fy: new Set(['1995'])
+            });
+
+            const redux = Object.assign({}, mockSubmitRedux, {
+                stagedFilters: Object.assign({}, mockSubmitRedux.stagedFilters, changedStage),
+                appliedFilters: Object.assign({}, mockSubmitRedux.appliedFilters.filters, changedApplied)
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...redux}
+                    {...mockActions} />
+            );
+            const compare = container.instance().compareStores();
+            expect(compare).toBeTruthy();
+        });
+    });
+    describe('stagingChanged', () => {
+        it('should set the filtersChanged state to true when the stores are not equal', () => {
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...mockActions} />
+            );
+            container.instance().compareStores = jest.fn(() => false);
+
+            container.instance().stagingChanged();
+            expect(container.state().filtersChanged).toBeTruthy();
+        });
+        it('should set the filtersChanged state to false when the stores are equal and the filtersChanged state was previously true', () => {
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...mockActions} />
+            );
+            container.instance().compareStores = jest.fn(() => true);
+            container.setState({
+                filtersChanged: true
+            });
+
+            container.instance().stagingChanged();
+            expect(container.state().filtersChanged).toBeFalsy();
+        });
+    });
+    describe('applyStagedFilters', () => {
+        it('should tell Redux to copy the staged filter set to the applied filter set', () => {
+            const actions = Object.assign({}, mockActions, {
+                applyStagedFilters: jest.fn()
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...actions} />
+            );
+            container.instance().applyStagedFilters();
+
+            expect(actions.applyStagedFilters).toHaveBeenCalledTimes(1);
+        });
+
+        it('should reset the filtersChanged state to false', () => {
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...mockActions} />
+            );
+            container.setState({
+                filtersChanged: true
+            });
+
+            container.instance().applyStagedFilters();
+
+            expect(container.state().filtersChanged).toBeFalsy();
+        });
+    });
+    describe('resetFilters', () => {
+        it('should reset all the staged filters to their initial states', () => {
+            const actions = Object.assign({}, mockActions, {
+                clearStagedFilters: jest.fn()
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...actions} />
+            );
+
+            container.instance().resetFilters();
+            expect(actions.clearStagedFilters).toHaveBeenCalledTimes(1);
+        });
+        it('should reset all the applied filters to their initial states', () => {
+            const actions = Object.assign({}, mockActions, {
+                resetAppliedFilters: jest.fn()
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    {...mockSubmitRedux}
+                    {...actions} />
+            );
+
+            container.instance().resetFilters();
+            expect(actions.resetAppliedFilters).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/tests/containers/dashboard/filters/mockFilters.js
+++ b/tests/containers/dashboard/filters/mockFilters.js
@@ -7,7 +7,7 @@ export const mockActions = {
     applyStagedFilters: jest.fn(),
     clearStagedFilters: jest.fn(),
     resetAppliedFilters: jest.fn(),
-    setAppliedFilterEmptiness: jest.fn()
+    setAppliedFilterEmptiness: jest.fn(),
     updateAgencyFilter: jest.fn()
 };
 

--- a/tests/containers/dashboard/filters/mockFilters.js
+++ b/tests/containers/dashboard/filters/mockFilters.js
@@ -6,7 +6,8 @@ export const mockActions = {
     clearGenericFilter: jest.fn(),
     applyStagedFilters: jest.fn(),
     clearStagedFilters: jest.fn(),
-    resetAppliedFilters: jest.fn()
+    resetAppliedFilters: jest.fn(),
+    setAppliedFilterEmptiness: jest.fn()
 };
 
 export const mockRedux = {

--- a/tests/containers/dashboard/filters/mockFilters.js
+++ b/tests/containers/dashboard/filters/mockFilters.js
@@ -1,10 +1,19 @@
 import { initialState } from 'redux/reducers/dashboard/dashboardFiltersReducer';
+import { initialState as appliedInitialState } from 'redux/reducers/dashboard/appliedFiltersReducer';
 
 export const mockActions = {
     updateGenericFilter: jest.fn(),
-    clearGenericFilter: jest.fn()
+    clearGenericFilter: jest.fn(),
+    applyStagedFilters: jest.fn(),
+    clearStagedFilters: jest.fn(),
+    resetAppliedFilters: jest.fn()
 };
 
 export const mockRedux = {
     selectedFilters: initialState
+};
+
+export const mockSubmitRedux = {
+    stagedFilters: initialState,
+    appliedFilters: appliedInitialState
 };

--- a/tests/redux/dashboard/appliedFiltersReducer-test.js
+++ b/tests/redux/dashboard/appliedFiltersReducer-test.js
@@ -67,18 +67,4 @@ describe('appliedDashboardFiltersReducer', () => {
             expect(state._empty).toBeFalsy();
         });
     });
-
-    describe('SET_APPLIED_FILTER_COMPLETION', () => {
-        it('should set the _complete value', () => {
-            let state = appliedDashboardFiltersReducer(undefined, {});
-            expect(state._complete).toBeTruthy();
-
-            const action = {
-                type: 'SET_APPLIED_FILTER_COMPLETION',
-                complete: false
-            };
-            state = appliedDashboardFiltersReducer(state, action);
-            expect(state._complete).toBeFalsy();
-        });
-    });
 });


### PR DESCRIPTION
**High level description:**
Adds the "Apply Filters" and "Reset Filters" buttons to the dashboard sidebar.

**Technical details:**
- Components are very similar to USAS [SearchSidebarSubmitContainer](https://github.com/fedspendingtransparency/usaspending-website/blob/dev/src/js/containers/search/SearchSidebarSubmitContainer.jsx) and [SearchSidebarSubmit](https://github.com/fedspendingtransparency/usaspending-website/blob/dev/src/js/components/search/SearchSidebarSubmit.jsx)
- Removed `setAppliedFilterCompletion` logic, since in this case the submit container itself isn't kicking off an API request (the visualizations will watch for changes to the applied filters) 

**Link to JIRA Ticket:**
[DEV-3662](https://federal-spending-transparency.atlassian.net/browse/DEV-3662)

**Mockup**
https://bahdigital.invisionapp.com/share/7GIABMNX8MV#/296021488_Historical-Search-Monthly-Single-No-Data 
_Note that we decided to stick with blue instead of gray for consistency with USAS_

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- [x] Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Design review complete
- [x] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- [x] Link to this PR in JIRA ticket