### PR TITLE
Warmfix DEV-4186 period picker inclusivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "lodash": "^4.17.15",
     "markdown": "^0.5.0",
     "mini-css-extract-plugin": "^0.6.0",
-    "moment": "^2.12.0",
+    "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
     "node-sass": "^4.12.0",
     "node-uuid": "^1.4.7",

--- a/src/js/helpers/periodPickerHelper.js
+++ b/src/js/helpers/periodPickerHelper.js
@@ -20,7 +20,13 @@ export const mostRecentPeriod = () => {
 
     let period = 12;
 
-    if (today.isBetween(moment(`12/19/${year}`, 'MM-DD-YYYY'), moment(`01/16/${year + 1}`, 'MM-DD-YYYY'), null, '[]')) {
+    if (today.isBetween(moment(`12/19/${year}`, 'MM-DD-YYYY'), moment(`12/31/${year}`, 'MM-DD-YYYY'), null, '[]')) {
+        // Period 2 before Jan 1
+        period = 2;
+        year += 1;
+    }
+    else if (today.isBetween(moment(`01/01/${year}`, 'MM-DD-YYYY'), moment(`01/16/${year}`, 'MM-DD-YYYY'), null, '[]')) {
+        // Period 2 after Jan 1
         period = 2;
     }
     else if (today.isBetween(moment(`01/17/${year}`, 'MM-DD-YYYY'), moment(`02/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
@@ -49,10 +55,6 @@ export const mostRecentPeriod = () => {
     }
     else if (today.isBetween(moment(`09/18/${year}`, 'MM-DD-YYYY'), moment(`10/16/${year}`, 'MM-DD-YYYY'), null, '[]')) {
         period = 11;
-    }
-
-    if (today.isBetween(moment(`12/19/${year}`, 'MM-DD-YYYY'), moment(`12/31/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        year += 1;
     }
 
     return {

--- a/tests/helpers/periodPickerHelper-test.js
+++ b/tests/helpers/periodPickerHelper-test.js
@@ -83,7 +83,7 @@ describe('periodPickerHelper', () => {
                 year: 1913
             });
         });
-        it('should return the next year from when period 2 becomes available until Dec 31st', () => {
+        it('should return the next calendar year from when period 2 becomes available until Dec 31st', () => {
             mockDate('1912-12-31');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output).toEqual({
@@ -91,7 +91,7 @@ describe('periodPickerHelper', () => {
                 year: 1913
             });
         });
-        it('should use the current year starting on Jan 1st', () => {
+        it('should use the current calendar year starting on Jan 1st', () => {
             mockDate('1913-01-01');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output).toEqual({

--- a/tests/helpers/periodPickerHelper-test.js
+++ b/tests/helpers/periodPickerHelper-test.js
@@ -75,8 +75,24 @@ describe('periodPickerHelper', () => {
                 year: 1912
             });
         });
-        it('if GTAS data is available for this year (2012), then it should return the next year (2013) for this specific window', () => {
+        it('if GTAS data is available for this year, then it should return the next year for this specific window', () => {
             mockDate('1912-12-19');
+            const output = periodPickerHelper.mostRecentPeriod();
+            expect(output).toEqual({
+                period: 2,
+                year: 1913
+            });
+        });
+        it('should return the next year from when period 2 becomes available until Dec 31st', () => {
+            mockDate('1912-12-31');
+            const output = periodPickerHelper.mostRecentPeriod();
+            expect(output).toEqual({
+                period: 2,
+                year: 1913
+            });
+        });
+        it('should use the current year starting on Jan 1st', () => {
+            mockDate('1913-01-01');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output).toEqual({
                 period: 2,


### PR DESCRIPTION
**High level description:**

Updates the Generate Detached File A fiscal year and period dropdowns to correctly handle dates from 12/31 to 1/16

**Technical details:**

- We were attempting to use the inclusivity parameter with moment.js's `isBetween` function, but the version of moment.js we were using did not support it. See https://momentjscom.readthedocs.io/en/latest/moment/05-query/06-is-between/. 
- Period 2 before 1/1 and period 2 after 1/1 needed to be checked for in separate conditions

**Link to JIRA Ticket:**

[DEV-4186](https://federal-spending-transparency.atlassian.net/browse/DEV-4186)

The following are ALL required for the PR to be merged:

Author: 
- [ ] JIRA ticket AC approved
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA

Reviewer(s):
- [ ] Frontend review completed