### PR TITLE
DEV-2174: text break validation errors

### DIFF
--- a/src/_scss/pages/validateData/fileItem/bottomSide/_table.scss
+++ b/src/_scss/pages/validateData/fileItem/bottomSide/_table.scss
@@ -1,24 +1,22 @@
-@import "../../../../components/tables/_scrollableTable";
+@import 'components/tables/_scrollableTable';
 
 @mixin bottomSideTable {
 	@include scrollableTable;
 
-	td,
-    th {
+	th, td {
         text-align: left;
-    }
-    th.headerColA,
-    td.cellColA {
-        width: 24%;
-    }
-    th.headerColB,
-    td.cellColB {
-        width: 59.8%;
-    }
-    th.headerColC {
-        width: 15.9%;
-    }
-    td.cellColC {
-        width: 15.9%;
+        word-break: normal;
+
+        &.colA {
+            width: 24%;
+        }
+
+        &.colB {
+            width: 59.8%;
+        }
+
+        &.colC {
+            width: 15.9%;
+        }
     }
 }

--- a/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
+++ b/src/js/components/validateData/validateValues/ValidateValuesErrorReport.jsx
@@ -41,8 +41,8 @@ export default class ValidateValuesErrorReport extends React.Component {
         this.state = {
             sortDirection: 'asc',
             sortField: 0,
-            headerClasses: ['headerColA', 'headerColB', 'headerColC'],
-            cellClasses: ['cellColA', 'cellColB', 'cellColC'],
+            headerClasses: ['colA', 'colB', 'colC'],
+            cellClasses: ['colA', 'colB', 'colC'],
             table: null,
             signedUrl: '',
             signInProgress: false


### PR DESCRIPTION
**High level description:**

Updating the CSS for validation errors/warnings table so words don't break in the middle unless they're longer than the column

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-2174](https://federal-spending-transparency.atlassian.net/browse/DEV-2174)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] All componentWillReceiveProps, componentWillMount, and componentWillUpdate in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)

Reviewer(s):
- Design review completed
- [x] Frontend review completed