### PR TITLE
DEV-4821 settings impact dropdowns

### DIFF
--- a/src/_scss/pages/modals/settings/_impactDropdown.scss
+++ b/src/_scss/pages/modals/settings/_impactDropdown.scss
@@ -10,6 +10,7 @@
                     .usa-dt-picker__button-text {
                         font-size: $small-font-size;
                         font-weight: $font-normal;
+                        color: $font-color;
                     }
                     .usa-dt-picker__button-icon {
                         svg {
@@ -26,6 +27,7 @@
                         .usa-dt-picker__item {
                             font-size: $small-font-size;
                             font-weight: $font-normal;
+                            color: $font-color;
                         }
                     }
                 }

--- a/src/_scss/pages/modals/settings/_impactDropdown.scss
+++ b/src/_scss/pages/modals/settings/_impactDropdown.scss
@@ -6,7 +6,7 @@
                 @include flex(1 1 auto);
                 .usa-dt-picker__button {
                     margin: 0;
-                    padding: 0;
+                    padding: rem(3);
                     .usa-dt-picker__button-text {
                         font-size: $small-font-size;
                         font-weight: $font-normal;
@@ -20,7 +20,8 @@
                 }
                 .usa-dt-picker__list {
                     z-index: 4;
-                    width: rem(78);
+                    width: rem(84);
+                    overflow: hidden; // prevent scrollbars in this list
                     .usa-dt-picker__list-item {
                         .usa-dt-picker__item {
                             font-size: $small-font-size;

--- a/src/_scss/pages/modals/settings/_impactDropdown.scss
+++ b/src/_scss/pages/modals/settings/_impactDropdown.scss
@@ -1,0 +1,47 @@
+// Override component library default styles
+.settings-table__row {
+    .settings-table__data {
+        .usa-dt-picker {
+            .usa-dt-picker__dropdown-container {
+                @include flex(1 1 auto);
+                .usa-dt-picker__button {
+                    margin: 0;
+                    padding: 0;
+                    .usa-dt-picker__button-text {
+                        font-size: $small-font-size;
+                        font-weight: $font-normal;
+                    }
+                    .usa-dt-picker__button-icon {
+                        svg {
+                            width: rem(16);
+                            height: rem(16);
+                        }
+                    }
+                }
+                .usa-dt-picker__list {
+                    z-index: 4;
+                    width: rem(78);
+                    .usa-dt-picker__list-item {
+                        .usa-dt-picker__item {
+                            font-size: $small-font-size;
+                            font-weight: $font-normal;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    &:nth-child(odd) {
+        .settings-table__data{
+            .usa-dt-picker {
+                .usa-dt-picker__dropdown-container {
+                    .usa-dt-picker__button {
+                        background-color: $color-gray-lightest;
+                    }
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/_scss/pages/modals/settings/_impactDropdown.scss
+++ b/src/_scss/pages/modals/settings/_impactDropdown.scss
@@ -21,9 +21,10 @@
                 }
                 .usa-dt-picker__list {
                     z-index: 4;
-                    width: rem(84);
+                    width: auto;
                     overflow: hidden; // prevent scrollbars in this list
                     .usa-dt-picker__list-item {
+                        border-top: 0;
                         .usa-dt-picker__item {
                             font-size: $small-font-size;
                             font-weight: $font-normal;

--- a/src/_scss/pages/modals/settings/_settingsModal.scss
+++ b/src/_scss/pages/modals/settings/_settingsModal.scss
@@ -61,6 +61,12 @@
         @include brokerTable;
         .settings-table {
             margin-top: rem(25);
+            tr.settings-table__row {
+                td.settings-table__data {
+                    padding-top: rem(12);
+                    padding-bottom: rem(12);
+                }
+            }
             .settings-table__rule {
                 padding-left: rem(10);
             }

--- a/src/_scss/pages/modals/settings/_settingsModal.scss
+++ b/src/_scss/pages/modals/settings/_settingsModal.scss
@@ -67,8 +67,9 @@
             .fa-bars {
                 margin-right: rem(10);
             }
-            .settings-table__row {
-                &.settings-table__row_significance {
+            @import './impactDropdown';
+            .settings-table__data {
+                &.settings-table__data_significance {
                     white-space: nowrap;
                 }
             }

--- a/src/js/components/settings/SettingsModal.jsx
+++ b/src/js/components/settings/SettingsModal.jsx
@@ -110,6 +110,7 @@ export default class SettingsModal extends React.Component {
                                     <div className="validation-rule-select">
                                         <h2><FontAwesomeIcon icon="filter" /> Validation Rules</h2>
                                         <Picker
+                                            id="validation-rules-picker"
                                             options={ruleList}
                                             selectedOption={this.state.selectedRule.label}
                                             sortFn={() => 0}

--- a/src/js/components/settings/table/ImpactDropdown.jsx
+++ b/src/js/components/settings/table/ImpactDropdown.jsx
@@ -30,6 +30,7 @@ const ImpactDropdown = ({ rule, selectedOption, updateImpact }) => {
     ));
     return (
         <Picker
+            id={`impact-${rule}-picker`}
             options={impactOptions}
             selectedOption={selectedOption}
             sortFn={() => 0} />

--- a/src/js/components/settings/table/ImpactDropdown.jsx
+++ b/src/js/components/settings/table/ImpactDropdown.jsx
@@ -1,0 +1,41 @@
+/**
+ * ImpactDropdown.jsx
+ * Created by Lizzie Salita 4/27/20
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { startCase } from 'lodash';
+import { Picker } from 'data-transparency-ui';
+
+const propTypes = {
+    rule: PropTypes.string.isRequired,
+    selectedOption: PropTypes.oneOf(['low', 'medium', 'high']),
+    updateImpact: PropTypes.func.isRequired
+};
+
+const impacts = [
+    'low',
+    'medium',
+    'high'
+];
+
+const ImpactDropdown = ({ rule, selectedOption, updateImpact }) => {
+    const impactOptions = impacts.map((impact) => (
+        {
+            value: impact,
+            name: startCase(impact),
+            onClick: () => updateImpact(rule, impact)
+        }
+    ));
+    return (
+        <Picker
+            options={impactOptions}
+            selectedOption={selectedOption}
+            sortFn={() => 0} />
+    );
+};
+
+ImpactDropdown.propTypes = propTypes;
+
+export default ImpactDropdown;

--- a/src/js/components/settings/table/ImpactDropdown.jsx
+++ b/src/js/components/settings/table/ImpactDropdown.jsx
@@ -10,7 +10,7 @@ import { Picker } from 'data-transparency-ui';
 
 const propTypes = {
     rule: PropTypes.string.isRequired,
-    selectedOption: PropTypes.oneOf(['low', 'medium', 'high']),
+    selectedOption: PropTypes.oneOf(['Low', 'Medium', 'High']),
     updateImpact: PropTypes.func.isRequired
 };
 
@@ -25,7 +25,7 @@ const ImpactDropdown = ({ rule, selectedOption, updateImpact }) => {
         {
             value: impact,
             name: startCase(impact),
-            onClick: () => updateImpact(rule, impact)
+            onClick: () => updateImpact(impact, rule)
         }
     ));
     return (

--- a/src/js/components/settings/table/SettingsTable.jsx
+++ b/src/js/components/settings/table/SettingsTable.jsx
@@ -29,18 +29,18 @@ const SettingsTable = ({ results, updateImpact }) => {
         <th key={col}>{startCase(col)}</th>
     ));
     const tableRows = results.map((row) => (
-        <tr key={`settings-table-row-${row.label}`}>
-            <td className="settings-table__row settings-table__row_significance">
+        <tr className="settings-table__row" key={`settings-table-row-${row.label}`}>
+            <td className="settings-table__data settings-table__data_significance">
                 <FontAwesomeIcon icon="bars" />
                 {row.significance}.<span className="settings-table__rule">{row.label}</span>
             </td>
-            <td className="settings-table__row">
+            <td className="settings-table__data">
                 <ImpactDropdown
                     rule={row.label}
                     selectedOption={startCase(row.impact)}
                     updateImpact={updateImpact} />
             </td>
-            <td className="settings-table__row">
+            <td className="settings-table__data">
                 <div title={row.description} className="ellipse-box">
                     {row.description}
                 </div>

--- a/src/js/components/settings/table/SettingsTable.jsx
+++ b/src/js/components/settings/table/SettingsTable.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { startCase } from 'lodash';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ImpactDropdown from './ImpactDropdown';
 
 const propTypes = {
     results: PropTypes.array
@@ -24,7 +25,7 @@ const columns = [
 
 const SettingsTable = ({ results }) => {
     const tableHeaders = columns.map((col) => (
-        <th>{startCase(col)}</th>
+        <th key={col}>{startCase(col)}</th>
     ));
     const tableRows = results.map((row) => (
         <tr key={`settings-table-row-${row.label}`}>
@@ -33,7 +34,10 @@ const SettingsTable = ({ results }) => {
                 {row.significance}.<span className="settings-table__rule">{row.label}</span>
             </td>
             <td className="settings-table__row">
-                {startCase(row.impact)}
+                <ImpactDropdown
+                    rule={row.label}
+                    selectedOption={startCase(row.impact)}
+                    updateImpact={(rule, impact) => console.log(rule, impact)} />
             </td>
             <td className="settings-table__row">
                 <div title={row.description} className="ellipse-box">

--- a/src/js/components/settings/table/SettingsTable.jsx
+++ b/src/js/components/settings/table/SettingsTable.jsx
@@ -10,7 +10,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import ImpactDropdown from './ImpactDropdown';
 
 const propTypes = {
-    results: PropTypes.array
+    results: PropTypes.array,
+    updateImpact: PropTypes.func
 };
 
 const defaultProps = {
@@ -23,7 +24,7 @@ const columns = [
     'description'
 ];
 
-const SettingsTable = ({ results }) => {
+const SettingsTable = ({ results, updateImpact }) => {
     const tableHeaders = columns.map((col) => (
         <th key={col}>{startCase(col)}</th>
     ));
@@ -37,7 +38,7 @@ const SettingsTable = ({ results }) => {
                 <ImpactDropdown
                     rule={row.label}
                     selectedOption={startCase(row.impact)}
-                    updateImpact={(rule, impact) => console.log(rule, impact)} />
+                    updateImpact={updateImpact} />
             </td>
             <td className="settings-table__row">
                 <div title={row.description} className="ellipse-box">

--- a/src/js/containers/settings/SettingsTableContainer.jsx
+++ b/src/js/containers/settings/SettingsTableContainer.jsx
@@ -5,9 +5,11 @@
 
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { updateSavedSettings, updateImpact } from 'redux/actions/settingsActions';
 import { fetchSettings } from 'helpers/settingsHelper';
-import SettingsTable from '../../components/settings/table/SettingsTable';
+import SettingsTable from 'components/settings/table/SettingsTable';
 
 const propTypes = {
     agencyCode: PropTypes.string,
@@ -16,14 +18,16 @@ const propTypes = {
 };
 
 const SettingsTableContainer = ({ agencyCode, file, errorLevel }) => {
-    const [results, setResults] = useState([]);
     const [loading, setLoading] = useState(false);
+    const dispatch = useDispatch();
+    const { stagedSettings } = useSelector((state) => state.settings);
+    const updateImpactSetting = (impact, rule) => dispatch(updateImpact(impact, rule, errorLevel));
 
     useEffect(() => {
         if (agencyCode && file) {
             setLoading(true);
             fetchSettings(agencyCode, file).then((data) => {
-                setResults(data);
+                dispatch(updateSavedSettings(data));
                 setLoading(false);
             });
         }
@@ -32,8 +36,13 @@ const SettingsTableContainer = ({ agencyCode, file, errorLevel }) => {
     if (loading) {
         return (<p>Loading...</p>);
     }
-    else if (results.length !== 0) {
-        return (<SettingsTable results={results[`${errorLevel}s`]} />);
+    else if (stagedSettings[`${errorLevel}s`].length !== 0) {
+        return (
+            <SettingsTable
+                results={stagedSettings[`${errorLevel}s`]}
+                updateImpact={updateImpactSetting}
+                errorLevel={errorLevel} />
+        );
     }
     return (
         <p>Please select an agency.</p>

--- a/src/js/redux/actions/settingsActions.js
+++ b/src/js/redux/actions/settingsActions.js
@@ -1,0 +1,25 @@
+/**
+  * settingsActions.js
+  * Created by Lizzie Salita 4/27/20
+  **/
+
+export const updateSavedSettings = (settings) => ({
+    type: 'UPDATE_SAVED_SETTINGS',
+    settings
+});
+
+export const updatedStagedSettings = (settings) => ({
+    type: 'UPDATE_STAGED_SETTINGS',
+    settings
+});
+
+export const updateImpact = (impact, rule, errorLevel) => ({
+    type: 'UPDATE_IMPACT',
+    impact,
+    rule,
+    errorLevel
+});
+
+export const clearSettings = () => ({
+    type: 'CLEAR_SETTINGS'
+});

--- a/src/js/redux/reducers/index.js
+++ b/src/js/redux/reducers/index.js
@@ -10,6 +10,7 @@ import { submissionsTableFiltersReducer } from './submissionsTable/submissionsTa
 import { appliedSubmissionsTableFiltersReducer } from './submissionsTable/appliedFiltersReducer';
 import { dashboardFiltersReducer } from './dashboard/dashboardFiltersReducer';
 import { appliedDashboardFiltersReducer } from './dashboard/appliedFiltersReducer';
+import { settingsReducer } from './settingsReducer';
 
 const appReducer = combineReducers({
     session: sessionReducer,
@@ -21,7 +22,8 @@ const appReducer = combineReducers({
     submissionsTableFilters: submissionsTableFiltersReducer,
     appliedSubmissionsTableFilters: appliedSubmissionsTableFiltersReducer,
     dashboardFilters: dashboardFiltersReducer,
-    appliedDashboardFilters: appliedDashboardFiltersReducer
+    appliedDashboardFilters: appliedDashboardFiltersReducer,
+    settings: settingsReducer
 });
 
 export default appReducer;

--- a/src/js/redux/reducers/settingsReducer.js
+++ b/src/js/redux/reducers/settingsReducer.js
@@ -1,0 +1,59 @@
+/**
+ * settingsReducer.js
+ * Created by Lizzie Salita 4/27/20
+ **/
+
+
+import { cloneDeep } from 'lodash';
+
+export const initialState = {
+    stagedSettings: {
+        warnings: [],
+        errors: []
+    },
+    savedSettings: {
+        warnings: [],
+        errors: []
+    }
+};
+
+export const settingsReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case 'UPDATE_SAVED_SETTINGS': {
+            return Object.assign({}, state, {
+                stagedSettings: action.settings,
+                savedSettings: action.settings
+            });
+        }
+
+        case 'UPDATE_STAGED_SETTINGS': {
+            const settings = Object.assign({}, state.stagedSettings, {
+                [`${action.errorLevel}s`]: action.settings
+            });
+            return Object.assign({}, state, {
+                stagedSettings: settings
+            });
+        }
+
+        case 'UPDATE_IMPACT': {
+            const settings = cloneDeep(state.stagedSettings[`${action.errorLevel}s`]);
+            // Find the index of the rule to update
+            const index = settings.findIndex((setting) => setting.label === action.rule);
+            settings[index].impact = action.impact;
+            const stagedSettings = Object.assign({}, state.stagedSettings, {
+                [`${action.errorLevel}s`]: settings
+            });
+            return Object.assign({}, state, {
+                stagedSettings
+            });
+        }
+
+        case 'CLEAR_SETTINGS': {
+            return initialState;
+        }
+
+        default:
+            return state;
+    }
+};
+

--- a/tests/redux/mockData.js
+++ b/tests/redux/mockData.js
@@ -1,0 +1,36 @@
+export const mockSettings = {
+    warnings: [
+        {
+            description: 'A18 description',
+            label: 'A18',
+            significance: 1,
+            impact: 'high'
+        },
+        {
+            description: 'A19 description',
+            label: 'A19',
+            significance: 2,
+            impact: 'high'
+        },
+        {
+            description: 'A35 description',
+            label: 'A35',
+            significance: 3,
+            impact: 'high'
+        }
+    ],
+    errors: [
+        {
+            description: 'A30.1 description',
+            label: 'A30.1',
+            significance: 1,
+            impact: 'medium'
+        },
+        {
+            description: 'A30.2 description',
+            label: 'A30.2',
+            significance: 2,
+            impact: 'high'
+        }
+    ]
+};

--- a/tests/redux/settingsReducer-test.js
+++ b/tests/redux/settingsReducer-test.js
@@ -1,0 +1,91 @@
+/**
+ * settingsReducer-test.js
+ * Created by Lizzie Salita 4/27/20
+ */
+
+import { settingsReducer, initialState } from 'redux/reducers/settingsReducer';
+import { mockSettings } from './mockData';
+
+describe('settingsReducer', () => {
+    describe('UPDATE_SAVED_SETTINGS', () => {
+        const action = {
+            type: 'UPDATE_SAVED_SETTINGS',
+            settings: mockSettings
+        };
+
+        it('should update the saved settings', () => {
+            const updatedState = settingsReducer(undefined, action);
+            expect(updatedState.savedSettings).toEqual(mockSettings);
+        });
+
+        it('should also update the staged settings', () => {
+            const updatedState = settingsReducer(undefined, action);
+            expect(updatedState.stagedSettings).toEqual(mockSettings);
+        });
+    });
+    describe('UPDATE_STAGED_SETTINGS', () => {
+        const action = {
+            type: 'UPDATE_STAGED_SETTINGS',
+            settings: mockSettings.warnings,
+            errorLevel: 'warning'
+        };
+
+        it('should update the staged settings for the given error level', () => {
+            const updatedState = settingsReducer(undefined, action);
+            expect(updatedState.stagedSettings.warnings).toEqual(mockSettings.warnings);
+        });
+
+        it('should not update the saved settings', () => {
+            const updatedState = settingsReducer(undefined, action);
+            expect(updatedState.savedSettings.warnings).toEqual(initialState.savedSettings.warnings);
+        });
+    });
+    describe('UPDATE_IMPACT', () => {
+        // Settings will already be populated when we invoke this action
+        const state = { stagedSettings: mockSettings, savedSettings: mockSettings };
+        it('should change the impact of the specified rule to its given value', () => {
+            const action = {
+                type: 'UPDATE_IMPACT',
+                impact: 'low',
+                rule: 'A35',
+                errorLevel: 'warning'
+            };
+
+            const updatedState = settingsReducer(state, action);
+            expect(updatedState.stagedSettings.warnings).toEqual([
+                {
+                    description: 'A18 description',
+                    label: 'A18',
+                    significance: 1,
+                    impact: 'high'
+                },
+                {
+                    description: 'A19 description',
+                    label: 'A19',
+                    significance: 2,
+                    impact: 'high'
+                },
+                {
+                    description: 'A35 description',
+                    label: 'A35',
+                    significance: 3,
+                    impact: 'low'
+                }
+            ]);
+        });
+    });
+    describe('CLEAR_SETTINGS', () => {
+        it('should reset the dashboard filters to their initial state', () => {
+            const state = { stagedSettings: mockSettings, savedSettings: mockSettings };
+
+            // Reset the filters
+            const resetAction = {
+                type: 'CLEAR_SETTINGS'
+            };
+
+            const restoredState = settingsReducer(state, resetAction);
+
+            expect(restoredState).toEqual(initialState);
+        });
+    });
+});


### PR DESCRIPTION
**High level description:**

Allow users to select an impact of low, medium, or high for each rule from dropdowns in the settings modal table. 

**Technical details:**

- Uses the `Picker` component from the component library
- Sets up Redux store for the saved settings and staged settings; adds an action for updating the impact of a rule
- Includes unit tests for the reducer

**Link to JIRA Ticket:**

[DEV-4821](https://federal-spending-transparency.atlassian.net/browse/DEV-4821), subtask of [DEV-4297](https://federal-spending-transparency.atlassian.net/browse/DEV-4297)

**Mockup**
https://bahdigital.invisionapp.com/share/QEIACQKF2JW#/296030446_Active_-_Settings_5

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension) - one issue that needs to be resolved in the component library (see [DEV-4475](https://federal-spending-transparency.atlassian.net/browse/DEV-4475))

Reviewer(s):
- [ ] Frontend review completed
- [x] #1346 merged or closed
- [x] Base changed to `dev`