### PR TITLE
Warmfix DEV-4427 submission back button

### DIFF
--- a/src/_scss/layouts/validation/progress/_step.scss
+++ b/src/_scss/layouts/validation/progress/_step.scss
@@ -1,85 +1,95 @@
 @mixin validationProgressStep {
+    li {
+        float: left;
+        text-align: center;
+        position: relative;
+        z-index: 5;
+        margin: 0.5rem 0 0;
+        font-size: 1.4rem;
 
-	li {
-		float: left;
-		text-align: center;
-		position: relative;
-		z-index:5;
-		margin: 0.5rem 0 0;
-		font-size: 1.4rem;
+        &::before {
+            display: none;
+        }
 
-		&::before {
-			display: none;
-		}
+        &::after {
+            display: none;
+        }
+    }
 
-		&::after {
-			display: none;
-		}
-	}
+    .name {
+        display: block;
+        text-align: center;
+        opacity: 0.3;
+		font-size: 1.2rem;
+		a {
+			color: $color-gray-dark;
+			&:hover {
+				text-decoration: none;
+			}
+        };
+    }
 
+    .step {
+        background-color: $color-white;
+        border-radius: 100%;
+        line-height: 1.2;
+        width: 2.4em;
+        height: 2.4em;
+        padding-top: 0.6em;
+        display: inline-block;
+        z-index: 0;
 
-	.name {
-		display: block;
-		vertical-align: bottom;
-		text-align: center;
-		color: $color-gray-dark;
-		opacity: 0.3;
-		font-size: 1.2rem
-	}
-	.step {
-		color: $color-gray-cool-light;
-		background-color: $color-white;
-		border-radius: 100%;
-		line-height: 1.2;
-		width: 2.4em;
-		height: 2.4em;
-		padding-top: 0.6em;
-		display: inline-block;
-		z-index: 0;
+        .stepLink {
+            color: $color-gray-cool-light;
+            background-color: transparent;
+            border: none;
+        }
 
-		.stepLink {
-      color: $color-gray-cool-light;
-      background-color: transparent;
-      border: none;
-		}
+        a {
+			color: $color-gray-cool-light;
+			&:hover {
+				text-decoration: none;
+			}
+        }
 
-		span {
-			opacity: 0.3;
-		}
+        span {
+            opacity: 0.3;
+        }
 
-		&:before {
-			content: "";
-			display: block;
-			background-color: $color-white;
-			height: 0.4em;
-			width: 50%;
-			position: absolute;
-			bottom: 0.9em;
-			left: 0;
-			z-index: -1;
-		}
+        &:before {
+            content: "";
+            display: block;
+            background-color: $color-white;
+            height: 0.4em;
+            width: 50%;
+            position: absolute;
+            bottom: 0.9em;
+            left: 0;
+            z-index: -1;
+        }
 
-		&:after {
-			content: "";
-			display: block;
-			background-color: $color-white;
-			height: 0.4em;
-			width: 50%;
-			position: absolute;
-			bottom: 0.9em;
-			right: 0;
-			z-index: -1;
-		}
-	}
+        &:after {
+            content: "";
+            display: block;
+            background-color: $color-white;
+            height: 0.4em;
+            width: 50%;
+            position: absolute;
+            bottom: 0.9em;
+            right: 0;
+            z-index: -1;
+        }
+    }
 
-	li:first-of-type {
-		.step:before {
-			display: none;
-		}
-	}
-	li:last-of-type {
-		.step:after {
-			display: none;
-		}
-	}
+    li:first-of-type {
+        .step:before {
+            display: none;
+        }
+    }
+
+    li:last-of-type {
+        .step:after {
+            display: none;
+        }
+    }
 }

--- a/src/js/components/SharedComponents/Progress.jsx
+++ b/src/js/components/SharedComponents/Progress.jsx
@@ -5,31 +5,26 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { stepNames, classes } from 'dataMapping/dabs/progress';
+import { routes } from 'dataMapping/dabs/submission';
 
 const propTypes = {
     stepNames: PropTypes.array,
     currentStep: PropTypes.number,
     totalSteps: PropTypes.number,
-    setStep: PropTypes.func,
-    barClasses: PropTypes.object
+    barClasses: PropTypes.object,
+    id: PropTypes.string.isRequired
 };
 
 const defaultProps = {
     currentStep: 1,
     totalSteps: 5,
     stepNames,
-    setStep: () => {},
     barClasses: classes
 };
 
 export default class Progress extends React.Component {
-    // update outer container
-    // on bar or label click
-    handleClick(step) {
-        this.props.setStep(step);
-    }
-
     // get appropriate class name for step
     // same for bar and labels
     className(index) {
@@ -49,25 +44,34 @@ export default class Progress extends React.Component {
     // bar button
     bar(index) {
         const isDisabled = this.isDisabled(index + 1);
-        return (
-            <button
-                disabled={isDisabled}
-                onClick={this.handleClick.bind(this, index)}
-                className="stepLink">
-                {index + 1}
-            </button>
-        );
+
+        const button = isDisabled ?
+            (
+                <button
+                    disabled
+                    className="stepLink">
+                    {index + 1}
+                </button>
+            ) :
+            (
+                <Link to={`/submission/${this.props.id}/${routes[index]}`}>{index + 1}</Link>
+            );
+        return button;
     }
     // label button
     label(index) {
         const isDisabled = this.isDisabled(index + 1);
-        return (
-            <button
-                disabled={isDisabled}
-                onClick={this.handleClick.bind(this, index)}>
-                {this.props.stepNames[index]}
-            </button>
-        );
+        const button = isDisabled ?
+            (
+                <button
+                    disabled={isDisabled}>
+                    {this.props.stepNames[index]}
+                </button>
+            ) :
+            (
+                <Link to={`/submission/${this.props.id}/${routes[index]}`}>{this.props.stepNames[index]}</Link>
+            );
+        return button;
     }
     // list that creates the horizontal progress bar
     // or list that creates the horizontal progress label

--- a/src/js/components/crossFile/CrossFileContent.jsx
+++ b/src/js/components/crossFile/CrossFileContent.jsx
@@ -12,7 +12,8 @@ import CrossFileOverlay from './CrossFileOverlay';
 const propTypes = {
     reloadData: PropTypes.func,
     uploadFiles: PropTypes.func,
-    submission: PropTypes.object
+    submission: PropTypes.object,
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {

--- a/src/js/components/crossFile/CrossFileOverlay.jsx
+++ b/src/js/components/crossFile/CrossFileOverlay.jsx
@@ -4,6 +4,7 @@
   */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import _ from 'lodash';
 import * as Icons from '../SharedComponents/icons/Icons';
 import CommonOverlay from '../SharedComponents/overlays/CommonOverlay';
@@ -18,7 +19,8 @@ const propTypes = {
     agencyName: PropTypes.string,
     mode: PropTypes.string,
     loading: PropTypes.bool,
-    nextStep: PropTypes.func
+    nextStep: PropTypes.func,
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {
@@ -198,6 +200,23 @@ export default class CrossFileOverlay extends React.Component {
     }
 
     render() {
+        const nextButton = this.state.overlay.nextButtonDisabled ?
+            (
+                <button
+                    className={`usa-da-validation-overlay-review usa-da-button${
+                        this.state.overlay.nextButtonClass}`}
+                    disabled>
+                    Next
+                </button>
+            ) :
+            (
+                <Link
+                    className={`usa-da-validation-overlay-review usa-da-button${
+                        this.state.overlay.nextButtonClass}`}
+                    to={`/submission/${this.props.submissionID}/generateEF`}>
+                        Next
+                </Link>
+            );
         return (
             <CommonOverlay
                 header={this.state.overlay.message}
@@ -212,13 +231,7 @@ export default class CrossFileOverlay extends React.Component {
                         onClick={this.props.uploadFiles}>
                         {this.state.overlay.buttonText}
                     </button>
-                    <button
-                        className={`usa-da-validation-overlay-review usa-da-button${
-                            this.state.overlay.nextButtonClass}`}
-                        disabled={this.state.overlay.nextButtonDisabled}
-                        onClick={this.pressedNext.bind(this)}>
-                        Next
-                    </button>
+                    {nextButton}
                 </div>
             </CommonOverlay>
         );

--- a/src/js/components/generateEF/GenerateEFOverlay.jsx
+++ b/src/js/components/generateEF/GenerateEFOverlay.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import * as Icons from '../SharedComponents/icons/Icons';
 import CommonOverlay from '../SharedComponents/overlays/CommonOverlay';
 import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
@@ -13,16 +14,15 @@ import * as PermissionsHelper from '../../helpers/permissionsHelper';
 
 const propTypes = {
     generateFiles: PropTypes.func,
-    nextPage: PropTypes.func,
     session: PropTypes.object,
     hasErrors: PropTypes.bool,
     isReady: PropTypes.bool,
-    agency_name: PropTypes.string
+    agency_name: PropTypes.string,
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {
     generateFiles: null,
-    nextPage: null,
     session: null,
     hasErrors: false,
     isReady: false,
@@ -30,11 +30,6 @@ const defaultProps = {
 };
 
 export default class GenerateEFOverlay extends React.Component {
-    clickedNext(e) {
-        e.preventDefault();
-        this.props.nextPage();
-    }
-
     clickedGenerate(e) {
         e.preventDefault();
         this.props.generateFiles();
@@ -82,6 +77,21 @@ export default class GenerateEFOverlay extends React.Component {
             buttonDisabled = true;
         }
 
+        const nextButton = nextDisabled ?
+            (
+                <button
+                    className={`usa-da-validation-overlay-review usa-da-button${nextClass}`}
+                    disabled>
+                    Next
+                </button>
+            ) :
+            (
+                <Link
+                    className={`usa-da-validation-overlay-review usa-da-button${nextClass}`}
+                    to={`/submission/${this.props.submissionID}/reviewData`}>
+                        Next
+                </Link>
+            );
 
         return (
             <CommonOverlay
@@ -96,12 +106,7 @@ export default class GenerateEFOverlay extends React.Component {
                         onClick={this.clickedGenerate.bind(this)}>
                         Regenerate Files
                     </button>
-                    <button
-                        className={`usa-da-button usa-da-validation-overlay-review ${nextClass}`}
-                        disabled={nextDisabled}
-                        onClick={this.clickedNext.bind(this)}>
-                        Next
-                    </button>
+                    {nextButton}
                 </div>
             </CommonOverlay>
         );

--- a/src/js/components/generateFiles/GenerateFilesContent.jsx
+++ b/src/js/components/generateFiles/GenerateFilesContent.jsx
@@ -16,7 +16,8 @@ const propTypes = {
     updateError: PropTypes.func,
     d1: PropTypes.object,
     d2: PropTypes.object,
-    updateFileProperty: PropTypes.func
+    updateFileProperty: PropTypes.func,
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {

--- a/src/js/components/generateFiles/GenerateFilesOverlay.jsx
+++ b/src/js/components/generateFiles/GenerateFilesOverlay.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import CommonOverlay from '../SharedComponents/overlays/CommonOverlay';
 import * as Icons from '../SharedComponents/icons/Icons';
 import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
@@ -12,17 +13,16 @@ import * as PermissionHelper from '../../helpers/permissionsHelper';
 
 const propTypes = {
     generateFiles: PropTypes.func,
-    nextPage: PropTypes.func,
     session: PropTypes.object,
     errorDetails: PropTypes.string,
     state: PropTypes.string,
-    agency_name: PropTypes.string
+    agency_name: PropTypes.string,
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {
     state: 'incomplete',
     generateFiles: null,
-    nextPage: null,
     session: null,
     errorDetails: '',
     agency_name: ''
@@ -32,11 +32,6 @@ export default class GenerateFilesOverlay extends React.Component {
     clickedGenerate(e) {
         e.preventDefault();
         this.props.generateFiles();
-    }
-
-    clickedNext(e) {
-        e.preventDefault();
-        this.props.nextPage();
     }
 
     render() {
@@ -96,6 +91,22 @@ export default class GenerateFilesOverlay extends React.Component {
             buttonDisabled = true;
         }
 
+        const nextButton = nextDisabled ?
+            (
+                <button
+                    className={`usa-da-validation-overlay-review usa-da-button${nextClass}`}
+                    disabled>
+                    Next
+                </button>
+            ) :
+            (
+                <Link
+                    className={`usa-da-validation-overlay-review usa-da-button${nextClass}`}
+                    to={`/submission/${this.props.submissionID}/validateCrossFile`}>
+                        Next
+                </Link>
+            );
+
         return (
             <CommonOverlay
                 header={header}
@@ -110,12 +121,7 @@ export default class GenerateFilesOverlay extends React.Component {
                         onClick={this.clickedGenerate.bind(this)}>
                         Generate Files
                     </button>
-                    <button
-                        className={`usa-da-button usa-da-validation-overlay-review ${nextClass}`}
-                        disabled={nextDisabled}
-                        onClick={this.clickedNext.bind(this)}>
-                        Next
-                    </button>
+                    {nextButton}
                 </div>
             </CommonOverlay>
         );

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -15,9 +15,7 @@ import ReviewDataContainer from '../../containers/review/ReviewDataContainer';
 
 const propTypes = {
     submissionID: PropTypes.string,
-    nextStep: PropTypes.func,
     setStep: PropTypes.func,
-    setStepAndRoute: PropTypes.func,
     errorFromStep: PropTypes.func,
     step: PropTypes.number,
     isError: PropTypes.bool,
@@ -29,23 +27,19 @@ export default class SubmissionPage extends React.Component {
     // all possible components DABS and FABS
     components() {
         const submissionID = this.props.submissionID;
-        const { nextStep, setStep, errorFromStep } = this.props;
+        const { setStep, errorFromStep } = this.props;
         return [
             (<ValidateDataContainer
                 submissionID={submissionID}
-                nextStep={nextStep}
                 errorFromStep={errorFromStep} />),
             (<GenerateFilesContainer
                 submissionID={submissionID}
-                nextStep={nextStep}
                 errorFromStep={errorFromStep} />),
             (<CrossFileContentContainer
                 submissionID={submissionID}
-                nextStep={nextStep}
                 errorFromStep={errorFromStep} />),
             (<GenerateEFContainer
                 submissionID={submissionID}
-                nextStep={nextStep}
                 errorFromStep={errorFromStep} />),
             (<ReviewDataContainer
                 {...this.props}
@@ -80,7 +74,6 @@ export default class SubmissionPage extends React.Component {
         const {
             isLoading,
             isError,
-            setStepAndRoute,
             submissionID
         } = this.props;
         let content = this.whichComponent();
@@ -97,8 +90,7 @@ export default class SubmissionPage extends React.Component {
                         <div className="row">
                             <Progress
                                 currentStep={step}
-                                id={submissionID}
-                                setStep={setStepAndRoute} />
+                                id={submissionID} />
                         </div>
                     </div>
                 </div>

--- a/src/js/components/validateData/ValidationContent.jsx
+++ b/src/js/components/validateData/ValidationContent.jsx
@@ -19,7 +19,7 @@ const propTypes = {
     agencyName: PropTypes.string,
     hasFailed: PropTypes.bool,
     hasFinished: PropTypes.bool,
-    nextStep: PropTypes.func
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {
@@ -70,9 +70,9 @@ export default class ValidationContent extends React.Component {
         }
         else {
             overlay = (<ValidationOverlayContainer
-                nextStep={this.props.nextStep}
                 warnings={warnings}
-                errors={errors} />);
+                errors={errors}
+                submissionID={this.props.submissionID} />);
         }
 
         return (

--- a/src/js/components/validateData/ValidationOverlay.jsx
+++ b/src/js/components/validateData/ValidationOverlay.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import * as Icons from '../SharedComponents/icons/Icons';
 import CommonOverlay from '../SharedComponents/overlays/CommonOverlay';
 
@@ -16,7 +17,7 @@ const propTypes = {
     warnings: PropTypes.array,
     allowUpload: PropTypes.bool,
     notAllowed: PropTypes.bool,
-    nextStep: PropTypes.func
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {
@@ -30,10 +31,6 @@ const defaultProps = {
 };
 
 export default class ValidationOverlay extends React.Component {
-    pressedNext() {
-        this.props.nextStep();
-    }
-
     isUploadingFiles() {
         return (Object.keys(this.props.submission.files).length > 0);
     }
@@ -112,6 +109,22 @@ export default class ValidationOverlay extends React.Component {
             header = this.props.uploadApiCallError;
         }
 
+        const nextButton = nextButtonDisabled ?
+            (
+                <button
+                    className={`usa-da-validation-overlay-review usa-da-button${nextButtonClass}`}
+                    disabled>
+                    Next
+                </button>
+            ) :
+            (
+                <Link
+                    className={`usa-da-validation-overlay-review usa-da-button${nextButtonClass}`}
+                    to={`/submission/${this.props.submissionID}/generateFiles`}>
+                        Next
+                </Link>
+            );
+
         return (
             <CommonOverlay
                 header={header}
@@ -127,13 +140,7 @@ export default class ValidationOverlay extends React.Component {
                         data-testid="validate-overlay-upload-button">
                         {buttonText}
                     </button>
-                    <button
-                        className={`usa-da-validation-overlay-review usa-da-button${nextButtonClass}`}
-                        disabled={nextButtonDisabled}
-                        onClick={this.pressedNext.bind(this)}
-                        data-testid="validate-overlay-review-button">
-                        Next
-                    </button>
+                    {nextButton}
                 </div>
 
             </CommonOverlay>

--- a/src/js/containers/generateEF/GenerateEFContainer.jsx
+++ b/src/js/containers/generateEF/GenerateEFContainer.jsx
@@ -22,8 +22,7 @@ import Banner from '../../components/SharedComponents/Banner';
 const propTypes = {
     submission: PropTypes.object,
     submissionID: PropTypes.string,
-    errorFromStep: PropTypes.func,
-    nextStep: PropTypes.func
+    errorFromStep: PropTypes.func
 };
 
 const defaultProps = {
@@ -176,15 +175,10 @@ class GenerateEFContainer extends React.Component {
         }
     }
 
-    nextPage() {
-        this.props.nextStep();
-    }
-
     render() {
         let content = (<GenerateEFContent
             {...this.props}
             {...this.state}
-            nextPage={this.nextPage.bind(this)}
             generateFiles={this.generateFiles.bind(this)} />);
 
         if (this.state.fullPageError) {

--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -27,8 +27,7 @@ const propTypes = {
     setSubmissionPublishStatus: PropTypes.func,
     submission: PropTypes.object,
     submissionID: PropTypes.string,
-    errorFromStep: PropTypes.func,
-    nextStep: PropTypes.func
+    errorFromStep: PropTypes.func
 };
 
 const defaultProps = {
@@ -533,7 +532,6 @@ export class GenerateFilesContainer extends React.Component {
                     handleDateChange={this.handleDateChange}
                     updateError={this.updateError}
                     generateFiles={this.generateFiles}
-                    nextPage={this.props.nextStep}
                     updateFileProperty={this.updateFileProperty}
                     clickedDownload={this.clickedDownload} />
             </div>

--- a/src/js/containers/submission/SubmissionContainer.jsx
+++ b/src/js/containers/submission/SubmissionContainer.jsx
@@ -41,7 +41,6 @@ export class SubmissionContainer extends React.Component {
 
         this.setStep = this.setStep.bind(this);
         this.errorFromStep = this.errorFromStep.bind(this);
-        this.nextStep = this.nextStep.bind(this);
     }
 
     componentDidMount() {
@@ -141,17 +140,6 @@ export class SubmissionContainer extends React.Component {
             goToRoute: true
         });
     }
-    // clicked next button in child Overlay components
-    // add 1 to step
-    nextStep() {
-        let step = this.state.step;
-        step += 1;
-        const completedSteps = [];
-        for (let i = 0; i < this.state.completedSteps.length; i++) {
-            completedSteps[i] = step >= i;
-        }
-        this.setState({ step, completedSteps }, this.updateRoute);
-    }
 
     render() {
         const params = this.props.computedMatch.params;
@@ -171,7 +159,6 @@ export class SubmissionContainer extends React.Component {
                 isLoading={isLoading}
                 isError={isError}
                 errorMessage={errorMessage}
-                nextStep={this.nextStep}
                 setStep={this.setStep} />
         );
     }

--- a/src/js/containers/validateData/ValidationOverlayContainer.jsx
+++ b/src/js/containers/validateData/ValidationOverlayContainer.jsx
@@ -17,7 +17,8 @@ import { kGlobalConstants } from '../../GlobalConstants';
 import * as UploadHelper from '../../helpers/uploadHelper';
 
 const propTypes = {
-    submission: PropTypes.object
+    submission: PropTypes.object,
+    submissionID: PropTypes.string
 };
 
 const defaultProps = {

--- a/tests/components/sharedComponents/progress/Progress-test.jsx
+++ b/tests/components/sharedComponents/progress/Progress-test.jsx
@@ -10,11 +10,6 @@ import Progress from 'components/SharedComponents/Progress';
 import { mockProps } from './mockData';
 
 describe('Progress Component', () => {
-    it('handleClick, should call setStep on click', () => {
-        const component = shallow(<Progress {...mockProps} />);
-        component.instance().handleClick();
-        expect(mockProps.setStep).toHaveBeenCalled();
-    });
     describe('className', () => {
         it('should set classname to the step classname', () => {
             const component = shallow(<Progress {...mockProps} />);

--- a/tests/containers/dabsSubmissionContainer/mockData.js
+++ b/tests/containers/dabsSubmissionContainer/mockData.js
@@ -3,9 +3,6 @@ export const mockProps = {
         params: {
             submissionID: "2054"
         }
-    },
-    history: {
-        push: jest.fn()
     }
 };
 
@@ -15,12 +12,13 @@ export const originalState = {
     errorMessage: '',
     step: 0,
     originalStep: 0,
-    completedSteps: {
-        0: false,
-        1: false,
-        2: false,
-        3: false
-    }
+    completedSteps: [
+        false,
+        false,
+        false,
+        false
+    ],
+    goToRoute: false
 };
 
 export const routes = [


### PR DESCRIPTION
**High level description:**

Fixes a bug that caused the browser back button not to work as expected when accessing a submission via the submission table and trying to go back to the table. 

**Technical details:**

- Refactored the Submission page to use `react-router-dom`'s `Redirect` component instead of pushing to the history API. 
- The Progress bar and Next buttons are now using `react-router-dom`'s `Link`

**Link to JIRA Ticket:**

[DEV-4427](https://federal-spending-transparency.atlassian.net/browse/DEV-4427)

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled Demo including Testing/Front-end
- [x] Verified cross-browser compatibility
- N/A Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Frontend review completed