### PR TITLE
DEV-4288 Fix Created By filter

### DIFF
--- a/src/js/containers/dashboard/filters/CreatedByFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/CreatedByFilterContainer.jsx
@@ -54,7 +54,7 @@ export class CreatedByFilterContainer extends React.Component {
         if (input) {
             // If the user has entered a search string, only show matching results
             results = results.filter((user) => {
-                const name = user.name.toLowerCase();
+                const name = (user.name && user.name.toLowerCase()) || user.email.toLowerCase();
                 return name.includes(input.toLowerCase());
             });
         }
@@ -64,7 +64,7 @@ export class CreatedByFilterContainer extends React.Component {
         if (selectedUser.name && selectedUser.id) {
             results = results.filter((user) => {
                 const formattedUser = {
-                    name: user.name,
+                    name: user.name || user.email, // because some older users have no name
                     id: user.user_id
                 };
                 return !isEqual(formattedUser, selectedUser);
@@ -73,9 +73,9 @@ export class CreatedByFilterContainer extends React.Component {
 
         // Format the results for display in the dropdown
         const filteredResults = results.map((user) => ({
-            title: user.name,
+            title: user.name || user.email,
             subtitle: '',
-            data: { name: user.name, id: user.user_id }
+            data: { name: user.name || user.email, id: user.user_id }
         }));
 
         this.setState({

--- a/tests/containers/dashboard/filters/CreatedByFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/CreatedByFilterContainer-test.jsx
@@ -36,7 +36,7 @@ describe('CreatedByFilterContainer', () => {
             {...mockReduxActive} />
         );
         const newState = cloneDeep(container.instance().state);
-        newState.results = [{ name: 'ABC', user_id: 123 }, { name: 'XYZ', user_id: 456 }];
+        newState.results = [{ name: 'ABC', user_id: 123, email: 'abc@email.com' }, { name: 'XYZ', user_id: 456, email: 'xyz@email.com' }];
         container.instance().setState({ ...newState });
 
         container.instance().parseAutocomplete('test');
@@ -61,7 +61,7 @@ describe('CreatedByFilterContainer', () => {
                 {...mockReduxActive} />
             );
             const newState = cloneDeep(container.instance().state);
-            newState.results = [{ name: 'ABC', user_id: 123 }, { name: 'XYZ', user_id: 456 }];
+            newState.results = [{ name: 'ABC', user_id: 123, email: 'abc@email.com' }, { name: 'XYZ', user_id: 456, email: 'xyz@email.com' }];
             container.instance().setState({ ...newState });
 
             container.instance().parseAutocomplete('y');
@@ -80,7 +80,7 @@ describe('CreatedByFilterContainer', () => {
                 {...updatedRedux} />
             );
             const newState = cloneDeep(container.instance().state);
-            newState.results = [{ name: 'ABC', user_id: 123 }, { name: 'XYZ', user_id: 456 }];
+            newState.results = [{ name: 'ABC', user_id: 123, email: 'abc@email.com' }, { name: 'XYZ', user_id: 456, email: 'xyz@email.com' }];
             container.instance().setState({ ...newState });
 
             container.instance().parseAutocomplete();
@@ -90,6 +90,23 @@ describe('CreatedByFilterContainer', () => {
                 title: 'XYZ',
                 subtitle: '',
                 data: { name: 'XYZ', id: 456 }
+            });
+        });
+        it('should handle users with no name', () => {
+            const container = shallow(<CreatedByFilterContainer
+                {...mockActions}
+                {...mockReduxActive} />
+            );
+            const newState = cloneDeep(container.instance().state);
+            newState.results = [{ name: 'ABC', user_id: 123, email: 'abc@email.com' }, { name: '', user_id: 456, email: 'xyz@email.com' }];
+            container.instance().setState({ ...newState });
+
+            container.instance().parseAutocomplete('y');
+            expect(container.instance().state.filteredResults.length).toEqual(1);
+            expect(container.instance().state.filteredResults[0]).toEqual({
+                title: 'xyz@email.com',
+                subtitle: '',
+                data: { name: 'xyz@email.com', id: 456 }
             });
         });
     });


### PR DESCRIPTION
**High level description:**

Fixes a bug with the Created By filter in staging.

**Technical details:**

Displays the email address associated with the account when no name is available.

**Link to JIRA Ticket:**

Follow up to [DEV-4288](https://federal-spending-transparency.atlassian.net/browse/DEV-4288)

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Provided Instructions for Testing

Reviewer(s):
- [x] Frontend review completed
- [x] Merged after [Backend#1791](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1791)