### PR TITLE
Warmfix add graph colors

### DIFF
--- a/src/js/components/dashboard/graph/BarChartStacked.jsx
+++ b/src/js/components/dashboard/graph/BarChartStacked.jsx
@@ -278,9 +278,13 @@ ${xAxis.items[0].label} to ${xAxis.items[xAxis.items.length - 1].label}.`;
                     const space = data.bottom === 0 ? 0 : this.props.spaceBetweenStacks;
                     // calculate height by getting the Y position of the bottom of
                     // the bar and taking the difference
-                    height = (values.yScale(data.bottom) - space) - yPos;
+                    const yPosBottom = values.yScale(data.bottom);
+                    height = (yPosBottom - space) - yPos;
                     // prevent a negative height
                     height = height < 0 ? 0 : height;
+
+                    // Get the midpoint of the stack for the tooltip position
+                    const mid = yPos - ((yPos - yPosBottom) / 2);
 
                     // merge the positioning of the stacked item with its metadata
                     const element = Object.assign({}, stack, {
@@ -295,7 +299,7 @@ ${xAxis.items[0].label} to ${xAxis.items[xAxis.items.length - 1].label}.`;
                             ...data,
                             position: {
                                 x: xPos + (barWidth / 2) + values.padding.left,
-                                y: yPos
+                                y: mid - 22 // subtract 22px to line up the pointer instead of the top of the tooltip
                             }
                         }
                     });

--- a/src/js/dataMapping/dashboard/fileLabels.js
+++ b/src/js/dataMapping/dashboard/fileLabels.js
@@ -25,5 +25,11 @@ export const chartColors = [
     '#923051', // cranberry
     '#00BFE7', // cerulean
     '#122E51', // navy
-    '#94BFA2' // sage green
+    '#94BFA2', // sage green
+    '#7E22CE', // purple
+    '#F1354C', // red
+    '#22CE7E', // bright green
+    '#90A4FF', // periwinkle
+    '#D4E525', // chartreuse
+    '#4C9EB2' // teal
 ];


### PR DESCRIPTION
**High level description:**

- Adds more colors to the legend to allow for up to 17 rules
- Centers the tooltip pointer on the vertical middle of each stack to avoid confusion for smaller stacks

**Link to JIRA Ticket:**

[DEV-3664](https://federal-spending-transparency.atlassian.net/browse/DEV-3664)

**Mockup**
https://bahdigital.invisionapp.com/share/7GIABMNX8MV#/296021489_Historical-Search-Monthly-Single-Data

The following are ALL required for the PR to be merged:

Author: 
- [ ] Verified cross-browser compatibility
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Design review completed
- [ ] Frontend review completed