### PR TITLE
DEV-4292 apply active filters

### DIFF
--- a/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
+++ b/src/js/containers/dashboard/filters/SubmitButtonContainer.jsx
@@ -105,6 +105,9 @@ export class SubmitButtonContainer extends React.Component {
             requiredFields = stagedFilters.historical.file && stagedFilters.historical.agency
             && stagedFilters.historical.quarters.size > 0 && stagedFilters.historical.fy.size > 0;
         }
+        else {
+            requiredFields = stagedFilters.active.file && stagedFilters.active.agency;
+        }
         return (
             <SubmitButton
                 filtersChanged={this.state.filtersChanged}

--- a/tests/containers/dashboard/filters/SubmitButtonContainer-test.jsx
+++ b/tests/containers/dashboard/filters/SubmitButtonContainer-test.jsx
@@ -8,9 +8,6 @@ import { shallow } from 'enzyme';
 import { Set } from 'immutable';
 import { cloneDeep } from 'lodash';
 
-import { initialState as initialApplied } from 'redux/reducers/dashboard/appliedFiltersReducer';
-import { initialState as initialStaged } from 'redux/reducers/dashboard/dashboardFiltersReducer';
-
 import { SubmitButtonContainer } from 'containers/dashboard/filters/SubmitButtonContainer';
 
 import { mockActions, mockSubmitRedux } from './mockFilters';
@@ -119,6 +116,22 @@ describe('SubmitButtonContainer', () => {
             expect(actions.applyStagedFilters).toHaveBeenCalledTimes(1);
         });
 
+        it('should do the same for active filters', () => {
+            const actions = Object.assign({}, mockActions, {
+                applyStagedFilters: jest.fn()
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    type="active"
+                    {...mockSubmitRedux}
+                    {...actions} />
+            );
+            container.instance().applyStagedFilters();
+
+            expect(actions.applyStagedFilters).toHaveBeenCalledWith('active', mockSubmitRedux.stagedFilters.active);
+        });
+
         it('should reset the filtersChanged state to false', () => {
             const container = shallow(
                 <SubmitButtonContainer
@@ -150,6 +163,21 @@ describe('SubmitButtonContainer', () => {
 
             container.instance().resetFilters();
             expect(actions.clearStagedFilters).toHaveBeenCalledTimes(1);
+        });
+        it('should do the same for active filters', () => {
+            const actions = Object.assign({}, mockActions, {
+                clearStagedFilters: jest.fn()
+            });
+
+            const container = shallow(
+                <SubmitButtonContainer
+                    type="active"
+                    {...mockSubmitRedux}
+                    {...actions} />
+            );
+
+            container.instance().resetFilters();
+            expect(actions.clearStagedFilters).toHaveBeenCalledWith('active');
         });
         it('should reset all the applied filters to their initial states', () => {
             const actions = Object.assign({}, mockActions, {


### PR DESCRIPTION
**High level description:**

Allows users to apply active dashboard filters when required filters have been selected.

**Link to JIRA Ticket:**

[DEV-4292](https://federal-spending-transparency.atlassian.net/browse/DEV-4292), [DEV-4301](https://federal-spending-transparency.atlassian.net/browse/DEV-4301)

**Mockup**
https://bahdigital.invisionapp.com/share/QEIACQKF2JW#/296030436_Active_-_MVP_-_Entry_5

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Frontend review completed