### PR TITLE
DEV-4519 test submission banner

### DIFF
--- a/src/_scss/layouts/login/_topBanner.scss
+++ b/src/_scss/layouts/login/_topBanner.scss
@@ -49,5 +49,8 @@
         margin-bottom: 0;
         font-size: 1.4rem;
         text-align: left;
+        a {
+            color: $color-cool-blue;
+        }
     }
 }

--- a/src/_scss/layouts/login/_topBanner.scss
+++ b/src/_scss/layouts/login/_topBanner.scss
@@ -6,7 +6,7 @@
 
     &.warning-banner {
         background: as-alpha($color-gold-lightest, 0.95);
-        border-bottom: 1px solid $color-gold-lighter;
+        border-bottom: 3px solid $color-gold-lighter;
 
         .banner-icon {
             svg {
@@ -17,7 +17,7 @@
 
     &.info-banner {
         background: as-alpha($color-primary-alt-lightest, 0.95);
-        border-bottom: 1px solid $color-primary-alt-light;
+        border-bottom: 3px solid $color-primary-alt-light;
 
         .banner-icon {
             svg {
@@ -41,6 +41,7 @@
         font-size: $h3-font-size;
         font-weight: $font-bold;
         margin-bottom: 0;
+        max-width: none;
     }
 
     .banner-content p {

--- a/src/js/components/SharedComponents/BannerRow.jsx
+++ b/src/js/components/SharedComponents/BannerRow.jsx
@@ -9,7 +9,7 @@ import { parseMarkdown } from 'helpers/helpHelper';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const propTypes = {
-    type: PropTypes.string,
+    type: PropTypes.oneOf(['warning', 'info']),
     header: PropTypes.string,
     message: PropTypes.string
 };

--- a/src/js/components/addData/AddDataMeta.jsx
+++ b/src/js/components/addData/AddDataMeta.jsx
@@ -6,14 +6,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
-import { Link } from 'react-router-dom';
 import AgencyListContainer from '../../containers/SharedContainers/AgencyListContainer';
 import * as Icons from '../SharedComponents/icons/Icons';
 import Modal from '../SharedComponents/Modal';
 import DateTypeField from './metadata/DateTypeField';
 import DateRangeField from './metadata/DateRangeField';
 import SubmitComponent from './metadata/SubmitComponent';
-import * as AgencyHelper from '../../helpers/agencyHelper';
 
 const propTypes = {
     updateMetaData: PropTypes.func
@@ -126,41 +124,7 @@ export default class AddDataMeta extends React.Component {
     }
 
     submitMetadata() {
-        const agency = this.state.agency;
-        const codeType = this.state.codeType;
-        const endDate = this.state.endDate;
-        const dateType = this.state.dateType;
-
-        // Only make a request to check certified submission for quarterly submission.
-        if (dateType === 'quarter') {
-            const month = endDate.substr(0, 2);
-            const quarter = (parseInt(month, 10) % 12) + 3;
-            let year = endDate.substr(3);
-
-            if (quarter === 3) {
-                year = parseInt(year, 10) + 1;
-            }
-
-            const cgacCode = codeType === 'cgac_code' ? agency : null;
-            const frecCode = codeType === 'frec_code' ? agency : null;
-            AgencyHelper.checkYearQuarter(cgacCode, frecCode, year, quarter).then(() => {
-                this.props.updateMetaData(this.state);
-            }).catch((err) => {
-                this.setState({
-                    showModal: true,
-                    modalMessage: (
-                        <div>
-                            {err.message} You can update the certified submission
-                            <Link to={`/submission/${err.submissionId}/validateData`}> here</Link>
-                            .
-                        </div>
-                    )
-                });
-            });
-        }
-        else {
-            this.props.updateMetaData(this.state);
-        }
+        this.props.updateMetaData(this.state);
     }
 
     validateAgency() {

--- a/src/js/components/reviewData/ReviewDataContent.jsx
+++ b/src/js/components/reviewData/ReviewDataContent.jsx
@@ -19,7 +19,8 @@ import { formatSize } from '../../helpers/util';
 const propTypes = {
     data: PropTypes.object,
     session: PropTypes.object,
-    submissionID: PropTypes.string
+    submissionID: PropTypes.string,
+    testSubmission: PropTypes.bool
 };
 
 const defaultProps = {
@@ -170,6 +171,9 @@ export default class ReviewDataContent extends React.Component {
         else if (blockedWindow) {
             certifyButtonText = `You cannot certify until ${
                 moment(blockedWindow.end_date).format("dddd, MMMM D, YYYY")}`;
+        }
+        else if (this.props.testSubmission) {
+            certifyButtonText = 'Test submissions cannot be certified';
         }
         else if (this.checkAffiliations('submitter') || this.props.session.admin) {
             certifyButtonText = "Certify & Publish";

--- a/src/js/components/reviewData/ReviewDataPage.jsx
+++ b/src/js/components/reviewData/ReviewDataPage.jsx
@@ -14,12 +14,14 @@ import ReviewLoading from './ReviewLoading';
 const propTypes = {
     data: PropTypes.object,
     submissionID: PropTypes.string,
-    submission: PropTypes.object
+    submission: PropTypes.object,
+    testSubmission: PropTypes.bool
 };
 
 const defaultProps = {
     data: null,
-    submission: null
+    submission: null,
+    testSubmission: false
 };
 
 export default class ReviewDataPage extends React.Component {

--- a/src/js/components/submission/SubmissionHeader.jsx
+++ b/src/js/components/submission/SubmissionHeader.jsx
@@ -36,9 +36,9 @@ const SubmissionHeader = (props) => {
             <div className="container">
                 <div className="row usa-da-content-add-data usa-da-page-title flex-center-content-only-height">
                     <div className="col-md-10 mt-40 mb-20">
-                        <div className="display-2" data-contentstart="start">
+                        <h1 className="display-2" data-contentstart="start">
                             Upload & Validate a New Submission
-                        </div>
+                        </h1>
                     </div>
                     <div className="col-md-2">
                         {submissionContext}

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -58,7 +58,10 @@ export default class SubmissionPage extends React.Component {
                 content = <GenerateEFContainer submissionID={submissionID} errorFromStep={this.props.errorFromStep} />;
                 break;
             case 5:
-                content = <ReviewDataContainer submissionID={submissionID} errorFromStep={this.props.errorFromStep} />;
+                content = (<ReviewDataContainer
+                    submissionID={submissionID}
+                    errorFromStep={this.props.errorFromStep}
+                    testSubmission={!!submissionInfo.certified_submission} />);
                 break;
             default:
                 content = null;

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -13,11 +13,11 @@ import GenerateEFContainer from 'containers/generateEF/GenerateEFContainer';
 import ReviewDataContainer from 'containers/review/ReviewDataContainer';
 
 import SubmissionHeader from './SubmissionHeader';
+import BannerRow from '../SharedComponents/BannerRow';
 
 const propTypes = {
-    submissionID: PropTypes.string,
+    submissionID: PropTypes.string.isRequired,
     setStep: PropTypes.func,
-    errorFromStep: PropTypes.func,
     error: PropTypes.bool,
     errorMessage: PropTypes.string,
     loading: PropTypes.bool,
@@ -26,6 +26,18 @@ const propTypes = {
     originalStep: PropTypes.number,
     lastCompletedStep: PropTypes.number,
     completedStep: PropTypes.func
+};
+
+const defaultProps = {
+    setStep: () => {},
+    error: false,
+    errorMessage: '',
+    loading: true,
+    submissionInfo: {},
+    currentStep: 0,
+    originalStep: 0,
+    lastCompletedStep: 0,
+    completedStep: () => {}
 };
 
 export default class SubmissionPage extends React.Component {
@@ -70,10 +82,17 @@ export default class SubmissionPage extends React.Component {
 
         if (loading) content = this.loadingMessage();
         if (error) content = this.errorMessage();
+        const testBanner = this.props.submissionInfo.test_submission ? (
+            <BannerRow
+                type="warning"
+                header="This is a test submission since one has already been certified for this fiscal quarter."
+                message="You will not be able to certify this submission." />
+        ) : null;
         return (
             <div className="usa-da-submission-page">
                 <Navbar activeTab="submissionGuide" type="dabs" />
                 <SubmissionHeader {...this.props.submissionInfo} />
+                {testBanner}
                 <div className="usa-da-content-step-block" name="content-top">
                     <div className="container center-block">
                         <div className="row">
@@ -90,3 +109,4 @@ export default class SubmissionPage extends React.Component {
 }
 
 SubmissionPage.propTypes = propTypes;
+SubmissionPage.defaultProps = defaultProps;

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -74,7 +74,6 @@ export default class SubmissionPage extends React.Component {
                 <Navbar activeTab="submissionGuide" type="dabs" />
                 <main>
                     <SubmissionHeader {...submissionInfo} />
-                    {testBanner}
                     <div className="usa-da-content-step-block" name="content-top">
                         <div className="container center-block">
                             <div className="row">
@@ -84,6 +83,7 @@ export default class SubmissionPage extends React.Component {
                             </div>
                         </div>
                     </div>
+                    {testBanner}
                     {error ? (<DABSFABSErrorMessage message={errorMessage} />) : null}
                     {loading ? (<ReviewLoading />) : null}
                     {content}

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -92,18 +92,20 @@ export default class SubmissionPage extends React.Component {
         return (
             <div className="usa-da-submission-page">
                 <Navbar activeTab="submissionGuide" type="dabs" />
-                <SubmissionHeader {...submissionInfo} />
-                {testBanner}
-                <div className="usa-da-content-step-block" name="content-top">
-                    <div className="container center-block">
-                        <div className="row">
-                            <Progress
-                                currentStep={currentStep}
-                                id={submissionID} />
+                <main>
+                    <SubmissionHeader {...submissionInfo} />
+                    {testBanner}
+                    <div className="usa-da-content-step-block" name="content-top">
+                        <div className="container center-block">
+                            <div className="row">
+                                <Progress
+                                    currentStep={currentStep}
+                                    id={submissionID} />
+                            </div>
                         </div>
                     </div>
-                </div>
-                {content}
+                    {content}
+                </main>
             </div>
         );
     }

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -57,7 +57,8 @@ export default class SubmissionPage extends React.Component {
             loading,
             error,
             submissionID,
-            currentStep
+            currentStep,
+            submissionInfo
         } = this.props;
         let content;
         switch (currentStep) {
@@ -82,17 +83,16 @@ export default class SubmissionPage extends React.Component {
 
         if (loading) content = this.loadingMessage();
         if (error) content = this.errorMessage();
-        // TODO - change the submission URL
-        const testBanner = this.props.submissionInfo.test_submission ? (
+        const testBanner = submissionInfo.certified_submission ? (
             <BannerRow
                 type="warning"
                 header="This is a test submission since one has already been certified for this fiscal quarter."
-                message="You will not be able to certify this submission. To view the certified submission, [click here](/#/submission/1234)." />
+                message={`You will not be able to certify this submission. To view the certified submission, [click here](/#/submission/${submissionInfo.certified_submission}).`} />
         ) : null;
         return (
             <div className="usa-da-submission-page">
                 <Navbar activeTab="submissionGuide" type="dabs" />
-                <SubmissionHeader {...this.props.submissionInfo} />
+                <SubmissionHeader {...submissionInfo} />
                 {testBanner}
                 <div className="usa-da-content-step-block" name="content-top">
                     <div className="container center-block">

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -82,11 +82,12 @@ export default class SubmissionPage extends React.Component {
 
         if (loading) content = this.loadingMessage();
         if (error) content = this.errorMessage();
+        // TODO - change the submission URL
         const testBanner = this.props.submissionInfo.test_submission ? (
             <BannerRow
                 type="warning"
                 header="This is a test submission since one has already been certified for this fiscal quarter."
-                message="You will not be able to certify this submission." />
+                message="You will not be able to certify this submission. To view the certified submission, [click here](/#/submission/1234)." />
         ) : null;
         return (
             <div className="usa-da-submission-page">

--- a/src/js/components/submission/SubmissionPage.jsx
+++ b/src/js/components/submission/SubmissionPage.jsx
@@ -16,13 +16,8 @@ import SubmissionHeader from './SubmissionHeader';
 import BannerRow from '../SharedComponents/BannerRow';
 
 const propTypes = {
-<<<<<<< HEAD
-    submissionID: PropTypes.string.isRequired,
-    setStep: PropTypes.func,
-=======
     submissionID: PropTypes.string,
     errorFromStep: PropTypes.func,
->>>>>>> fix/dev-4427-submission-back-button
     error: PropTypes.bool,
     errorMessage: PropTypes.string,
     loading: PropTypes.bool,
@@ -31,15 +26,11 @@ const propTypes = {
 };
 
 const defaultProps = {
-    setStep: () => {},
     error: false,
     errorMessage: '',
     loading: true,
     submissionInfo: {},
-    currentStep: 0,
-    originalStep: 0,
-    lastCompletedStep: 0,
-    completedStep: () => {}
+    currentStep: 0
 };
 
 export default class SubmissionPage extends React.Component {

--- a/src/js/containers/review/ReviewDataContainer.jsx
+++ b/src/js/containers/review/ReviewDataContainer.jsx
@@ -12,7 +12,8 @@ import ReviewDataPage from 'components/reviewData/ReviewDataPage';
 
 const propTypes = {
     submissionID: PropTypes.string,
-    errorFromStep: PropTypes.func
+    errorFromStep: PropTypes.func,
+    testSubmission: PropTypes.bool
 };
 
 class ReviewDataContainer extends React.Component {

--- a/src/js/containers/submission/SubmissionStepsContainer.jsx
+++ b/src/js/containers/submission/SubmissionStepsContainer.jsx
@@ -22,7 +22,8 @@ export class SubmissionStepsContainer extends React.Component {
         super(props);
 
         this.state = {
-            loading: true,
+            stepLoading: true,
+            metadataLoading: true,
             error: false,
             errorMessage: '',
             submissionInfo: {},
@@ -64,11 +65,15 @@ export class SubmissionStepsContainer extends React.Component {
     }
 
     getSubmission() {
+        this.setState({
+            metadataLoading: true
+        });
         const { submissionID } = this.props.computedMatch.params;
         ReviewHelper.fetchSubmissionMetadata(submissionID, 'dabs')
             .then((data) => {
                 this.setState({
-                    submissionInfo: data
+                    submissionInfo: data,
+                    metadataLoading: false
                 });
             })
             .catch((error) => {
@@ -77,6 +82,9 @@ export class SubmissionStepsContainer extends React.Component {
     }
 
     getOriginalStep(stepNumber) {
+        this.setState({
+            stepLoading: true
+        });
         const params = this.props.computedMatch.params;
         SubmissionGuideHelper.getSubmissionPage(params.submissionID)
             .then((res) => {
@@ -87,7 +95,7 @@ export class SubmissionStepsContainer extends React.Component {
                 }
                 this.setState(
                     {
-                        loading: false,
+                        stepLoading: false,
                         error: false,
                         errorMessage: '',
                         currentStep
@@ -103,7 +111,7 @@ export class SubmissionStepsContainer extends React.Component {
             .catch((err) => {
                 const { message } = err.body;
                 this.setState({
-                    loading: false,
+                    stepLoading: false,
                     error: true,
                     errorMessage: message,
                     currentStep: 0
@@ -130,7 +138,8 @@ export class SubmissionStepsContainer extends React.Component {
             <SubmissionPage
                 submissionID={submissionID}
                 {...this.state}
-                errorFromStep={this.errorFromStep} />
+                errorFromStep={this.errorFromStep}
+                loading={this.state.metadataLoading || this.state.stepLoading} />
         );
     }
 }

--- a/src/js/helpers/agencyHelper.js
+++ b/src/js/helpers/agencyHelper.js
@@ -53,23 +53,3 @@ export const fetchSubTierAgencies = () => {
 
     return deferred.promise;
 };
-
-export function checkYearQuarter(cgac, frec, year, quarter) {
-    const deferred = Q.defer();
-    const validCgac = cgac || '';
-    const validFrec = frec || '';
-    Request.get(`${kGlobalConstants.API}check_year_quarter/?cgac_code=${validCgac}&frec_code=${validFrec}&` +
-                `reporting_fiscal_year=${year}&reporting_fiscal_period=${quarter}`)
-        .end((err, res) => {
-            if (err) {
-                const response = Object.assign({}, res.body);
-                response.httpStatus = res.status;
-                deferred.reject(response);
-            }
-            else {
-                deferred.resolve(res);
-            }
-        });
-
-    return deferred.promise;
-}

--- a/tests/containers/dabsSubmissionContainer/SubmissionStepsContainer-test.jsx
+++ b/tests/containers/dabsSubmissionContainer/SubmissionStepsContainer-test.jsx
@@ -77,11 +77,11 @@ describe('SubmissionStepsContainer', () => {
         it('should update state', async () => {
             await container.instance().getOriginalStep();
             const {
-                loading,
+                stepLoading,
                 error,
                 currentStep
             } = container.instance().state;
-            expect(loading).toEqual(false);
+            expect(stepLoading).toEqual(false);
             expect(error).toEqual(false);
             expect(currentStep).toEqual(4);
         });
@@ -109,9 +109,11 @@ describe('SubmissionStepsContainer', () => {
         it('should update the state based on the result', async () => {
             await container.instance().getSubmission();
             const {
-                submissionInfo
+                submissionInfo,
+                metadataLoading
             } = container.instance().state;
             expect(submissionInfo).toEqual(submissionMetadata);
+            expect(metadataLoading).toBeFalsy();
         });
     });
 


### PR DESCRIPTION
**High level description:**

Adds a "test submission" banner to let users know when they are looking at a submission for an agency that already has a certified submission for the same fiscal quarter. 

**Link to JIRA Ticket:**

[DEV-4519](https://federal-spending-transparency.atlassian.net/browse/DEV-4519)

**Mockup**
https://bahdigital.invisionapp.com/share/QEIACQKF2JW#/296030458_DEV_3800-_Test_Submission

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Frontend review completed
- [x] Merged concurrently with [Backend#1800](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1800)
- [x] #1288 merged