### PR TITLE
Fix: Update ActiveDashboardImpacts Data per Gauge

### DIFF
--- a/src/js/components/dashboard/impacts/ActiveDashboardImpacts.jsx
+++ b/src/js/components/dashboard/impacts/ActiveDashboardImpacts.jsx
@@ -39,13 +39,13 @@ const ActiveDashboardImpacts = (props) => (
                     hasFailed={props.hasFailed} />
                 <ImpactGauge
                     level="medium"
-                    submissionData={props.submissionData.low}
+                    submissionData={props.submissionData.medium}
                     openModal={props.openModal}
                     inFlight={props.inFlight}
                     hasFailed={props.hasFailed} />
                 <ImpactGauge
                     level="high"
-                    submissionData={props.submissionData.low}
+                    submissionData={props.submissionData.high}
                     openModal={props.openModal}
                     inFlight={props.inFlight}
                     hasFailed={props.hasFailed} />


### PR DESCRIPTION
**High level description:**

During demos, it was discovered that the gauges data all pointed to the low impact counts. This properly distinguishes them.

**Technical details:**

N/A

**Link to JIRA Ticket:**

N/A

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed