### PR TITLE
OPS Fix: Populating Webpack config based on CAS_ROOT environment variable

### DIFF
--- a/webpack/webpack.dev.config.js
+++ b/webpack/webpack.dev.config.js
@@ -53,7 +53,9 @@ module.exports = merge(common, {
                 PUBLIC_FILES: process.env.PUBLIC_FILES
                     ? JSON.stringify(process.env.PUBLIC_FILES)
                     : JSON.stringify(""),
-                CAS_ROOT: JSON.stringify("https://login.test.max.gov"),
+                CAS_ROOT: process.env.CAS_ROOT
+                    ? JSON.stringify(process.env.CAS_ROOT)
+                    : JSON.stringify("https://login.test.max.gov"),
                 IS_DEV: JSON.stringify('true'),
                 IS_LOCAL: process.env.IS_LOCAL && process.env.IS_LOCAL === 'true'
                     ? JSON.stringify('true')

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -78,7 +78,9 @@ module.exports = merge(common, {
                 PUBLIC_FILES: process.env.PUBLIC_FILES
                     ? JSON.stringify(process.env.PUBLIC_FILES)
                     : JSON.stringify(""),
-                CAS_ROOT: JSON.stringify("https://login.max.gov"),
+                CAS_ROOT: process.env.CAS_ROOT
+                    ? JSON.stringify(process.env.CAS_ROOT)
+                    : JSON.stringify("https://login.max.gov"),
                 IS_DEV: JSON.stringify('false'),
                 IS_LOCAL: process.env.IS_LOCAL && process.env.IS_LOCAL === 'true'
                     ? JSON.stringify('true')


### PR DESCRIPTION
**High level description:**

This allows environmental settings for the CAS_ROOT setting. 

**Technical details:**

N/A

**Link to JIRA Ticket:**

N/A

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Verified on Sandbox

Reviewer(s):
- Design review completed
- [ ] Frontend review completed