### PR TITLE
Fix graph legend

### DIFF
--- a/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
@@ -73,7 +73,7 @@ export class WarningsInfoGraphContainer extends React.Component {
     generateLegend(yData) {
         let rules = [];
         yData.forEach((submission) => {
-            rules = union(rules, submission.map((rule) => Object.values(rule)[0]));
+            rules = union(rules, submission.map((rule) => rule.label));
         });
         return buildLegend(rules);
     }

--- a/tests/containers/dashboard/graph/WarningsInfoGraphContainer-test.jsx
+++ b/tests/containers/dashboard/graph/WarningsInfoGraphContainer-test.jsx
@@ -49,6 +49,8 @@ describe('WarningsInfoGraphContainer', () => {
             );
             const ySeries = [
                 [{
+                    instances: 1234,
+                    percent_total: 42,
                     label: "C23"
                 }, {
                     label: "C12"


### PR DESCRIPTION
**High level description:**
Fixes a bug that caused the legend to sometimes be generated incorrectly.

**Technical details:**
The previous implementation expected the rule label to be the first property in each rule object. The fix references the property name instead of using an index.

**Link to JIRA Ticket:**

[DEV-3664](https://federal-spending-transparency.atlassian.net/browse/DEV-3664)

The following are ALL required for the PR to be merged:

Reviewer(s):
- [x] Frontend review completed