### PR TITLE
DEV-5482/5534: reporting period displays

### DIFF
--- a/src/js/components/history/HistoryHeader.jsx
+++ b/src/js/components/history/HistoryHeader.jsx
@@ -55,12 +55,7 @@ export default class HistoryHeader extends React.Component {
                 <div className="row header">
                     <div className="col-xs-6">
                         <p className="metadata">Agency: {this.state.metadata.agency_name}</p>
-                        <p className="metadata">
-                            Reporting Period Start: {this.state.metadata.reporting_period}
-                        </p>
-                        <p className="metadata">
-                            Reporting Period End: {this.state.metadata.reporting_period}
-                        </p>
+                        <p className="metadata">Reporting Period: {this.state.metadata.reporting_period}</p>
                     </div>
                     <div className="col-xs-6">
                         <p className="metadata">Created: {createdOn}</p>

--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -19,7 +19,6 @@ import * as uploadActions from 'redux/actions/uploadActions';
 
 import * as GenerateFilesHelper from 'helpers/generateFilesHelper';
 import * as ReviewHelper from 'helpers/reviewHelper';
-import * as UtilHelper from 'helpers/util';
 
 const propTypes = {
     setSubmissionId: PropTypes.func,
@@ -125,38 +124,6 @@ export class GenerateFilesContainer extends React.Component {
             });
     }
 
-    parseDate(raw, type) {
-        // convert the API dates back into date objects
-        let month;
-        let day;
-        let year;
-
-        if (raw.indexOf('Q') > -1) {
-            // it's quarters!
-            const quarter = raw.split('/')[0].substring(1);
-            const rawYear = raw.split('/')[1];
-            const monthDay = UtilHelper.quarterToMonth(quarter, rawYear, type);
-            month = monthDay.split('/')[0];
-            year = monthDay.split('/')[1];
-        }
-        else {
-            // it's months
-            month = raw.split('/')[0];
-            year = raw.split('/')[1];
-        }
-
-        // now we need to calculate the day of month
-        if (type === 'start') {
-            day = '01';
-        }
-        else if (type === 'end') {
-            const date = moment().month(parseInt(month, 10) - 1).year(year);
-            day = date.endOf('month').format('DD');
-        }
-
-        return `${month}/${day}/${year}`;
-    }
-
     checkForPreviousFiles() {
         // check if D1 and D2 files already exist for this submission
         Q.allSettled([
@@ -221,8 +188,8 @@ export class GenerateFilesContainer extends React.Component {
                 this.props.setSubmissionPublishStatus(data.publish_status);
 
                 // check if quarter or month
-                const defaultStart = moment(this.parseDate(data.reporting_period, 'start'), 'MM/DD/YYYY');
-                const defaultEnd = moment(this.parseDate(data.reporting_period, 'end'), 'MM/DD/YYYY');
+                const defaultStart = moment(data.reporting_start_date, 'MM/DD/YYYY');
+                const defaultEnd = moment(data.reporting_end_date, 'MM/DD/YYYY');
 
                 const output = {
                     state: 'ready',

--- a/tests/containers/generateFiles/GenerateFilesContainer-test.jsx
+++ b/tests/containers/generateFiles/GenerateFilesContainer-test.jsx
@@ -44,28 +44,6 @@ describe('GenerateFilesContainer', () => {
             expect(setAgencyName).toHaveBeenCalled();
         });
     });
-    describe('parseDate', () => {
-        it('should convert quarters from the API into MM/DD/YYY', () => {
-            const container = shallow(<GenerateFilesContainer {...mockProps} {...mockActions} />);
-            const date = container.instance().parseDate('Q1/1999', 'start');
-            expect(date).toEqual('10/01/1998');
-        });
-        it('should convert months from the API into date objects', () => {
-            const container = shallow(<GenerateFilesContainer {...mockProps} {...mockActions} />);
-            const date = container.instance().parseDate('03/1999', 'start');
-            expect(date).toEqual('03/01/1999');
-        });
-        it('should handle end dates for quarters', () => {
-            const container = shallow(<GenerateFilesContainer {...mockProps} {...mockActions} />);
-            const date = container.instance().parseDate('Q2/1999', 'end');
-            expect(date).toEqual('03/31/1999');
-        });
-        it('should handle end dates for months', () => {
-            const container = shallow(<GenerateFilesContainer {...mockProps} {...mockActions} />);
-            const date = container.instance().parseDate('03/1999', 'end');
-            expect(date).toEqual('03/31/1999');
-        });
-    });
     describe('handleDateChange', () => {
         it('should update the state with the new date', () => {
             const container = shallow(<GenerateFilesContainer {...mockProps} {...mockActions} />);


### PR DESCRIPTION
**High level description:**

Updating the displays for reporting period to use P## for monthly submissions.

**Technical details:**

- Period 2 specifically is P01-P02/YYYY format for periods.
- Swapped to using the actual reporting periods from the submission in the database when generating default D1/D2 dates instead of manually deriving them.

**Link to JIRA Ticket:**

[DEV-5482](https://federal-spending-transparency.atlassian.net/browse/DEV-5482)
[DEV-5534](https://federal-spending-transparency.atlassian.net/browse/DEV-5534)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#1913](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1913)