### PR TITLE
DEV-3666: historical dashboard table go to

### DIFF
--- a/src/_scss/pages/dashboard/table/_dashboardPagination.scss
+++ b/src/_scss/pages/dashboard/table/_dashboardPagination.scss
@@ -1,6 +1,7 @@
 .dashboard-table-pagination {
     @import "../../../sharedComponents/paginator";
     @import "../../../sharedComponents/limitSelector";
+    @import "../../../sharedComponents/goTo";
     @include display(flex);
 
     .table-paginator {

--- a/src/_scss/sharedComponents/_goTo.scss
+++ b/src/_scss/sharedComponents/_goTo.scss
@@ -1,0 +1,36 @@
+.table-go-to {
+    margin-left: rem(18);
+
+    input {
+        width: rem(48);
+        margin: 0 rem(6);
+    }
+
+    label {
+        font-size: rem(12);
+        font-weight: normal;
+    }
+
+    button {
+        color: $color-white;
+        font-size: rem(12);
+        font-weight: $font-bold;
+        transition: opacity 0.15s;
+        padding: rem(5) rem(15);
+        border: 0;
+
+        background-color: $color-primary;
+
+        &:hover {
+            background-color: $color-primary-darker;            
+        }
+
+        &[disabled] {
+            opacity: 0.5;
+            cursor: not-allowed;
+            &:hover {
+                background-color: $color-primary;
+            }
+        }
+    }
+}

--- a/src/_scss/sharedComponents/_goTo.scss
+++ b/src/_scss/sharedComponents/_goTo.scss
@@ -18,6 +18,7 @@
         transition: opacity 0.15s;
         padding: rem(5) rem(15);
         border: 0;
+        border-radius: rem(2);
 
         background-color: $color-primary;
 

--- a/src/js/components/SharedComponents/DropdownTypeahead.jsx
+++ b/src/js/components/SharedComponents/DropdownTypeahead.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Awesomplete from 'awesomplete';
+import { keyCodes } from 'dataMapping/keyMappings';
 import DropdownTypeaheadCheckbox from './DropdownTypeaheadCheckbox';
 
 import TypeaheadWarning from './TypeaheadWarning';
@@ -189,7 +190,7 @@ export default class DropdownTypeahead extends React.Component {
 
         // enable tab keyboard shortcut for selection
         this.awesomplete.addEventListener('keydown', (e) => {
-            if (e.keyCode === 9) {
+            if (e.keyCode === keyCodes.tab) {
                 this.typeahead.select();
             }
         });

--- a/src/js/components/SharedComponents/Typeahead.jsx
+++ b/src/js/components/SharedComponents/Typeahead.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Awesomplete from 'awesomplete';
+import { keyCodes } from 'dataMapping/keyMappings';
 
 import TypeaheadWarning from './TypeaheadWarning';
 
@@ -122,7 +123,7 @@ export default class Typeahead extends React.Component {
 
         // enable tab keyboard shortcut for selection
         this.awesomplete.addEventListener('keydown', (e) => {
-            if (e.keyCode === 9) {
+            if (e.keyCode === keyCodes.tab) {
                 this.typeahead.select();
             }
         });

--- a/src/js/components/SharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/SharedComponents/autocomplete/Autocomplete.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, find, uniqueId } from 'lodash';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { keyCodes } from 'dataMapping/keyMappings';
 
 import Warning from './Warning';
 import SuggestionHolder from './SuggestionHolder';
@@ -129,7 +130,7 @@ export default class Autocomplete extends React.Component {
         // enable tab keyboard shortcut for selection
         target.addEventListener('keydown', (e) => {
             // Enter
-            if (e.keyCode === 13) {
+            if (e.keyCode === keyCodes.enter) {
                 e.preventDefault();
                 this.select(this.props.values[this.state.selectedIndex]);
                 if (!this.props.retainValue) {
@@ -137,16 +138,16 @@ export default class Autocomplete extends React.Component {
                 }
             }
             // Tab or Escape
-            else if (e.keyCode === 9 || e.keyCode === 27) {
+            else if (e.keyCode === keyCodes.tab || e.keyCode === keyCodes.escape) {
                 target.value = '';
                 this.close();
             }
             // Previous
-            else if (e.keyCode === 38) {
+            else if (e.keyCode === keyCodes.up) {
                 this.previous();
             }
             // Next
-            else if (e.keyCode === 40) {
+            else if (e.keyCode === keyCodes.down) {
                 this.next();
             }
         });

--- a/src/js/components/SharedComponents/autocomplete/Autocomplete.jsx
+++ b/src/js/components/SharedComponents/autocomplete/Autocomplete.jsx
@@ -138,7 +138,7 @@ export default class Autocomplete extends React.Component {
                 }
             }
             // Tab or Escape
-            else if (e.keyCode === keyCodes.tab || e.keyCode === keyCodes.escape) {
+            else if (e.keyCode === keyCodes.tab || e.keyCode === keyCodes.esc) {
                 target.value = '';
                 this.close();
             }

--- a/src/js/components/SharedComponents/table/TableGoTo.jsx
+++ b/src/js/components/SharedComponents/table/TableGoTo.jsx
@@ -1,0 +1,86 @@
+/**
+ * TableGoTo.jsx
+ * Created by Alisa Burdeyny 12/5/19
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    changePage: PropTypes.func.isRequired,
+    totalPages: PropTypes.number
+};
+
+const defaultProps = {
+    totalPages: 10
+};
+
+export default class TableLimit extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            goToPage: ''
+        };
+
+        this.changePage = this.changePage.bind(this);
+        this.changedInput = this.changedInput.bind(this);
+        this.onKeyDownHandler = this.onKeyDownHandler.bind(this);
+        this.validPage = this.validPage.bind(this);
+    }
+
+    changePage() {
+        this.props.changePage(parseInt(this.state.goToPage, 10));
+    }
+
+    changedInput(e) {
+        this.setState({
+            goToPage: e.target.value
+        });
+    }
+
+    onKeyDownHandler(e) {
+        if(e.keyCode == 13 && this.validPage()) {
+            e.preventDefault();
+            this.changePage();
+        }
+    }
+
+    validPage() {
+        if (this.state.goToPage === '' || parseInt(this.state.goToPage, 10) < 1 ||
+            parseInt(this.state.goToPage, 10) > this.props.totalPages) {
+            return false;
+        }
+
+        return true;
+    }
+
+    render() {
+        return (
+            <div className="table-go-to">
+                <label htmlFor="table-go-to">
+                    Go to page
+                </label>
+                <input
+                    type="number"
+                    id="table-go-to"
+                    title={"Enter a number between 1 and " + this.props.totalPages}
+                    min="1"
+                    max={this.props.totalPages}
+                    placeholder={"1-" + this.props.totalPages}
+                    value={this.state.goToPage}
+                    onChange={this.changedInput}
+                    onKeyDown={this.onKeyDownHandler} />
+                <button
+                    onClick={this.changePage}
+                    disabled={!this.validPage()}>
+                    Go
+                </button>
+            </div>
+        );
+    }
+}
+
+TableLimit.propTypes = propTypes;
+TableLimit.defaultProps = defaultProps;
+ 

--- a/src/js/components/SharedComponents/table/TableGoTo.jsx
+++ b/src/js/components/SharedComponents/table/TableGoTo.jsx
@@ -23,10 +23,17 @@ export default class TableLimit extends React.Component {
             goToPage: ''
         };
 
+        this.onKeyDownHandler = this.onKeyDownHandler.bind(this);
         this.changePage = this.changePage.bind(this);
         this.changedInput = this.changedInput.bind(this);
-        this.onKeyDownHandler = this.onKeyDownHandler.bind(this);
         this.validPage = this.validPage.bind(this);
+    }
+
+    onKeyDownHandler(e) {
+        if (e.keyCode === 13 && this.validPage()) {
+            e.preventDefault();
+            this.changePage();
+        }
     }
 
     changePage() {
@@ -37,13 +44,6 @@ export default class TableLimit extends React.Component {
         this.setState({
             goToPage: e.target.value
         });
-    }
-
-    onKeyDownHandler(e) {
-        if(e.keyCode == 13 && this.validPage()) {
-            e.preventDefault();
-            this.changePage();
-        }
     }
 
     validPage() {
@@ -64,10 +64,10 @@ export default class TableLimit extends React.Component {
                 <input
                     type="number"
                     id="table-go-to"
-                    title={"Enter a number between 1 and " + this.props.totalPages}
+                    title={`Enter a number between 1 and ${this.props.totalPages}`}
                     min="1"
                     max={this.props.totalPages}
-                    placeholder={"1-" + this.props.totalPages}
+                    placeholder={`1-${this.props.totalPages}`}
                     value={this.state.goToPage}
                     onChange={this.changedInput}
                     onKeyDown={this.onKeyDownHandler} />
@@ -83,4 +83,3 @@ export default class TableLimit extends React.Component {
 
 TableLimit.propTypes = propTypes;
 TableLimit.defaultProps = defaultProps;
- 

--- a/src/js/components/SharedComponents/table/TableGoTo.jsx
+++ b/src/js/components/SharedComponents/table/TableGoTo.jsx
@@ -14,7 +14,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    totalPages: 10
+    totalPages: 1
 };
 
 export default class TableLimit extends React.Component {
@@ -58,8 +58,9 @@ export default class TableLimit extends React.Component {
     }
 
     render() {
+        const placeholder = this.props.totalPages > 1 ? `1-${this.props.totalPages}` : '1';
         return (
-            <div className="table-go-to">
+            <form className="table-go-to">
                 <label htmlFor="table-go-to">
                     Go to page
                 </label>
@@ -69,7 +70,7 @@ export default class TableLimit extends React.Component {
                     title={`Enter a number between 1 and ${this.props.totalPages}`}
                     min="1"
                     max={this.props.totalPages}
-                    placeholder={`1-${this.props.totalPages}`}
+                    placeholder={placeholder}
                     value={this.state.goToPage}
                     onChange={this.changedInput}
                     onKeyDown={this.onKeyDownHandler} />
@@ -78,7 +79,7 @@ export default class TableLimit extends React.Component {
                     disabled={!this.validPage()}>
                     Go
                 </button>
-            </div>
+            </form>
         );
     }
 }

--- a/src/js/components/SharedComponents/table/TableGoTo.jsx
+++ b/src/js/components/SharedComponents/table/TableGoTo.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { keyCodes } from 'dataMapping/keyMappings';
+
 const propTypes = {
     changePage: PropTypes.func.isRequired,
     totalPages: PropTypes.number
@@ -30,7 +32,7 @@ export default class TableLimit extends React.Component {
     }
 
     onKeyDownHandler(e) {
-        if (e.keyCode === 13 && this.validPage()) {
+        if (e.keyCode === keyCodes.enter && this.validPage()) {
             e.preventDefault();
             this.changePage();
         }

--- a/src/js/components/dashboard/table/DashboardTablePagination.jsx
+++ b/src/js/components/dashboard/table/DashboardTablePagination.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 
 import TablePaginator from 'components/SharedComponents/table/TablePaginator';
 import TableLimit from 'components/SharedComponents/table/TableLimit';
+import TableGoTo from 'components/SharedComponents/table/TableGoTo';
 
 const propTypes = {
     totalPages: PropTypes.number,
@@ -34,6 +35,9 @@ export default class DashboardTablePagination extends React.Component {
                 <TableLimit
                     changeLimit={this.props.changeLimit}
                     pageLimit={this.props.pageLimit} />
+                <TableGoTo
+                    changePage={this.props.changePage}
+                    totalPages={this.props.totalPages} />
             </div>
         );
     }

--- a/src/js/components/generateFiles/components/DatePicker.jsx
+++ b/src/js/components/generateFiles/components/DatePicker.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DayPicker, { DateUtils } from 'react-day-picker';
 import moment from 'moment';
+import { keyCodes } from 'dataMapping/keyMappings';
 import * as Icons from '../../SharedComponents/icons/Icons';
 
 const propTypes = {
@@ -98,7 +99,7 @@ export default class DatePicker extends React.Component {
     }
 
     escapeDatePicker(e) {
-        if (e.keyCode === 27) {
+        if (e.keyCode === keyCodes.escape) {
             this.toggleDatePicker(e);
         }
     }

--- a/src/js/components/generateFiles/components/DatePicker.jsx
+++ b/src/js/components/generateFiles/components/DatePicker.jsx
@@ -99,7 +99,7 @@ export default class DatePicker extends React.Component {
     }
 
     escapeDatePicker(e) {
-        if (e.keyCode === keyCodes.escape) {
+        if (e.keyCode === keyCodes.esc) {
             this.toggleDatePicker(e);
         }
     }

--- a/src/js/dataMapping/keyMappings.js
+++ b/src/js/dataMapping/keyMappings.js
@@ -1,4 +1,8 @@
 // Mapping keyboard keys to their numerical values
 export const keyCodes = {
-    enter: 13
+    tab: 9,
+    enter: 13,
+    escape: 27,
+    up: 38,
+    down: 40
 };

--- a/src/js/dataMapping/keyMappings.js
+++ b/src/js/dataMapping/keyMappings.js
@@ -1,0 +1,4 @@
+// Mapping keyboard keys to their numerical values
+export const keyCodes = {
+    enter: 13
+};

--- a/src/js/dataMapping/keyMappings.js
+++ b/src/js/dataMapping/keyMappings.js
@@ -2,7 +2,7 @@
 export const keyCodes = {
     tab: 9,
     enter: 13,
-    escape: 27,
+    esc: 27,
     up: 38,
     down: 40
 };


### PR DESCRIPTION
**High level description:**

Adding a "go to" to the historical dashboard table

**Technical details:**

- Go button is disabled if a valid value isn't entered into the input
- Enter key works only if a valid value is entered
- Added key code mappings so we don't have to know the number to check for keys

**Link to JIRA Ticket:**

[DEV-3666](https://federal-spending-transparency.atlassian.net/browse/DEV-3666)

**Mockup**
https://bahdigital.invisionapp.com/share/7GIABMNX8MV#/screens/296021489
NOTE: After discussion with design team, the "Go to page" message and the input box are flipped, designer not available as of making this PR to update mocks

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed