### PR TITLE
DEV-2174: Text break cross file

### DIFF
--- a/src/_scss/components/tables/_scrollableTable.scss
+++ b/src/_scss/components/tables/_scrollableTable.scss
@@ -35,7 +35,6 @@
 		max-height: 250px;
         display: block;
         overflow-y: scroll;
-        word-break: break-all;
 
 		tr:last-child {
             & td {

--- a/src/_scss/pages/validateData/fileItem/bottomSide/_table.scss
+++ b/src/_scss/pages/validateData/fileItem/bottomSide/_table.scss
@@ -5,7 +5,6 @@
 
 	th, td {
         text-align: left;
-        word-break: normal;
 
         &.colA {
             width: 24%;


### PR DESCRIPTION
**High level description:**

Missed one of the scrollable tables in the last PR

**Technical details:**

No idea why we were always breaking the word, just removing that from the CSS for scrollable tables

**Link to JIRA Ticket:**

[DEV-2174](https://federal-spending-transparency.atlassian.net/browse/DEV-2174)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- All componentWillReceiveProps in relevant child/parent components/containers replaced with [future compatible life-cycle methods](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) per [JIRA item 3339](https://federal-spending-transparency.atlassian.net/browse/DEV-3339)

Reviewer(s):
- Design review completed
- [x] Frontend review completed