### PR TITLE
DEV-4942: Updating DABS Banner to be more explicit

### DIFF
--- a/src/js/components/SharedComponents/SubmissionWarningBanner.jsx
+++ b/src/js/components/SharedComponents/SubmissionWarningBanner.jsx
@@ -58,8 +58,9 @@ export default class SubmissionWarningBanner extends React.Component {
                     header: (<p>Submission Updated</p>),
                     message: (
                         <p>
-                            This submission has been updated.
-                            If you would like changes to be reflected on USASpending, please certify. <br />
+                            To <b>re-certify</b> with these changes, complete the submission process and certify. <br />
+                            To <b>undo</b> these changes, click "Revert Submission" here or on the review page.
+                            This will immediately undo your changes and return the submission to its previously certified state. <br />
                             <button
                                 disabled={disabled}
                                 className={`usa-da-button btn-primary btn-full${disabled ? ' btn-disabled' : ''}`}

--- a/src/js/components/SharedComponents/SubmissionWarningBanner.jsx
+++ b/src/js/components/SharedComponents/SubmissionWarningBanner.jsx
@@ -59,7 +59,7 @@ export default class SubmissionWarningBanner extends React.Component {
                     message: (
                         <p>
                             To <b>re-certify</b> with these changes, complete the submission process and certify. <br />
-                            To <b>undo</b> these changes, click "Revert Submission" here or on the review page.
+                            To <b>undo</b> these changes, click &quot;Revert Submission&quot; here or on the review page.
                             This will immediately undo your changes and return the submission to its previously certified state. <br />
                             <button
                                 disabled={disabled}


### PR DESCRIPTION
**High level description:**

Simply updating the Banner to be more explicit for when users have the option to revert their submission.

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-4942](https://federal-spending-transparency.atlassian.net/browse/DEV-4942)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed