### PR TITLE
DEV-5144: separate publish certify

### DIFF
--- a/src/js/components/reviewData/CertificationModal/ReviewDataCertifyModal.jsx
+++ b/src/js/components/reviewData/CertificationModal/ReviewDataCertifyModal.jsx
@@ -57,7 +57,7 @@ export default class ReviewDataCertifyModal extends React.Component {
         e.preventDefault();
         this.setState({ loading: true });
 
-        ReviewHelper.certifySubmission(this.props.submissionID)
+        ReviewHelper.publishCertifyDABSSubmission(this.props.submissionID)
             .then(() => {
                 this.setState({ loading: false });
                 this.closeModal();

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -424,10 +424,10 @@ export const saveNarrative = (narrative) => {
     return deferred.promise;
 };
 
-export const certifySubmission = (submissionId) => {
+export const publishCertifyDABSSubmission = (submissionId) => {
     const deferred = Q.defer();
 
-    Request.post(`${kGlobalConstants.API}certify_submission/`)
+    Request.post(`${kGlobalConstants.API}publish_and_certify_dabs_submission/`)
         .send({ submission_id: submissionId })
         .end((err, res) => {
             if (err) {


### PR DESCRIPTION
**High level description:**

Renaming the endpoint used by the frontend so it keeps working until the frontend work is done

**Technical details:**

Using the `publish_and_certify_dabs_submission` endpoint instead of the `certify_submission` endpoint because it was renamed

**Link to JIRA Ticket:**

[DEV-5144](https://federal-spending-transparency.atlassian.net/browse/DEV-5144)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#1903](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1903)