### PR TITLE
DEV-4703 alert already certified

### DIFF
--- a/src/js/components/SharedComponents/Modal.jsx
+++ b/src/js/components/SharedComponents/Modal.jsx
@@ -25,15 +25,12 @@ export default class ErrorModal extends React.Component {
     }
 
     render() {
-        // adding this because the linter doesn't like when we just pass true
-        const trueProps = true;
         return (
             <Modal
                 mounted={this.props.isOpen}
                 onExit={this.closeModal.bind(this)}
-                underlayClickExits={trueProps}
-                verticallyCenter={trueProps}
-                initialFocus="#modal-button"
+                underlayClickExits
+                verticallyCenter
                 titleId="usa-da-certify-modal">
                 <div className="usa-da-modal-page">
                     <div id="usa-da-certify-modal" className="usa-da-certify-modal">

--- a/src/js/components/addData/AddDataMeta.jsx
+++ b/src/js/components/addData/AddDataMeta.jsx
@@ -45,7 +45,7 @@ export default class AddDataMeta extends React.Component {
             modalMessage: '',
             showModal: false,
             message: this.successMessage,
-            testSubmission: false
+            certifiedSubmission: null
         };
 
         this.closeModal = this.closeModal.bind(this);
@@ -56,7 +56,7 @@ export default class AddDataMeta extends React.Component {
             showModal: false,
             modalMessage: ''
         });
-        if (this.state.testSubmission) {
+        if (this.state.certifiedSubmission) {
             this.props.updateMetaData(this.state);
         }
     }
@@ -156,7 +156,7 @@ export default class AddDataMeta extends React.Component {
                 .catch((err) => {
                     this.setState({
                         showModal: true,
-                        testSubmission: true,
+                        certifiedSubmission: err.submissionId,
                         modalMessage: (
                             <div>
                                 {

--- a/src/js/components/addData/AddDataPage.jsx
+++ b/src/js/components/addData/AddDataPage.jsx
@@ -9,6 +9,7 @@ import AddDataContainer from 'containers/addData/AddDataContainer';
 import Footer from 'components/SharedComponents/FooterComponent';
 import Navbar from 'components/SharedComponents/navigation/NavigationComponent';
 import Banner from 'components/SharedComponents/Banner';
+import BannerRow from 'components/SharedComponents/BannerRow';
 import SubmissionHeader from 'components/submission/SubmissionHeader';
 import AddDataMeta from './AddDataMeta';
 
@@ -34,12 +35,21 @@ export default class AddDataPage extends React.Component {
             bodyComponent = <AddDataContainer metaData={this.props.submission.meta} />;
         }
 
+        const { certifiedSubmission } = this.props.submission.meta;
+        const testBanner = certifiedSubmission ? (
+            <BannerRow
+                type="warning"
+                header="This is a test submission since one has already been certified for this fiscal quarter."
+                message={`You will not be able to certify this submission. To view the certified submission, [click here](/#/submission/${certifiedSubmission}).`} />
+        ) : null;
+
         return (
             <div className="usa-da-add-data-page">
                 <div className="usa-da-site_wrap">
                     <Navbar activeTab="submissionGuide" type={this.props.type} />
                     <SubmissionHeader />
                     <Banner type="dabs" />
+                    {testBanner}
                     {bodyComponent}
                 </div>
                 <Footer />

--- a/src/js/containers/addData/AddDataPageContainer.jsx
+++ b/src/js/containers/addData/AddDataPageContainer.jsx
@@ -8,9 +8,8 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import * as uploadActions from '../../redux/actions/uploadActions';
-
-import AddDataPage from '../../components/addData/AddDataPage';
+import * as uploadActions from 'redux/actions/uploadActions';
+import AddDataPage from 'components/addData/AddDataPage';
 
 const propTypes = {
     resetSubmission: PropTypes.func,

--- a/src/js/helpers/agencyHelper.js
+++ b/src/js/helpers/agencyHelper.js
@@ -53,3 +53,23 @@ export const fetchSubTierAgencies = () => {
 
     return deferred.promise;
 };
+
+export function checkYearQuarter(cgac, frec, year, quarter) {
+    const deferred = Q.defer();
+    const validCgac = cgac || '';
+    const validFrec = frec || '';
+    Request.get(`${kGlobalConstants.API}check_year_quarter/?cgac_code=${validCgac}&frec_code=${validFrec}&` +
+                `reporting_fiscal_year=${year}&reporting_fiscal_period=${quarter}`)
+        .end((err, res) => {
+            if (err) {
+                const response = Object.assign({}, res.body);
+                response.httpStatus = res.status;
+                deferred.reject(response);
+            }
+            else {
+                deferred.resolve(res);
+            }
+        });
+
+    return deferred.promise;
+}

--- a/src/js/redux/actions/uploadActions.js
+++ b/src/js/redux/actions/uploadActions.js
@@ -35,7 +35,8 @@ export const setMeta = (state) => ({
         codeType: state.codeType,
         startDate: state.startDate,
         endDate: state.endDate,
-        dateType: state.dateType
+        dateType: state.dateType,
+        certifiedSubmission: state.certifiedSubmission
     }
 });
 


### PR DESCRIPTION
**High level description:**

When users create a new submission for an agency + fiscal quarter combo that has already been certified, display a modal before proceeding to the upload page and show a banner on the upload page.

**Technical details:**

- Reverts [this commit](https://github.com/fedspendingtransparency/data-act-broker-web-app/commit/28c44f614e9ccc9e9355f0820c33142f85c7382f) and changes the modal message, and advances to the upload page when the modal is closed.
- Passes the certified submission id to the `setMeta` redux action

**Link to JIRA Ticket:**

[DEV-4703](https://federal-spending-transparency.atlassian.net/browse/DEV-4703)

The following are ALL required for the PR to be merged:

Author: 
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [ ] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Design review completed
- [ ] Frontend review completed