### PR TITLE
Fix FABS submission status

### DIFF
--- a/src/js/components/reviewData/ReviewDataContent.jsx
+++ b/src/js/components/reviewData/ReviewDataContent.jsx
@@ -18,14 +18,12 @@ import { formatSize } from '../../helpers/util';
 
 const propTypes = {
     data: PropTypes.object,
-    params: PropTypes.object,
     session: PropTypes.object,
     submissionID: PropTypes.string
 };
 
 const defaultProps = {
     data: null,
-    params: null,
     session: null,
     submissionID: ''
 };
@@ -223,7 +221,7 @@ export default class ReviewDataContent extends React.Component {
                         <div className="col-md-4" />
                         <ReviewDataNarrative
                             narrative={this.props.data.file_narrative}
-                            submissionID={this.props.params.submissionID} />
+                            submissionID={this.props.submissionID} />
                     </div>
                     <div className="mt-20 row submission-button-holder">
                         <div className="col-md-4" />

--- a/src/js/components/reviewData/ReviewDataPage.jsx
+++ b/src/js/components/reviewData/ReviewDataPage.jsx
@@ -6,28 +6,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Banner from 'components/SharedComponents/Banner';
-import Footer from '../SharedComponents/FooterComponent';
-
+import Footer from 'components/SharedComponents/FooterComponent';
+import PublishedSubmissionWarningBanner from 'components/SharedComponents/PublishedSubmissionWarningBanner';
 import ReviewDataContent from './ReviewDataContent';
 import ReviewLoading from './ReviewLoading';
-import PublishedSubmissionWarningBanner from '../../components/SharedComponents/PublishedSubmissionWarningBanner';
 
 const propTypes = {
     data: PropTypes.object,
-    params: PropTypes.object,
+    submissionID: PropTypes.string,
     submission: PropTypes.object
 };
 
 const defaultProps = {
     data: null,
-    params: null,
     submission: null
 };
 
 export default class ReviewDataPage extends React.Component {
     render() {
         let currentComponent;
-        const submissionID = this.props.params.submissionID;
+        const { submissionID } = this.props;
 
         if (!this.props.data.ready) {
             currentComponent = <ReviewLoading />;

--- a/src/js/components/uploadFabsFile/UploadFabsFilePage.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFilePage.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Footer from '../SharedComponents/FooterComponent';
-import Navbar from '../SharedComponents/navigation/NavigationComponent';
+import Footer from 'components/SharedComponents/FooterComponent';
+import Navbar from 'components/SharedComponents/navigation/NavigationComponent';
 
 import UploadFabsFileMeta from './UploadFabsFileMeta';
 import UploadFabsFileValidation from './UploadFabsFileValidation';
@@ -16,7 +16,7 @@ const propTypes = {
     setSubmissionId: PropTypes.func,
     setSubmissionState: PropTypes.func,
     history: PropTypes.object,
-    params: PropTypes.object,
+    computedMatch: PropTypes.object,
     type: PropTypes.oneOf(['dabs', 'fabs']),
     submission: PropTypes.object
 };
@@ -25,7 +25,6 @@ const defaultProps = {
     setSubmissionId: () => {},
     setSubmissionState: () => {},
     history: {},
-    params: {},
     submission: {}
 };
 
@@ -37,8 +36,8 @@ export default class UploadFabsFilePage extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { params } = this.props;
-        if (params.submissionID !== prevProps.params.submissionID) {
+        const { params } = this.props.computedMatch;
+        if (params.submissionID !== prevProps.computedMatch.params.submissionID) {
             this.props.setSubmissionId(params.submissionID);
         }
     }
@@ -50,7 +49,7 @@ export default class UploadFabsFilePage extends React.Component {
 
     render() {
         let content = null;
-        if (this.props.params.submissionID) {
+        if (this.props.computedMatch.params.submissionID) {
             content = (<UploadFabsFileValidation
                 {...this.props}
                 submission={this.props.submission}

--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -9,27 +9,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import ValidateValuesFileContainer from '../../containers/validateData/ValidateValuesFileContainer';
-import ValidateDataFileContainer from '../../containers/validateData/ValidateDataFileContainer';
+import * as UploadHelper from 'helpers/uploadHelper';
+import * as GenerateFilesHelper from 'helpers/generateFilesHelper';
+import * as PermissionsHelper from 'helpers/permissionsHelper';
+import * as ReviewHelper from 'helpers/reviewHelper';
+import ValidateValuesFileContainer from 'containers/validateData/ValidateValuesFileContainer';
+import ValidateDataFileContainer from 'containers/validateData/ValidateDataFileContainer';
+import Banner from 'components/SharedComponents/Banner';
+import * as Icons from 'components/SharedComponents/icons/Icons';
+import DABSFABSErrorMessage from 'components/SharedComponents/DABSFABSErrorMessage';
 import PublishModal from './PublishModal';
-import Banner from '../SharedComponents/Banner';
 import UploadFabsFileError from './UploadFabsFileError';
 import UploadFabsFileHeader from './UploadFabsFileHeader';
-
-import * as UploadHelper from '../../helpers/uploadHelper';
-import * as GenerateFilesHelper from '../../helpers/generateFilesHelper';
-import * as PermissionsHelper from '../../helpers/permissionsHelper';
-import * as ReviewHelper from '../../helpers/reviewHelper';
 import { kGlobalConstants } from '../../GlobalConstants';
 
-import * as Icons from '../SharedComponents/icons/Icons';
-import DABSFABSErrorMessage from '../SharedComponents/DABSFABSErrorMessage';
 
 const propTypes = {
     setSubmissionState: PropTypes.func,
     resetSubmission: PropTypes.func,
     item: PropTypes.object,
-    params: PropTypes.object,
+    computedMatch: PropTypes.object,
     session: PropTypes.object,
     submission: PropTypes.object
 };
@@ -37,7 +36,6 @@ const propTypes = {
 const defaultProps = {
     setSubmissionState: () => {},
     item: {},
-    params: {},
     session: {},
     submission: {}
 };
@@ -74,16 +72,18 @@ export class UploadFabsFileValidation extends React.Component {
 
     componentDidMount() {
         this.isUnmounted = false;
-        if (this.props.params.submissionID) {
-            this.setSubmissionMetadata(this.props.params.submissionID);
-            this.checkFileStatus(this.props.params.submissionID);
+        const { submissionID } = this.props.computedMatch.params;
+        if (submissionID) {
+            this.setSubmissionMetadata(submissionID);
+            this.checkFileStatus(submissionID);
         }
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.params.submissionID !== this.props.params.submissionID && this.props.params.submissionID) {
-            this.setSubmissionMetadata(this.props.params.submissionID);
-            this.checkFileStatus(this.props.params.submissionID);
+        const { submissionID } = this.props.computedMatch.params;
+        if (prevProps.computedMatch.params.submissionID !== submissionID && submissionID) {
+            this.setSubmissionMetadata(submissionID);
+            this.checkFileStatus(submissionID);
             this.setSubmissionError();
         }
     }
@@ -147,9 +147,10 @@ export class UploadFabsFileValidation extends React.Component {
     }
 
     revalidate() {
-        ReviewHelper.revalidateSubmission(this.props.params.submissionID, true)
+        const { submissionID } = this.props.computedMatch.params;
+        ReviewHelper.revalidateSubmission(submissionID, true)
             .then(() => {
-                this.checkFileStatus(this.props.params.submissionID);
+                this.checkFileStatus(submissionID);
             })
             .catch((error) => {
                 const errMsg =
@@ -560,7 +561,7 @@ export class UploadFabsFileValidation extends React.Component {
                 <PublishModal
                     rows={this.state.fabs_meta}
                     submit={this.submitFabs.bind(this)}
-                    submissionID={this.props.params.submissionID}
+                    submissionID={this.props.computedMatch.params.submissionID}
                     closeModal={this.closeModal.bind(this)}
                     isOpen={this.state.showPublish}
                     published={this.state.published} />

--- a/src/js/containers/history/HistoryContainer.jsx
+++ b/src/js/containers/history/HistoryContainer.jsx
@@ -7,27 +7,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import HistoryPage from '../../components/history/HistoryPage';
+import HistoryPage from 'components/history/HistoryPage';
 
 const propTypes = {
-    params: PropTypes.object,
     type: PropTypes.oneOf(['dabs', 'fabs'])
-};
-
-const defaultProps = {
-    params: {}
 };
 
 class HistoryContainer extends React.Component {
     render() {
         return (
-            <HistoryPage submissionID={this.props.params.submissionID} type={this.props.type} />
+            <HistoryPage type={this.props.type} />
         );
     }
 }
 
 HistoryContainer.propTypes = propTypes;
-HistoryContainer.defaultProps = defaultProps;
 
 export default connect(
     (state) => ({ session: state.session })

--- a/src/js/containers/review/ReviewDataContainer.jsx
+++ b/src/js/containers/review/ReviewDataContainer.jsx
@@ -7,17 +7,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import * as ReviewHelper from '../../helpers/reviewHelper';
-
-import ReviewDataPage from '../../components/reviewData/ReviewDataPage';
+import * as ReviewHelper from 'helpers/reviewHelper';
+import ReviewDataPage from 'components/reviewData/ReviewDataPage';
 
 const propTypes = {
-    params: PropTypes.object,
+    submissionID: PropTypes.string,
     errorFromStep: PropTypes.func
-};
-
-const defaultProps = {
-    params: {}
 };
 
 class ReviewDataContainer extends React.Component {
@@ -47,7 +42,7 @@ class ReviewDataContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.params.submissionID !== prevProps.params.submissionID) {
+        if (this.props.submissionID !== prevProps.submissionID) {
             // URL submission ID changed, reload
             this.loadData();
         }
@@ -55,17 +50,17 @@ class ReviewDataContainer extends React.Component {
 
     loadData() {
         let submissionData = {};
-
-        ReviewHelper.fetchSubmissionMetadata(this.props.params.submissionID, 'dabs')
+        const { submissionID } = this.props;
+        ReviewHelper.fetchSubmissionMetadata(submissionID, 'dabs')
             .then((data) => {
                 submissionData = data;
                 submissionData.ready = true;
 
-                return ReviewHelper.fetchSubmissionNarrative(this.props.params.submissionID);
+                return ReviewHelper.fetchSubmissionNarrative(submissionID);
             })
             .then((narrative) => {
                 submissionData.file_narrative = narrative;
-                return ReviewHelper.fetchObligations(this.props.params.submissionID);
+                return ReviewHelper.fetchObligations(submissionID);
             })
             .then((data) => {
                 submissionData.total_obligations = data.total_obligations;
@@ -104,7 +99,6 @@ class ReviewDataContainer extends React.Component {
 }
 
 ReviewDataContainer.propTypes = propTypes;
-ReviewDataContainer.defaultProps = defaultProps;
 
 const mapStateToProps = (state) => ({
     submission: state.submission,

--- a/src/js/containers/uploadFabsFile/UploadFabsFilePageContainer.jsx
+++ b/src/js/containers/uploadFabsFile/UploadFabsFilePageContainer.jsx
@@ -4,11 +4,21 @@
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import * as uploadActions from '../../redux/actions/uploadActions';
-import UploadFabsFilePage from '../../components/uploadFabsFile/UploadFabsFilePage';
+import * as uploadActions from 'redux/actions/uploadActions';
+import UploadFabsFilePage from 'components/uploadFabsFile/UploadFabsFilePage';
+
+const propTypes = {
+    setSubmissionId: PropTypes.func,
+    setSubmissionState: PropTypes.func,
+    history: PropTypes.object,
+    computedMatch: PropTypes.object,
+    type: PropTypes.oneOf(['dabs', 'fabs']),
+    submission: PropTypes.object
+};
 
 class UploadFabsFilePageContainer extends React.Component {
     render() {
@@ -17,6 +27,8 @@ class UploadFabsFilePageContainer extends React.Component {
         );
     }
 }
+
+UploadFabsFilePageContainer.propTypes = propTypes;
 
 export default connect(
     (state) => ({ submission: state.submission }),

--- a/tests/components/uploadFabsFilePage/UploadFabsFilePage-test.jsx
+++ b/tests/components/uploadFabsFilePage/UploadFabsFilePage-test.jsx
@@ -17,8 +17,10 @@ describe('UploadFabsFilePage', () => {
                 setSubmissionId: jest.fn(() => {}),
                 setSubmissionState: jest.fn(() => {}),
                 history: {},
-                params: {
-                    submissionID: '4321'
+                computedMatch: {
+                    params: {
+                        submissionID: '4321'
+                    }
                 },
                 route: {},
                 submission: {}

--- a/tests/components/uploadFabsFilePage/mockData.js
+++ b/tests/components/uploadFabsFilePage/mockData.js
@@ -1,10 +1,14 @@
+/* eslint-disable import/prefer-default-export */
 export const mockProps = {
     setSubmissionId: jest.fn(() => {}),
     setSubmissionState: jest.fn(() => {}),
     history: {},
-    params: {
-        submissionID: '1234'
+    computedMatch: {
+        params: {
+            submissionID: '1234'
+        }
     },
     route: {},
     submission: {}
 };
+/* eslint-enable import/prefer-default-export */


### PR DESCRIPTION
**High level description:**
Fixes a bug causing the `/FABSAddData/{submission id}` route to load incorrectly.

**Technical details:**

- In the new router setup, url params are nested in the `computedMatch` object.
- Also fixes a similar bug for the DABS Review Data page

**Link to JIRA Ticket:**
Relates to [DEV-3394](https://federal-spending-transparency.atlassian.net/browse/DEV-3394)

**Testing**
Go to https://broker-dev.usaspending.gov/#/FABSAddData/2125. The submission status for the previously uploaded file should display instead of the agency selector / upload component.

The following are ALL required for the PR to be merged:

Author: 
- [x] Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility

Reviewer(s):
- [x] Frontend review completed