### PR TITLE
Warmfix History Page Download Files

### DIFF
--- a/src/js/components/history/HistoryTable.jsx
+++ b/src/js/components/history/HistoryTable.jsx
@@ -83,9 +83,6 @@ export default class HistoryTable extends React.Component {
     }
 
     activeList() {
-        if (this.state.certifications[this.state.active].certified_files) {
-            return null;
-        }
         const activeSubmissionsFiles = this.state.certifications[this.state.active].certified_files;
         const list = [];
         for (let i = 0; i < activeSubmissionsFiles.length; i++) {


### PR DESCRIPTION
**High level description:**

Fixes a bug preventing the download files from showing up on the history page. 

**Technical details:**

Correction to [this sprint 99 change](https://github.com/fedspendingtransparency/data-act-broker-web-app/commit/bf693ccf5855550e26585d1974041a2a6a1f065f#diff-bdbaf64e22e6aa83fac6d05502b2d726L98). I misread the if statement as `!this.isUnmounted`.

**Link to JIRA Ticket:**

[DEV-4432](https://federal-spending-transparency.atlassian.net/browse/DEV-4432) (Download files are showing up in prod)

**Testing**
From the DABS Certified submission table, click the calendar icon to go to a Submission History page. Download links should be listed in the right-hand column. 

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Provided Instructions for Local Testing above and in JIRA
- N/A (adding back previously existing functionality) Verified cross-browser compatibility
- N/A (adding back previously existing functionality) Verified mobile/tablet/desktop/monitor responsiveness
- N/A (adding back previously existing functionality) Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- N/A (adding back previously existing functionality) Design review completed
- [x] Frontend review completed