### PR TITLE
Updating check_year_quarter logic per backend changes

### DIFF
--- a/src/js/components/addData/AddDataMeta.jsx
+++ b/src/js/components/addData/AddDataMeta.jsx
@@ -151,14 +151,15 @@ export default class AddDataMeta extends React.Component {
 
             const cgacCode = codeType === 'cgac_code' ? agency : null;
             const frecCode = codeType === 'frec_code' ? agency : null;
-            AgencyHelper.checkYearQuarter(cgacCode, frecCode, year, quarter)
+            const isQuarter = (dateType === 'quarter');
+            AgencyHelper.checkYearQuarter(cgacCode, frecCode, year, quarter, isQuarter)
                 .then(() => {
                     this.props.updateMetaData(this.state);
                 })
                 .catch((err) => {
                     this.setState({
                         showModal: true,
-                        certifiedSubmission: err.submissionId,
+                        certifiedSubmission: err.submissionIds[0],
                         modalMessage: (
                             <div className="alert-warning alert-warning_test-submission">
                                 <h3>
@@ -170,7 +171,7 @@ export default class AddDataMeta extends React.Component {
                                         `You will not be able to certify this submission since one has already been certified for this fiscal quarter.
                                         To view the certified submission, `
                                     }
-                                    <Link to={`/submission/${err.submissionId}/validateData`}>click here</Link>.
+                                    <Link to={`/submission/${err.submissionIds[0]}/validateData`}>click here</Link>.
                                 </p>
                             </div>
                         )

--- a/src/js/helpers/agencyHelper.js
+++ b/src/js/helpers/agencyHelper.js
@@ -54,12 +54,12 @@ export const fetchSubTierAgencies = () => {
     return deferred.promise;
 };
 
-export function checkYearQuarter(cgac, frec, year, quarter) {
+export function checkYearQuarter(cgac, frec, year, quarter, isQuarter) {
     const deferred = Q.defer();
     const validCgac = cgac || '';
     const validFrec = frec || '';
-    Request.get(`${kGlobalConstants.API}check_year_quarter/?cgac_code=${validCgac}&frec_code=${validFrec}&` +
-                `reporting_fiscal_year=${year}&reporting_fiscal_period=${quarter}`)
+    Request.get(`${kGlobalConstants.API}check_year_period/?cgac_code=${validCgac}&frec_code=${validFrec}&` +
+                `reporting_fiscal_year=${year}&reporting_fiscal_period=${quarter}&is_quarter=${isQuarter}`)
         .end((err, res) => {
             if (err) {
                 const response = Object.assign({}, res.body);


### PR DESCRIPTION
**High level description:**

Simply making sure the FE doesn't break with the changes to `check_year_quarter`

**Technical details:**

The quarter functionality still works fine. The monthly aspect of this check will not be implemented until next sprint.

**Link to JIRA Ticket:**

[DEV-5020](https://federal-spending-transparency.atlassian.net/browse/DEV-5020)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#1900](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1900)