### PR TITLE
Fix dashboard responsive content width

### DIFF
--- a/src/_scss/pages/dashboard/dashboard.scss
+++ b/src/_scss/pages/dashboard/dashboard.scss
@@ -8,7 +8,11 @@
     @import "./dashboardTabs";
     .dashboard-page {
         padding: rem(30);
-        @include display(flex);
+        .dashboard-page__wrapper {
+            @include flex-direction(row);
+            @include display(flex);
+            width: 100%;
+        }
         .dashboard-page__filters {
             @include display(flex);
             @include flex(0 0 auto);

--- a/src/_scss/pages/dashboard/dashboard.scss
+++ b/src/_scss/pages/dashboard/dashboard.scss
@@ -12,6 +12,17 @@
             @include flex-direction(row);
             @include display(flex);
             width: 100%;
+            @media(max-width: $small-screen) {
+                display: block;
+                .dashboard-page__filters {
+                    width: 100%;
+                    margin-right: 0;
+                }
+                .dashboard-page__content {
+                    margin-left: 0;
+                    margin-top: rem(15);
+                }
+            }
         }
         .dashboard-page__filters {
             @include display(flex);
@@ -46,17 +57,6 @@
             @import './dashboardViz';
             @import './graph/warningsInfoGraph';
             @import "./visualizations/summary.scss";
-        }
-        @media(max-width: $small-screen) {
-            display: block;
-            .dashboard-page__filters {
-                width: 100%;
-                margin-right: 0;
-            }
-            .dashboard-page__content {
-                margin-left: 0;
-                margin-top: rem(15);
-            }
         }
     }
 }

--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -98,11 +98,13 @@ export default class DashboardPage extends React.Component {
                         </div>
                     </div>
                     <div className="dashboard-page">
-                        <div className="dashboard-page__filters">
-                            <FilterSidebar filters={filters} />
-                        </div>
-                        <div className="dashboard-page__content">
-                            <DashboardContentContainer />
+                        <div className="dashboard-page__wrapper">
+                            <div className="dashboard-page__filters">
+                                <FilterSidebar filters={filters} />
+                            </div>
+                            <div className="dashboard-page__content">
+                                <DashboardContentContainer />
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
**High level description:**
Fixes a bug causing the main content of the dashboard to extend beyond the width of the header when changing the window size.

**Technical details:**

- Adds a new wrapper and overrides `@include flex-direction(column);` that applied to `usa-da-site_wrap`

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Frontend review completed
- N/A Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA 
- N/A Design review completed
- [ ] Verified cross-browser compatibility
- N/A All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)
- N/A Link to this PR in JIRA ticket