### PR TITLE
DEV-4318 Errors & Warnings tabs

### DIFF
--- a/src/_scss/pages/dashboard/_dashboardTabs.scss
+++ b/src/_scss/pages/dashboard/_dashboardTabs.scss
@@ -20,4 +20,15 @@
             }
         }
     }
+    &.dashboard-tabs_active {
+        background-color: transparent;
+        .dashboard-tabs__content {
+            @include justify-content(flex-start);
+        }
+        .dashboard-tabs__button {
+            &.dashboard-tabs__button_active {
+                border-bottom-color: $color-primary;
+            }
+        }
+    }
 }

--- a/src/_scss/pages/dashboard/dashboard.scss
+++ b/src/_scss/pages/dashboard/dashboard.scss
@@ -21,6 +21,7 @@
             @media(max-width: $small-screen) {
                 display: block;
                 .dashboard-page__filters {
+                    margin-top: 0;
                     width: 100%;
                     margin-right: 0;
                 }
@@ -39,6 +40,7 @@
             width: rem(260);
             background-color: $color-white;
             margin-right: rem(15);
+            margin-top: rem(50);
             border-radius: rem(5);
             border: solid rem(1) $color-gray-lighter;
             @import './filterSidebar';
@@ -47,12 +49,10 @@
             background-color: $color-white;
             @include flex(1 1 auto);
             min-width: 0;
+            margin-top: rem(50);
             margin-left: rem(15);
             border-radius: rem(5);
             border: solid rem(1) $color-gray-lighter;
-            &.dashboard-page__content_below {
-                margin-top: rem(40);
-            }
             h2 {
                 padding: rem(10) rem(20) rem(3);
                 font-size: $h2-font-size;
@@ -82,7 +82,7 @@
                             position: relative;
                             font-size: $h4-font-size;
                         }
-            
+
                         .button-icon {
                             @include flex(0 0 3.6rem);
                             @include display(flex);
@@ -108,6 +108,11 @@
         }
         .dashboard-page-active {
             .dashboard-page__content{
+                margin-top: 0;
+                &.dashboard-page__content_below {
+                    margin-top: rem(40);
+                }
+
                 h2 {
                     img {
                         height: 5rem;

--- a/src/js/components/dashboard/ActiveDashboard.jsx
+++ b/src/js/components/dashboard/ActiveDashboard.jsx
@@ -28,6 +28,7 @@ const ActiveDashboard = (props) => {
                 <div className="dashboard-tabs__content">
                     {errorLevels.map((level) => (
                         <ErrorLevelTab
+                            key={level}
                             errorLevel={level}
                             setErrorLevel={setErrorLevel}
                             active={errorLevel === level} />

--- a/src/js/components/dashboard/ActiveDashboard.jsx
+++ b/src/js/components/dashboard/ActiveDashboard.jsx
@@ -3,7 +3,7 @@
  * Created by Lizzie Salita 3/10/20
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -11,6 +11,7 @@ import ActiveDashboardOverviewContainer from 'containers/dashboard/ActiveDashboa
 import ActiveDashboardImpactsContainer from 'containers/dashboard/ActiveDashboardImpactsContainer';
 import SignificanceGraphContainer from 'containers/dashboard/graph/SignificanceGraphContainer';
 import ActiveDashboardTableContainer from 'containers/dashboard/table/ActiveDashboardTableContainer';
+import ErrorLevelTab from './ErrorLevelTab';
 
 const propTypes = {
     submissionID: PropTypes.string,
@@ -18,33 +19,46 @@ const propTypes = {
     backToList: PropTypes.func
 };
 
-const ActiveDashboard = (props) => (
-    <div className="dashboard-page-active">
-        <div className="dashboard-page__content">
-            {props.numResults > 1 ?
-                <button
-                    onClick={props.backToList}
-                    className="back-button">
-                    <div className="button-wrapper">
-                        <div className="button-icon">
-                            <FontAwesomeIcon icon="angle-left" />
+const errorLevels = ['error', 'warning'];
+const ActiveDashboard = (props) => {
+    const [errorLevel, setErrorLevel] = useState('warning');
+    return (
+        <div className="dashboard-page-active">
+            <div className="dashboard-page-active__error-levels">
+                {errorLevels.map((level) => (
+                    <ErrorLevelTab
+                        errorLevel={level}
+                        setErrorLevel={setErrorLevel}
+                        active={errorLevel === level} />
+                ))}
+            </div>
+            <div className="dashboard-page__content">
+                {props.numResults > 1 ?
+                    <button
+                        onClick={props.backToList}
+                        className="back-button">
+                        <div className="button-wrapper">
+                            <div className="button-icon">
+                                <FontAwesomeIcon icon="angle-left" />
+                            </div>
+                            <div className="button-content">
+                                Dashboard Submission Selection
+                            </div>
                         </div>
-                        <div className="button-content">
-                            Dashboard Submission Selection
-                        </div>
-                    </div>
-                </button> : null}
-            <ActiveDashboardOverviewContainer errorLevel="warning" submissionID={props.submissionID} />
+                    </button> : null}
+                <ActiveDashboardOverviewContainer errorLevel={errorLevel} submissionID={props.submissionID} />
+            </div>
+            <div className="dashboard-page__content dashboard-page__content_below">
+                <h2>Active Submission Summary</h2>
+                <hr />
+                <ActiveDashboardImpactsContainer errorLevel={errorLevel} submissionID={props.submissionID} />
+                <SignificanceGraphContainer errorLevel={errorLevel} submissionID={props.submissionID} />
+                <ActiveDashboardTableContainer submissionID={props.submissionID} />
+            </div>
         </div>
-        <div className="dashboard-page__content dashboard-page__content_below">
-            <h2>Active Submission Summary</h2>
-            <hr />
-            <ActiveDashboardImpactsContainer errorLevel="warning" submissionID={props.submissionID} />
-            <SignificanceGraphContainer errorLevel="warning" submissionID={props.submissionID} />
-            <ActiveDashboardTableContainer submissionID={props.submissionID} />
-        </div>
-    </div>
-);
+    );
+};
+
 
 ActiveDashboard.propTypes = propTypes;
 export default ActiveDashboard;

--- a/src/js/components/dashboard/ActiveDashboard.jsx
+++ b/src/js/components/dashboard/ActiveDashboard.jsx
@@ -53,7 +53,7 @@ const ActiveDashboard = (props) => {
                 <hr />
                 <ActiveDashboardImpactsContainer errorLevel={errorLevel} submissionID={props.submissionID} />
                 <SignificanceGraphContainer errorLevel={errorLevel} submissionID={props.submissionID} />
-                <ActiveDashboardTableContainer submissionID={props.submissionID} />
+                <ActiveDashboardTableContainer errorLevel={errorLevel} submissionID={props.submissionID} />
             </div>
         </div>
     );

--- a/src/js/components/dashboard/ActiveDashboard.jsx
+++ b/src/js/components/dashboard/ActiveDashboard.jsx
@@ -24,13 +24,15 @@ const ActiveDashboard = (props) => {
     const [errorLevel, setErrorLevel] = useState('warning');
     return (
         <div className="dashboard-page-active">
-            <div className="dashboard-page-active__error-levels">
-                {errorLevels.map((level) => (
-                    <ErrorLevelTab
-                        errorLevel={level}
-                        setErrorLevel={setErrorLevel}
-                        active={errorLevel === level} />
-                ))}
+            <div className="dashboard-tabs dashboard-tabs_active">
+                <div className="dashboard-tabs__content">
+                    {errorLevels.map((level) => (
+                        <ErrorLevelTab
+                            errorLevel={level}
+                            setErrorLevel={setErrorLevel}
+                            active={errorLevel === level} />
+                    ))}
+                </div>
             </div>
             <div className="dashboard-page__content">
                 {props.numResults > 1 ?

--- a/src/js/components/dashboard/ActiveDashboardOverview.jsx
+++ b/src/js/components/dashboard/ActiveDashboardOverview.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { startCase } from 'lodash';
 
 const propTypes = {
     submissionData: PropTypes.object,
@@ -58,7 +59,7 @@ const ActiveDashboardOverview = (props) => (
                     {props.submissionData.number_of_rules}
                 </div>
                 <div className="overview-section">
-                    <h4>Total # of Warings</h4>
+                    <h4>{`Total # of ${startCase(props.errorLevel)}s`}</h4>
                     {props.submissionData.total_instances}
                 </div>
             </div>

--- a/src/js/components/dashboard/ErrorLevelTab.jsx
+++ b/src/js/components/dashboard/ErrorLevelTab.jsx
@@ -1,0 +1,28 @@
+/**
+ * ErrorLevelTab.jsx
+ * Created by Lizzie Salita 4/13/20
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { startCase } from 'lodash';
+
+const propTypes = {
+    errorLevel: PropTypes.string,
+    setErrorLevel: PropTypes.func,
+    active: PropTypes.bool
+};
+
+const ErrorLevelTab = ({ errorLevel, setErrorLevel, active }) => {
+    const activeClass = active ? 'dashboard-tabs__button_active' : '';
+    return (
+        <button
+            className={`dashboard-tabs__button ${activeClass}`}
+            onClick={() => setErrorLevel(errorLevel)}>
+            {startCase(errorLevel)}s
+        </button>
+    );
+};
+
+ErrorLevelTab.propTypes = propTypes;
+export default ErrorLevelTab;

--- a/src/js/components/dashboard/ErrorLevelTab.jsx
+++ b/src/js/components/dashboard/ErrorLevelTab.jsx
@@ -14,10 +14,10 @@ const propTypes = {
 };
 
 const ErrorLevelTab = ({ errorLevel, setErrorLevel, active }) => {
-    const activeClass = active ? 'dashboard-tabs__button_active' : '';
+    const activeClass = active ? ' dashboard-tabs__button_active' : '';
     return (
         <button
-            className={`dashboard-tabs__button ${activeClass}`}
+            className={`dashboard-tabs__button${activeClass}`}
             onClick={() => setErrorLevel(errorLevel)}>
             {startCase(errorLevel)}s
         </button>

--- a/src/js/components/dashboard/impacts/ActiveDashboardImpacts.jsx
+++ b/src/js/components/dashboard/impacts/ActiveDashboardImpacts.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { startCase } from 'lodash';
 
 import ImpactGauge from 'components/dashboard/impacts/ImpactGauge';
 
@@ -14,16 +15,17 @@ const propTypes = {
         medium: PropTypes.object,
         high: PropTypes.object
     }),
-    openModal: PropTypes.func.isRequired
+    openModal: PropTypes.func.isRequired,
+    errorLevel: PropTypes.oneOf(['error', 'warning'])
 };
 
-const ActiveDashboardImpacts = ({ submissionData, openModal }) => (
+const ActiveDashboardImpacts = ({ submissionData, openModal, errorLevel }) => (
     <div className="dashboard-page__impacts">
-        <h3>Warning Status</h3>
+        <h3>{startCase(errorLevel)} Status</h3>
         <hr />
         <h4>Impact Count</h4>
         <p>
-            Identify to what degree current warnings impact your submission.
+            Identify to what degree current {errorLevel}s impact your submission.
             The values have been preset by your agency.
         </p>
         {submissionData ?

--- a/src/js/components/dashboard/table/ActiveDashboardTable.jsx
+++ b/src/js/components/dashboard/table/ActiveDashboardTable.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { startCase } from 'lodash';
 
 import DashboardTableHeader from 'components/dashboard/table/DashboardTableHeader';
 import NoResultsMessage from 'components/SharedComponents/NoResultsMessage';
@@ -19,7 +20,8 @@ const propTypes = {
     changeSort: PropTypes.func.isRequired,
     currSort: PropTypes.string,
     currOrder: PropTypes.string,
-    openModal: PropTypes.func.isRequired
+    openModal: PropTypes.func.isRequired,
+    errorLevel: PropTypes.oneOf(['error', 'warning'])
 };
 
 const defaultProps = {
@@ -30,40 +32,39 @@ const defaultProps = {
     currOrder: 'desc'
 };
 
-const tableHeaders = [
-    {
-        text: 'Significance',
-        class: 'dashboard-table__significance-column',
-        sortType: 'significance'
-    },
-    {
-        text: 'Warning Rule',
-        class: 'dashboard-table__label-column',
-        sortType: 'rule_label'
-    },
-    {
-        text: (<span>Number of<br />Instances</span>),
-        class: 'dashboard-table__instances-column',
-        sortType: 'instances'
-    },
-    {
-        text: 'Category',
-        class: 'dashboard-table__category-column',
-        sortType: 'category'
-    },
-    {
-        text: 'Impact',
-        class: 'dashboard-table__impact-column',
-        sortType: 'impact'
-    },
-    {
-        text: 'Rule Description',
-        class: null,
-        sortType: 'description'
-    }
-];
-
 export default class ActiveDashboardTable extends React.Component {
+    tableHeaders = () => [
+        {
+            text: 'Significance',
+            class: 'dashboard-table__significance-column',
+            sortType: 'significance'
+        },
+        {
+            text: `${startCase(this.props.errorLevel)} Rule`,
+            class: 'dashboard-table__label-column',
+            sortType: 'rule_label'
+        },
+        {
+            text: (<span>Number of<br />Instances</span>),
+            class: 'dashboard-table__instances-column',
+            sortType: 'instances'
+        },
+        {
+            text: 'Category',
+            class: 'dashboard-table__category-column',
+            sortType: 'category'
+        },
+        {
+            text: 'Impact',
+            class: 'dashboard-table__impact-column',
+            sortType: 'impact'
+        },
+        {
+            text: 'Rule Description',
+            class: null,
+            sortType: 'description'
+        }
+    ];
     render() {
         let contentMessage = <LoadingMessage />;
         let tableRows = [];
@@ -110,7 +111,7 @@ export default class ActiveDashboardTable extends React.Component {
                 <h3 className="dashboard-viz__heading">Table</h3>
                 <table>
                     <DashboardTableHeader
-                        headers={tableHeaders}
+                        headers={this.tableHeaders()}
                         changeSort={this.props.changeSort}
                         currSort={this.props.currSort}
                         currOrder={this.props.currOrder} />

--- a/src/js/containers/dashboard/ActiveDashboardImpactsContainer.jsx
+++ b/src/js/containers/dashboard/ActiveDashboardImpactsContainer.jsx
@@ -96,10 +96,13 @@ export class ActiveDashboardImpactsContainer extends React.Component {
                     isOpen={this.state.showModal} />);
         }
         return (
-            <div>
-                <ActiveDashboardImpacts submissionData={this.state.submissionData} openModal={this.openModal} />
+            <>
+                <ActiveDashboardImpacts
+                    submissionData={this.state.submissionData}
+                    openModal={this.openModal}
+                    errorLevel={this.props.errorLevel} />
                 {modal}
-            </div>
+            </>
         );
     }
 }

--- a/src/js/containers/dashboard/graph/SignificanceGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/SignificanceGraphContainer.jsx
@@ -93,7 +93,7 @@ export class SignificanceGraphContainer extends React.Component {
         return (
             <DashboardGraph
                 type="active"
-                description="Identify the significance of a particular rule based upon your agency’s preset values and filter warnings by category."
+                description={`Identify the significance of a particular rule based upon your agency’s preset values and filter ${this.props.errorLevel}s by category.`}
                 errorLevel={this.props.errorLevel}
                 {...this.state} />
         );

--- a/src/js/containers/dashboard/graph/SignificanceGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/SignificanceGraphContainer.jsx
@@ -35,7 +35,7 @@ export class SignificanceGraphContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (!isEqual(prevProps.appliedFilters, this.props.appliedFilters)) {
+        if (!isEqual(prevProps, this.props)) {
             this.fetchData();
         }
     }

--- a/src/js/containers/dashboard/table/ActiveDashboardTableContainer.jsx
+++ b/src/js/containers/dashboard/table/ActiveDashboardTableContainer.jsx
@@ -17,7 +17,8 @@ import BaseActiveDashboardTableRow from 'models/dashboard/BaseActiveDashboardTab
 
 const propTypes = {
     appliedFilters: PropTypes.object,
-    submissionID: PropTypes.string
+    submissionID: PropTypes.string,
+    errorLevel: PropTypes.string
 };
 
 export class ActiveDashboardTableContainer extends React.Component {
@@ -52,7 +53,7 @@ export class ActiveDashboardTableContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (!isEqual(this.props.appliedFilters, prevProps.appliedFilters)) {
+        if (!isEqual(this.props, prevProps)) {
             this.changePage(1);
         }
     }
@@ -116,7 +117,7 @@ export class ActiveDashboardTableContainer extends React.Component {
         const submissionId = parseInt(this.props.submissionID, 10);
 
         DashboardHelper.fetchActiveDashboardTableContents(submissionId, this.props.appliedFilters.file,
-            'warning', this.state.page, this.state.limit, this.state.sort, this.state.order)
+            this.props.errorLevel, this.state.page, this.state.limit, this.state.sort, this.state.order)
             .then((res) => {
                 this.parseRows(res);
             })

--- a/src/js/containers/dashboard/table/ActiveDashboardTableContainer.jsx
+++ b/src/js/containers/dashboard/table/ActiveDashboardTableContainer.jsx
@@ -18,7 +18,7 @@ import BaseActiveDashboardTableRow from 'models/dashboard/BaseActiveDashboardTab
 const propTypes = {
     appliedFilters: PropTypes.object,
     submissionID: PropTypes.string,
-    errorLevel: PropTypes.string
+    errorLevel: PropTypes.oneOf(['error', 'warning'])
 };
 
 export class ActiveDashboardTableContainer extends React.Component {
@@ -178,7 +178,8 @@ export class ActiveDashboardTableContainer extends React.Component {
                     changeSort={this.changeSort}
                     currSort={this.state.sort}
                     currOrder={this.state.order}
-                    openModal={this.openModal} />
+                    openModal={this.openModal}
+                    errorLevel={this.props.errorLevel} />
                 {pagination}
                 {modal}
             </div>


### PR DESCRIPTION
**High level description:**

Adds the ability to switch the active dashboard between errors and warnings view

**Technical details:**

- Updates existing containers to ensure a new API call is made with the correct `error_level` param when switching between errors and warnings
- Stores the error level in the `ActiveDashboard` component local state
- Adds whitespace above the filter sidebar and historical dashboard content for consistent vertical alignment

**Link to JIRA Ticket:**

[DEV-4318](https://federal-spending-transparency.atlassian.net/browse/DEV-4318)

**Mockup**
https://bahdigital.invisionapp.com/share/QEIACQKF2JW#/296030448_Active_-_MVP_-_1

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed