### PR TITLE
DEV-4270 help nav styling

### DIFF
--- a/src/_scss/layouts/default/header/_titleBar.scss
+++ b/src/_scss/layouts/default/header/_titleBar.scss
@@ -11,6 +11,12 @@
 		color: $color-white;
 	}
 
+	.display-2 {
+		@include display(flex);
+		@include align-items(center);
+		@include justify-content(space-between);
+	}
+
 	.usa-da-page-title {
 		* {
 			padding-left: 0;

--- a/src/_scss/layouts/default/header/_titleBar.scss
+++ b/src/_scss/layouts/default/header/_titleBar.scss
@@ -12,6 +12,9 @@
 	}
 
 	.display-2 {
+		@media(max-width: $small-screen) {
+			display: block;
+		}
 		@include display(flex);
 		@include align-items(center);
 		@include justify-content(space-between);

--- a/src/_scss/pages/help/_topNav.scss
+++ b/src/_scss/pages/help/_topNav.scss
@@ -1,38 +1,18 @@
 @import "../../components/buttons/_primary";
-.usa-da-content-dark {
-    .help-nav {
-        float: right;
-        margin-top: -10px;
-        .usa-da-button {
-            @include primaryButton;
-            font-weight: 400;
-        }
-        a {
-            color: $color-white;
-            text-decoration: none;
-        }
-        a.selected {
-            background-color: $color-gold-lighter;
-            color: $color-gray-warm-dark;
-        }
-    }
-}
 
-.usa-da-content-teal {
-    .help-nav {
-        float: right;
-        margin-top: -10px;
-        .usa-da-button {
-            @include primaryButton;
-            font-weight: 400;
-        }
-        a {
-            color: $color-white;
-            text-decoration: none;
-        }
-        a.selected {
-            background-color: $color-gold-lighter;
-            color: $color-gray-warm-dark;
-        }
+.help-nav {
+    @include display(flex);
+    @include flex(0 0 auto);
+    .usa-da-button {
+        @include primaryButton;
+        font-weight: 400;
+    }
+    a {
+        color: $color-white;
+        text-decoration: none;
+    }
+    a.selected {
+        background-color: $color-gold-lighter;
+        color: $color-gray-warm-dark;
     }
 }

--- a/src/js/components/help/historyPage.jsx
+++ b/src/js/components/help/historyPage.jsx
@@ -114,8 +114,8 @@ export default class HistoryPage extends React.Component {
                                 <div className="col-md-12 mt-40 mb-20">
                                     <div className="display-2" data-contentstart="start" tabIndex={-1}>
                                         Help | DATA Act Broker
+                                        <HelpNav selected="Help" type={this.props.type} />
                                     </div>
-                                    <HelpNav selected="Help" type={this.props.type} />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
**High level description:**

Fixes a bug causing the help page sub-navigation to display inconsistently. 

**Technical details:**

- Places the `HelpNav` component nested under the `.display-2` div on the History page to match other help pages
- Removes unnecessarily repeated CSS 
- Moves to flex instead of float to position the help nav

**Link to JIRA Ticket:**

[DEV-4270](https://federal-spending-transparency.atlassian.net/browse/DEV-4270)

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Frontend review completed