### PR TITLE
Changed data-transparency-ui to v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4396,7 +4396,7 @@
     },
     "data-transparency-ui": {
       "version": "github:fedspendingtransparency/data-transparency-ui#7fe08e890d515049236af2eb5b51a297783eb318",
-      "from": "github:fedspendingtransparency/data-transparency-ui#master",
+      "from": "github:fedspendingtransparency/data-transparency-ui#v0.2.0",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.25",
         "@fortawesome/free-solid-svg-icons": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "core-js": "^3.0.1",
     "css-loader": "^2.1.1",
     "d3": "^3.5.16",
-    "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#master",
+    "data-transparency-ui": "github:fedspendingtransparency/data-transparency-ui#v0.2.0",
     "d3-scale": "^1.0.4",
     "dompurify": "^0.7.4",
     "ent": "^2.2.0",


### PR DESCRIPTION
Changes the component library dependency to point to the latest release, [v0.2.0](https://github.com/fedspendingtransparency/data-transparency-ui/releases/tag/v0.2.0).
