### PR TITLE
DEV-1755 Complete migration to prop-types

### DIFF
--- a/src/js/components/submissionsTable/HistoryLink.jsx
+++ b/src/js/components/submissionsTable/HistoryLink.jsx
@@ -4,12 +4,13 @@
   */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import * as Icons from '../SharedComponents/icons/Icons';
 
 const propTypes = {
-    submissionId: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number
+    submissionId: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
     ]).isRequired
 };
 

--- a/src/js/containers/crossFile/CrossFileGenerateModalContainer.jsx
+++ b/src/js/containers/crossFile/CrossFileGenerateModalContainer.jsx
@@ -331,5 +331,5 @@ CrossFileGenerateModalContainer.propTypes = propTypes;
 CrossFileGenerateModalContainer.defaultProps = defaultProps;
 
 CrossFileGenerateModalContainer.contextTypes = {
-    store: React.PropTypes.object.isRequired
+    store: PropTypes.object.isRequired
 };


### PR DESCRIPTION
**High level description:**

Removes a deprecated React pattern in preparation for upgrading to React v16.

**Technical details:**

Removes the last few instances of accessing `PropTypes` via the main React package.

**Link to JIRA Ticket:**

[DEV-1755](https://federal-spending-transparency.atlassian.net/browse/DEV-1755)

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket

Reviewer(s):
- [ ] Frontend review completed