### PR TITLE
DEV-4316 Fix Dashboard graph tooltips in IE

### DIFF
--- a/src/js/components/dashboard/graph/active/SignificanceCircle.jsx
+++ b/src/js/components/dashboard/graph/active/SignificanceCircle.jsx
@@ -58,6 +58,7 @@ export default class SignificanceCircle extends React.Component {
         return (
             <g
                 tabIndex="0"
+                focusable
                 onMouseOver={this.mouseEntered}
                 onFocus={this.mouseEntered}
                 onMouseOut={this.mouseExited}

--- a/src/js/components/dashboard/graph/historical/StackedBar.jsx
+++ b/src/js/components/dashboard/graph/historical/StackedBar.jsx
@@ -64,6 +64,7 @@ export default class StackedBar extends React.Component {
                     height={this.props.height}
                     fill={this.props.color}
                     tabIndex="0"
+                    focusable
                     onMouseOver={this.mouseEntered}
                     onFocus={this.mouseEntered}
                     onMouseOut={this.mouseExited}


### PR DESCRIPTION
**High level description:**

Makes elements representing rules in DABS Dashboard graphs (stacked bars for Historical and circles for Active) keyboard accessible, and therefore able to trigger the tooltips via keyboard, in Internet Explorer.

**Technical details:**

Internet Explorer does not support `tabIndex`, which is our primary method for making otherwise non-interactive elements keyboard accessible. The `focusable` attribute should be added as well for IE. See https://allyjs.io/tutorials/focusing-in-svg.html#browser-compatibility.

**Link to JIRA Ticket:**

[DEV-4316](https://federal-spending-transparency.atlassian.net/browse/DEV-4316) (Failed Test)

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Frontend review completed