### PR TITLE
DEV-4831: dabs comment display save

### DIFF
--- a/src/_scss/pages/reviewData/leftSide/leftSide.scss
+++ b/src/_scss/pages/reviewData/leftSide/leftSide.scss
@@ -2,7 +2,6 @@
     @import "../../../components/buttons/_primary";
 
     position: relative;
-    background: #fff url('/graphics/large_file_icon.png') no-repeat;
     width: 24.0rem;
     margin: 0 auto;
     position: relative;

--- a/src/js/components/reviewData/ReviewDataNarrative.jsx
+++ b/src/js/components/reviewData/ReviewDataNarrative.jsx
@@ -120,7 +120,9 @@ export default class ReviewDataNarrative extends React.Component {
                     <h4>Add comments to files</h4>
                     <div className="row">
                         <div className="col-md-7">
-                            <ReviewDataNarrativeDropdown changeFile={this.changeFile} />
+                            <ReviewDataNarrativeDropdown
+                                changeFile={this.changeFile}
+                                currentFile={this.state.currentFile} />
                         </div>
                         <div className="col-md-5 pull-right">
                             <div

--- a/src/js/components/reviewData/ReviewDataNarrativeDropdown.jsx
+++ b/src/js/components/reviewData/ReviewDataNarrativeDropdown.jsx
@@ -7,28 +7,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-    changeFile: PropTypes.func
+    changeFile: PropTypes.func,
+    currentFile: PropTypes.string
 };
 
 const defaultProps = {
-    changeFile: null
+    changeFile: null,
+    currentFile: 'A'
 };
 
 export default class ReviewDataNarrativeDropdown extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.changeFile = this.changeFile.bind(this);
+    }
+
     changeFile(e) {
         e.preventDefault();
         this.props.changeFile(e.target.value);
     }
 
     render() {
-        const fileList = ["A", "B", "C", "D1", "D2", "E", "F"];
+        const fileList = ['A', 'B', 'C', 'D1', 'D2', 'E', 'F'];
         const dropdownOptions = [];
         for (let i = 0; i < fileList.length; i++) {
             dropdownOptions.push(<option key={i} value={fileList[i]}>File {fileList[i]}</option>);
         }
         return (
             <div className="file-dropdown">
-                <select onChange={this.changeFile.bind(this)}>
+                <select
+                    onChange={this.changeFile}
+                    value={this.props.currentFile}>
                     {dropdownOptions}
                 </select>
             </div>


### PR DESCRIPTION
**High level description:**

Making the selected file displayed in the comment file dropdown be the correct one even after a user saves their comments.

**Technical details:**

- The value of the dropdown is now whatever the current file is in the state of the parent so it's properly reflected everywhere.
- Bonus: Fixed that darn `large_file_icon.png` console error that we kept getting constantly

**Link to JIRA Ticket:**

[DEV-4831](https://federal-spending-transparency.atlassian.net/browse/DEV-4831)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed