### PR TITLE
Hotfix DEV-4431 & DEV-4432

### DIFF
--- a/src/js/components/history/HistoryPage.jsx
+++ b/src/js/components/history/HistoryPage.jsx
@@ -25,7 +25,7 @@ export default class HistoryPage extends React.Component {
         return (
             <div>
                 <div className="usa-da-site_wrap usa-da-history-page">
-                    <Navbar activeTab="dashboard" type={this.props.type} />
+                    <Navbar activeTab="submissionTable" type={this.props.type} />
                     <div className="usa-da-content-dark">
                         <div className="container">
                             <div className="row usa-da-page-title">

--- a/src/js/components/reviewData/CertificationModal/ReviewDataCertifyModal.jsx
+++ b/src/js/components/reviewData/CertificationModal/ReviewDataCertifyModal.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-aria-modal';
-import { Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import * as Icons from '../../SharedComponents/icons/Icons';
 import CertifyDisclaimer from './CertifyDisclaimer';
 import CertifyButtons from './CertifyButtons';
@@ -18,8 +18,7 @@ const propTypes = {
     session: PropTypes.object,
     submissionID: PropTypes.string,
     warnings: PropTypes.number,
-    isOpen: PropTypes.bool,
-    history: PropTypes.object
+    isOpen: PropTypes.bool
 };
 
 const defaultProps = {
@@ -40,7 +39,8 @@ export default class ReviewDataCertifyModal extends React.Component {
             publishComplete: false,
             closeable: true,
             errorMessage: "",
-            loading: false
+            loading: false,
+            goToSubmissionTable: false
         };
         this.closeModal = this.closeModal.bind(this);
         this.clickedCertifyButton = this.clickedCertifyButton.bind(this);
@@ -62,7 +62,9 @@ export default class ReviewDataCertifyModal extends React.Component {
                 this.setState({ loading: false });
                 this.closeModal();
                 // Redirect to submission dashboard after successful certification
-                this.props.history.push("/submissionsTable");
+                this.setState({
+                    goToSubmissionTable: true
+                });
             })
             .catch((error) => {
                 let errorMessage = "An error occurred while attempting to certify the submission. " +
@@ -103,6 +105,9 @@ export default class ReviewDataCertifyModal extends React.Component {
     }
 
     render() {
+        if (this.state.goToSubmissionTable) {
+            return <Redirect to="/submissionTable" />;
+        }
         let message = null;
         if (this.props.warnings > 0) {
             let warning = " warning";

--- a/src/js/containers/history/HistoryContainer.jsx
+++ b/src/js/containers/history/HistoryContainer.jsx
@@ -10,13 +10,15 @@ import { connect } from 'react-redux';
 import HistoryPage from 'components/history/HistoryPage';
 
 const propTypes = {
-    type: PropTypes.oneOf(['dabs', 'fabs'])
+    type: PropTypes.oneOf(['dabs', 'fabs']),
+    computedMatch: PropTypes.object
 };
 
 class HistoryContainer extends React.Component {
     render() {
+        const submissionID = this.props.computedMatch.params.submissionID;
         return (
-            <HistoryPage type={this.props.type} />
+            <HistoryPage type={this.props.type} submissionID={submissionID} />
         );
     }
 }


### PR DESCRIPTION
**High level description:**

- Fixes a bug that prevented users from being redirected to the Submission Table after certifying.
- Fixes a bug that prevented the Submission History page from loading the correct information.

**Technical details:**

DEV-4431
- Uses react-router `Redirect` 
- Corrects the url (`/submissionsTable` --> `/submissionsTable`)

DEV-4432
- Accesses the url param for submission ID via the method necessary for the updated router
- Passes the correct `activeTab` prop to the History Page

**Link to JIRA Ticket:**

[DEV-4431](https://federal-spending-transparency.atlassian.net/browse/DEV-4431),
[DEV-4432](https://federal-spending-transparency.atlassian.net/browse/DEV-4432)

**Local Testing**

DEV-4431
- On the Review Data page, click the "Certify & Publish" button to open the certify modal. Click "Publish to USAspending.gov". When certification is complete, you should be taken to the submission table page. 
- No UI changes

DEV-4432
- From the DABS Submission Table page, click the calendar icon for a submission in the certified table. The Submission History page should load with corresponding details about the submission you selected.
- While on the Submission History page, the Submission Table navigation tab should be highlighted as active instead of the "DABS Dashboard" tab

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Provided Instructions for Local Testing above and in JIRA

Reviewer(s):
- [x] Frontend review completed