### PR TITLE
Fix DEV-4287 single agency filter

### DIFF
--- a/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
+++ b/src/js/containers/dashboard/filters/DashboardAgencyFilterContainer.jsx
@@ -38,6 +38,12 @@ export class DashboardAgencyFilterContainer extends React.Component {
         this.loadData();
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.type !== prevProps.type) {
+            this.loadData();
+        }
+    }
+
     onSelect(agency) {
         // Add or remove the rule from Redux state
         this.props.updateGenericFilter(this.props.type, 'agency', agency);
@@ -53,7 +59,10 @@ export class DashboardAgencyFilterContainer extends React.Component {
                 });
                 if (agencies.length === 1) {
                     const code = agencies[0].cgac_code ? agencies[0].cgac_code : agencies[0].frec_code;
-                    this.props.updateGenericFilter(this.props.type, 'agency', code);
+                    // Prevent removing the agency if it has already been set by the other dashboard type
+                    if (this.props.selectedFilters[this.props.type].agency !== code) {
+                        this.props.updateGenericFilter(this.props.type, 'agency', code);
+                    }
                     this.props.setDescription(true);
                 }
             })

--- a/tests/containers/dashboard/filters/DashboardAgencyFilterContainer-test.jsx
+++ b/tests/containers/dashboard/filters/DashboardAgencyFilterContainer-test.jsx
@@ -16,6 +16,34 @@ describe('DashboardAgencyFilterContainer', () => {
     beforeEach(() => {
         jest.restoreAllMocks();
     });
+    it('should call loadData on mount', () => {
+        const container = shallow(<DashboardAgencyFilterContainer
+            type="active"
+            {...mockActions}
+            {...mockRedux} />
+        );
+
+        const loadData = jest.fn();
+        container.instance().loadData = loadData;
+
+        container.instance().componentDidMount();
+
+        expect(loadData).toHaveBeenCalled();
+    });
+    it('should call loadData when the dashboard type changes', () => {
+        const container = shallow(<DashboardAgencyFilterContainer
+            type="active"
+            {...mockActions}
+            {...mockRedux} />
+        );
+
+        const loadData = jest.fn();
+        container.instance().loadData = loadData;
+
+        container.instance().componentDidUpdate({ type: 'historical' });
+
+        expect(loadData).toHaveBeenCalled();
+    });
     describe('onSelect', () => {
         it('should call the updateAgencyFilter action', () => {
             const container = shallow(<DashboardAgencyFilterContainer


### PR DESCRIPTION
**High level description:**

Fixes a bug that prevented the (single) agency a user is assigned to from showing up in the agency filter when switching between the active & historical dashboards.

**Link to JIRA Ticket:**

[DEV-4287](https://federal-spending-transparency.atlassian.net/browse/DEV-4287)

**Testing:**
Login as a user with access to only one agency. Visit the DABS Dashboard, switch between Active and Historical dashboards. The agency tag for the agency to which you are assigned should be present in the agency filter (it might take a moment to load).

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility

Reviewer(s):
- [x] Frontend review completed