### PR TITLE
DEV-4625 fix Historical tab link in IE

### DIFF
--- a/src/_scss/pages/dashboard/_dashboardTabs.scss
+++ b/src/_scss/pages/dashboard/_dashboardTabs.scss
@@ -8,16 +8,16 @@
             padding: rem(6) 0;
             margin: rem(4) rem(25);
             font-size: rem(20);
-            a {
-                color: $color-white;
-                text-decoration: none;
-            }
             &.dashboard-tabs__button_active {
                 border-bottom: solid rem(2) $color-gold;
             }
             &:disabled {
                 color: $color-gray;
             }
+        }
+        a.dashboard-tabs__button {
+            color: $color-white;
+            text-decoration: none;
         }
     }
 }

--- a/src/js/components/dashboard/DashboardTab.jsx
+++ b/src/js/components/dashboard/DashboardTab.jsx
@@ -18,18 +18,19 @@ export default class DashboardTab extends React.Component {
     render() {
         const activeClass = this.props.active ? 'dashboard-tabs__button_active' : '';
         const link = this.props.disabled ? (
-            this.props.label
-        ) : (
-            <Link to={`/dashboard/${this.props.type}`}>{this.props.label}</Link>
-        );
-        return (
             <button
                 className={`dashboard-tabs__button ${activeClass}`}
-                onClick={this.setActiveTab}
                 disabled={this.props.disabled}>
-                {link}
+                {this.props.label}
             </button>
+        ) : (
+            <Link
+                className={`dashboard-tabs__button ${activeClass}`}
+                to={`/dashboard/${this.props.type}`}>
+                {this.props.label}
+            </Link>
         );
+        return link;
     }
 }
 


### PR DESCRIPTION
**High level description:**

Fixes the tab that links to the historical dashboard in Internet Explorer

**Technical details:**

* Issue was caused by a link nested under a button (a temporary measure while Active dashboard is dark-released)

**Link to JIRA Ticket:**

[DEV-4625](https://federal-spending-transparency.atlassian.net/browse/DEV-4625)


The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Frontend review completed