### PR TITLE
DEV-5027: Detached d1 element numbers

### DIFF
--- a/src/_scss/pages/generateDetachedFiles/generateDetachedFiles.scss
+++ b/src/_scss/pages/generateDetachedFiles/generateDetachedFiles.scss
@@ -70,5 +70,23 @@
         .right-align-box {
             text-align: right;
         }
+
+        .checkbox-wrapper {
+            text-align: left;
+            margin-left: 33%;
+            margin-bottom: rem(7);
+            padding-top: rem(10);
+            border-top: 1px $color-gray-warm-light dashed;
+
+            input[type="checkbox"] {
+                margin-left: rem(5);
+                vertical-align: middle;
+            }
+
+            label {
+                vertical-align: text-top;
+                line-height: rem(25);
+            }
+        }
     }
 }

--- a/src/js/components/generateDetachedFiles/DateSelect.jsx
+++ b/src/js/components/generateDetachedFiles/DateSelect.jsx
@@ -17,7 +17,8 @@ const propTypes = {
     updateError: PropTypes.func,
     d1: PropTypes.object,
     d2: PropTypes.object,
-    updateFileProperty: PropTypes.func
+    updateFileProperty: PropTypes.func,
+    clickedElementNumbersCheckbox: PropTypes.func
 };
 
 const defaultProps = {
@@ -27,7 +28,8 @@ const defaultProps = {
     updateError: null,
     d1: null,
     d2: null,
-    updateFileProperty: null
+    updateFileProperty: null,
+    clickedElementNumbersCheckbox: null
 };
 
 export default class DateSelect extends React.Component {
@@ -81,6 +83,16 @@ export default class DateSelect extends React.Component {
                         fileType="d1"
                         sectionType="fileFormat" />
                 </div>
+                <div className="checkbox-wrapper">
+                    <label htmlFor="fpds-element-check">
+                        Include FPDS Element Numbers
+                    </label>
+                    <input
+                        type="checkbox"
+                        id="fpds-element-check"
+                        checked={this.props.d1.elementNumbers}
+                        onChange={this.props.clickedElementNumbersCheckbox} />
+                </div>
                 <GenerateFileBox
                     label="File D1: Procurement Awards (FPDS data)"
                     datePlaceholder="Action"
@@ -91,7 +103,6 @@ export default class DateSelect extends React.Component {
                     onDateChange={this.handleDateChange.bind(this, "d1")}
                     updateError={this.updateError.bind(this, "d1")}
                     clickedDownload={this.clickedDownload.bind(this, "d1")} />
-
                 <div className="right-align-box">
                     <button
                         className="usa-da-button btn-default"

--- a/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
+++ b/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
@@ -50,7 +50,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 status: "",
                 jobID: null,
                 agencyType: 'awarding',
-                fileFormat: 'csv'
+                fileFormat: 'csv',
+                elementNumbers: false
             },
             d2: {
                 startDate: null,
@@ -65,7 +66,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 status: "",
                 jobID: null,
                 agencyType: 'awarding',
-                fileFormat: 'csv'
+                fileFormat: 'csv',
+                elementNumbers: false
             }
         };
 
@@ -74,6 +76,7 @@ export default class GenerateDetachedFilesPage extends React.Component {
         this.updateError = this.updateError.bind(this);
         this.handleDateChange = this.handleDateChange.bind(this);
         this.generateFile = this.generateFile.bind(this);
+        this.clickedElementNumbersCheckbox = this.clickedElementNumbersCheckbox.bind(this);
     }
 
     componentDidMount() {
@@ -137,6 +140,16 @@ export default class GenerateDetachedFilesPage extends React.Component {
             [file]: newState
         }, () => {
             this.validateDates(file);
+        });
+    }
+
+    clickedElementNumbersCheckbox() {
+        const newState = Object.assign(this.state.d1, {
+            elementNumbers: !this.state.d1.elementNumbers
+        });
+
+        this.setState({
+            d1: newState
         });
     }
 
@@ -221,7 +234,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
             start: tmpFile.startDate.format('MM/DD/YYYY'),
             end: tmpFile.endDate.format('MM/DD/YYYY'),
             agency_type: this.state[file].agencyType,
-            file_format: this.state[file].fileFormat
+            file_format: this.state[file].fileFormat,
+            element_numbers: this.state[file].elementNumbers
         };
 
         GenerateFilesHelper.generateDetachedFile(params)
@@ -321,7 +335,8 @@ export default class GenerateDetachedFilesPage extends React.Component {
                 updateError={this.updateError}
                 generateFile={this.generateFile}
                 updateFileProperty={this.updateFileProperty}
-                clickedDownload={this.clickedDownload} />);
+                clickedDownload={this.clickedDownload}
+                clickedElementNumbersCheckbox={this.clickedElementNumbersCheckbox} />);
         }
 
         return (


### PR DESCRIPTION
**High level description:**

Adding checkbox to include FPDS element numbers in detached D1 generation

**Technical details:**

The technical details can be placed here for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Link to JIRA Ticket:**

[DEV-5027](https://federal-spending-transparency.atlassian.net/browse/DEV-5027)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed