### PR TITLE
DEV-4294: settings modal layout

### DIFF
--- a/src/_scss/layouts/default/header/_userMenu.scss
+++ b/src/_scss/layouts/default/header/_userMenu.scss
@@ -38,7 +38,7 @@
         & .header-dropdown {
             background: $color-base;
             position: absolute;
-            z-index: 999999;
+            z-index: 999;
             margin-top: 0;
 
             & li {

--- a/src/_scss/pages/modals/modals.scss
+++ b/src/_scss/pages/modals/modals.scss
@@ -9,6 +9,8 @@
 
 	@import "./dashboard/dashboardModal";
 
+	@import "./settings/settingsModal";
+
 	.delete-button{
 		margin-right:10px;
 	}

--- a/src/_scss/pages/modals/settings/_settingsModal.scss
+++ b/src/_scss/pages/modals/settings/_settingsModal.scss
@@ -32,15 +32,15 @@
 
     .settings-modal__sidebar {
         @include flex(0 0 auto);
-        @include align-self(center);
+        @include align-self(stretch);
         background-color: #f1f1f1;
         padding: rem(12);
         padding-top: rem(32);
         width: rem(240);
-        height: 100%;
 
         h1 {
             margin: 0;
+            margin-bottom: rem(25);
             font-size: rem(25);
             font-weight: bold;
         }
@@ -48,18 +48,22 @@
 
     .settings-modal__main {
         @include flex(0 0 auto);
-        @include align-self(center);
+        @include align-self(stretch);
         padding-top: rem(32);
         padding-bottom: rem(25);
         padding-right: rem(40);
         padding-left: rem(25);
         width: rem(735);
-        height: 100%;
 
         h2 {
             margin: 0;
+            margin-bottom: rem(25);
             font-size: rem(25);
             font-weight: light;
+        }
+
+        .description {
+            width: rem(370);
         }
     }
 }

--- a/src/_scss/pages/modals/settings/_settingsModal.scss
+++ b/src/_scss/pages/modals/settings/_settingsModal.scss
@@ -27,7 +27,9 @@
 
     .settings-modal__content {
         @include display(flex);
+        width: rem(935);
         height: 100%;
+        margin: 0;
     }
 
     .settings-modal__sidebar {
@@ -51,9 +53,9 @@
         @include align-self(stretch);
         padding-top: rem(32);
         padding-bottom: rem(25);
-        padding-right: rem(40);
+        padding-right: 0;
         padding-left: rem(25);
-        width: rem(735);
+        width: rem(695);
 
         h2 {
             margin: 0;

--- a/src/_scss/pages/modals/settings/_settingsModal.scss
+++ b/src/_scss/pages/modals/settings/_settingsModal.scss
@@ -1,0 +1,65 @@
+.settings-modal {
+    background-color: $color-white;
+    border: solid rem(1) $color-gray-lighter;
+    border-radius: rem(3);
+    width: rem(975);
+    height: rem(650);
+    max-height: rem(650);
+    overflow-wrap: break-word;
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    .close-button {
+        float: right;
+        font-size: rem(30);
+        height: rem(30);
+        padding: 0;
+        margin-right: rem(12);
+        margin-top: rem(12);
+        border: none;
+        background-color: $color-white;
+        overflow: hidden;
+
+        svg {
+            margin-bottom: rem(5);
+        }
+    }
+
+    .settings-modal__content {
+        @include display(flex);
+        height: 100%;
+    }
+
+    .settings-modal__sidebar {
+        @include flex(0 0 auto);
+        @include align-self(center);
+        background-color: #f1f1f1;
+        padding: rem(12);
+        padding-top: rem(32);
+        width: rem(240);
+        height: 100%;
+
+        h1 {
+            margin: 0;
+            font-size: rem(25);
+            font-weight: bold;
+        }
+    }
+
+    .settings-modal__main {
+        @include flex(0 0 auto);
+        @include align-self(center);
+        padding-top: rem(32);
+        padding-bottom: rem(25);
+        padding-right: rem(40);
+        padding-left: rem(25);
+        width: rem(735);
+        height: 100%;
+
+        h2 {
+            margin: 0;
+            font-size: rem(25);
+            font-weight: light;
+        }
+    }
+}

--- a/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
+++ b/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import * as sessionActions from 'redux/actions/sessionActions';
 import * as PermissionHelper from 'helpers/permissionsHelper';
 import UserButton from 'components/SharedComponents/navigation/UserButton';
+import SettingsModal from 'components/settings/SettingsModal';
 import { kGlobalConstants } from '../../../GlobalConstants';
 import NavbarTab from './NavbarTab';
 import SkipNavigationLink from './SkipNavigationLink';
@@ -33,7 +34,13 @@ export class Navbar extends React.Component {
     constructor(props) {
         super(props);
 
+        this.state = {
+            showModal: false
+        };
+
         this.logout = this.logout.bind(this);
+        this.openSettingsModal = this.openSettingsModal.bind(this);
+        this.closeSettingsModal = this.closeSettingsModal.bind(this);
     }
 
     getTabs() {
@@ -78,8 +85,16 @@ export class Navbar extends React.Component {
         });
     }
 
-    openSettings() {
+    openSettingsModal() {
+        this.setState({
+            showModal: true
+        });
+    }
 
+    closeSettingsModal() {
+        this.setState({
+            showModal: false
+        });
     }
 
     render() {
@@ -93,8 +108,16 @@ export class Navbar extends React.Component {
             userButton = (<UserButton
                 buttonText={userText}
                 logout={this.logout}
-                openSettings={this.openSettings}
+                openSettings={this.openSettingsModal}
                 user={this.props.session.user} />);
+        }
+
+        let modal = null;
+        if (this.state.showModal) {
+            modal = (
+                <SettingsModal
+                    closeModal={this.closeSettingsModal}
+                    isOpen={this.state.showModal} />);
         }
 
         const headerTabs = Object.keys(tabNames).map((key) => (
@@ -152,6 +175,7 @@ export class Navbar extends React.Component {
                         </div>
                     </div>
                 </div>
+                {modal}
             </nav>
         );
     }

--- a/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
+++ b/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
@@ -109,7 +109,7 @@ export class Navbar extends React.Component {
             userButton = (<UserButton
                 buttonText={userText}
                 logout={this.logout}
-                openSettings={this.openSettings}
+                openSettings={this.openSettingsModal}
                 isSubmitter={isSubmitter} />);
         }
 

--- a/src/js/components/SharedComponents/navigation/UserButton.jsx
+++ b/src/js/components/SharedComponents/navigation/UserButton.jsx
@@ -27,6 +27,7 @@ export default class UserButton extends React.Component {
         };
 
         this.toggleDropdown = this.toggleDropdown.bind(this);
+        this.openSettings = this.openSettings.bind(this);
     }
 
     toggleDropdown() {
@@ -40,6 +41,11 @@ export default class UserButton extends React.Component {
                 showDropdown: false
             });
         }
+    }
+
+    openSettings() {
+        this.toggleDropdown();
+        this.props.openSettings();
     }
 
     render() {
@@ -64,7 +70,7 @@ export default class UserButton extends React.Component {
         if (!kGlobalConstants.PROD && displaySettings) {
             settingsButton = (
                 <li>
-                    <button onClick={this.props.openSettings}>
+                    <button onClick={this.openSettings}>
                         <FontAwesomeIcon icon="cog" />
                         Settings
                     </button>

--- a/src/js/components/settings/SettingsModal.jsx
+++ b/src/js/components/settings/SettingsModal.jsx
@@ -1,0 +1,71 @@
+/**
+ * SettingsModal.jsx
+ * Created by Alisa Burdeyny 04/10/20
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'react-aria-modal';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const propTypes = {
+    closeModal: PropTypes.func.isRequired,
+    isOpen: PropTypes.bool
+};
+
+const defaultProps = {
+    isOpen: false
+};
+
+export default class SettingsModal extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            agencyCode: ''
+        };
+
+        this.updateAgency = this.updateAgency.bind(this);
+    }
+
+    updateAgency(agencyCode) {
+        this.setState({
+            agencyCode
+        });
+    }
+
+    render() {
+        return (
+            <Modal
+                mounted={this.props.isOpen}
+                onExit={this.props.closeModal}
+                verticallyCenter
+                underlayClickExits
+                initialFocus="#close-button"
+                titleId="settings-modal">
+                <div className="usa-da-modal-page">
+                    <div id="settings-modal" className="settings-modal">
+                        <button
+                            id="close-button"
+                            className="close-button"
+                            onClick={this.props.closeModal}
+                            aria-label="close-modal-button">
+                            <FontAwesomeIcon icon="times" />
+                        </button>
+                        <div className="settings-modal__content">
+                            <div className="settings-modal__sidebar">
+                                <h1>Settings</h1>
+                            </div>
+                            <div className="settings-modal__main">
+                                <h2>Rule Settings</h2>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </Modal>
+        );
+    }
+}
+
+SettingsModal.defaultProps = defaultProps;
+SettingsModal.propTypes = propTypes;

--- a/src/js/components/settings/SettingsModal.jsx
+++ b/src/js/components/settings/SettingsModal.jsx
@@ -58,6 +58,10 @@ export default class SettingsModal extends React.Component {
                             </div>
                             <div className="settings-modal__main">
                                 <h2>Rule Settings</h2>
+                                <div className="description">
+                                    Change the Significance and Impact settings to alter the weight of your agency's
+                                    respective rules in the Active Dashboard chart.
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/settings/SettingsModal.jsx
+++ b/src/js/components/settings/SettingsModal.jsx
@@ -59,7 +59,7 @@ export default class SettingsModal extends React.Component {
                             <div className="settings-modal__main">
                                 <h2>Rule Settings</h2>
                                 <div className="description">
-                                    Change the Significance and Impact settings to alter the weight of your agency's
+                                    Change the Significance and Impact settings to alter the weight of your agency&apos;s
                                     respective rules in the Active Dashboard chart.
                                 </div>
                             </div>


### PR DESCRIPTION
**High level description:**

Basic layout for the settings modal

**Technical details:**

Modal works like all other modals with tabbing/keyboard/mouse/overlay click. Navigation dropdown closes when settings modal is opened.

**Link to JIRA Ticket:**

[DEV-4294](https://federal-spending-transparency.atlassian.net/browse/DEV-4294)

**Mockup**
https://bahdigital.invisionapp.com/share/QEIACQKF2JW#/screens/296030442

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Merged after [Frontend#1325](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1325)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed