### PR TITLE
DEV-6086: prevent wrong file type upload

### DIFF
--- a/src/js/components/crossFile/CrossFileOverlay.jsx
+++ b/src/js/components/crossFile/CrossFileOverlay.jsx
@@ -11,6 +11,7 @@ import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
 
 import * as PermissionsHelper from '../../helpers/permissionsHelper';
 import NextButton from '../submission/NextButton';
+import { checkValidFileList } from '../../helpers/util';
 
 const propTypes = {
     uploadFiles: PropTypes.func,
@@ -89,7 +90,7 @@ export default class CrossFileOverlay extends React.Component {
         this.props.nextStep();
     }
 
-    isUploadingFiles() {
+    hasStagedFiles() {
         if (Object.keys(this.props.submission.files).length > 0) {
             return true;
         }
@@ -116,6 +117,10 @@ export default class CrossFileOverlay extends React.Component {
                 // neither file in the pair is staged for upload, submission isn't ready for re-upload
                 return false;
             }
+        }
+
+        if (!checkValidFileList(this.props.submission.files)) {
+            return false;
         }
 
         // if we hit this point, the files are ready
@@ -184,14 +189,14 @@ export default class CrossFileOverlay extends React.Component {
         }
 
         // enable the upload button if the correct files have been staged for upload
-        if ((this.state.allowUpload || this.isUploadingFiles()) && PermissionsHelper
+        if ((this.state.allowUpload && this.hasStagedFiles()) && PermissionsHelper
             .checkAgencyPermissions(this.props.session, this.props.agencyName)) {
             overlay.uploadButtonDisabled = false;
             overlay.uploadButtonClass = ' btn-primary';
         }
         else {
             overlay.uploadButtonDisabled = true;
-            overlay.uploadButtonDisabled = '-disabled';
+            overlay.uploadButtonClass = '-disabled';
         }
 
         this.setState({

--- a/src/js/components/uploadFabsFile/UploadFabsFileBox.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileBox.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FileComponent from '../addData/FileComponent';
 import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
+import { validUploadFileChecker } from '../../helpers/util';
 
 const propTypes = {
     uploadFile: PropTypes.func,
@@ -34,7 +35,8 @@ export default class UploadFabsFileBox extends React.Component {
         }
 
         const fileStateReady = this.props.submission.files && this.props.submission.files.fabs &&
-            this.props.submission.files.fabs.state === 'ready';
+            this.props.submission.files.fabs.state === 'ready' &&
+            validUploadFileChecker(this.props.submission.files.fabs);
         const disabled = !fileStateReady || (this.props.fabs.status === "uploading");
         return (
             <div className="usa-da-upload-fabs-file-box dashed-border-top">

--- a/src/js/components/validateData/ValidationOverlay.jsx
+++ b/src/js/components/validateData/ValidationOverlay.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import * as Icons from '../SharedComponents/icons/Icons';
 import CommonOverlay from '../SharedComponents/overlays/CommonOverlay';
 import NextButton from '../submission/NextButton';
+import { checkValidFileList } from '../../helpers/util';
 
 const propTypes = {
     uploadFiles: PropTypes.func,
@@ -90,13 +91,21 @@ export default class ValidationOverlay extends React.Component {
         }
         else if (this.props.submission.state === 'prepare') {
             uploadButtonDisabled = true;
-            uploadButtonDisabled = '-disabled';
+            uploadButtonClass = '-disabled';
             buttonText = 'Gathering data...';
 
             if (this.props.errors.length === 0) {
                 nextButtonClass = '-disabled';
                 nextButtonDisabled = true;
             }
+        }
+        else if (!checkValidFileList(this.props.submission.files)) {
+            uploadButtonDisabled = true;
+            uploadButtonClass = '-disabled';
+            buttonText = 'Invalid File Types';
+
+            nextButtonClass = '-disabled';
+            nextButtonDisabled = true;
         }
 
         if (this.props.notAllowed) {

--- a/src/js/containers/addData/AddDataContainer.jsx
+++ b/src/js/containers/addData/AddDataContainer.jsx
@@ -16,7 +16,7 @@ import AddDataContent from 'components/addData/AddDataContent';
 import ErrorMessage from 'components/SharedComponents/ErrorMessage';
 import { fileTypes } from './fileTypes';
 import { kGlobalConstants } from '../../GlobalConstants';
-import { validUploadFileChecker } from '../../helpers/util';
+import { checkValidFileList } from '../../helpers/util';
 
 
 const propTypes = {
@@ -46,14 +46,12 @@ class AddDataContainer extends React.Component {
     componentDidUpdate(prevProps) {
         if (prevProps.submission.files !== this.props.submission.files) {
             if (Object.keys(this.props.submission.files).length === fileTypes.length) {
-                for (const file of Object.keys(this.props.submission.files)) {
-                    const currFile = this.props.submission.files[file];
-                    if (!validUploadFileChecker(currFile)) {
-                        this.props.setSubmissionState('empty');
-                        return;
-                    }
+                if (!checkValidFileList(this.props.submission.files)) {
+                    this.props.setSubmissionState('empty');
                 }
-                this.props.setSubmissionState('ready');
+                else {
+                    this.props.setSubmissionState('ready');
+                }
             }
         }
     }

--- a/src/js/containers/addData/AddDataContainer.jsx
+++ b/src/js/containers/addData/AddDataContainer.jsx
@@ -16,6 +16,7 @@ import AddDataContent from 'components/addData/AddDataContent';
 import ErrorMessage from 'components/SharedComponents/ErrorMessage';
 import { fileTypes } from './fileTypes';
 import { kGlobalConstants } from '../../GlobalConstants';
+import { validUploadFileChecker } from '../../helpers/util';
 
 
 const propTypes = {
@@ -43,8 +44,15 @@ class AddDataContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.submission.state === 'empty') {
+        if (prevProps.submission.files !== this.props.submission.files) {
             if (Object.keys(this.props.submission.files).length === fileTypes.length) {
+                for (const file of Object.keys(this.props.submission.files)) {
+                    const currFile = this.props.submission.files[file];
+                    if (!validUploadFileChecker(currFile)) {
+                        this.props.setSubmissionState('empty');
+                        return;
+                    }
+                }
                 this.props.setSubmissionState('ready');
             }
         }

--- a/src/js/containers/crossFile/CrossFileUploadButtonContainer.jsx
+++ b/src/js/containers/crossFile/CrossFileUploadButtonContainer.jsx
@@ -12,6 +12,8 @@ import * as uploadActions from '../../redux/actions/uploadActions';
 
 import UploadButton from '../../components/validateData/ValidateDataUploadButton';
 
+import { validUploadFileChecker } from '../../helpers/util';
+
 const propTypes = {
     setCrossFileStage: PropTypes.func,
     setUploadItem: PropTypes.func,
@@ -74,6 +76,11 @@ class CrossFileUploadButtonContainer extends React.Component {
             // technically this is an optional upload, but we are going to pass a different CSS class in instead
             isOptional = false;
             additionalClasses = ' btn-staged-upload';
+
+            // if the file isn't a valid type, set it to danger colors
+            if (!validUploadFileChecker(this.props.submission.files[this.props.fileKey])) {
+                additionalClasses = ' btn-danger-outline';
+            }
         }
 
         return (

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -88,6 +88,17 @@ export const validUploadFileChecker = (rawFile) => {
     return 'unset';
 };
 
+
+export const checkValidFileList = (fileList) => {
+    for (const file of Object.keys(fileList)) {
+        const currFile = fileList[file];
+        if (!validUploadFileChecker(currFile)) {
+            return false;
+        }
+    }
+    return true;
+};
+
 export const earliestFileAYear = 2017;
 
 export const convertDateToQuarter = (date) => {


### PR DESCRIPTION
**High level description:**

Disable the upload button if a bad file type is staged so the user can't even try to upload it

**Technical details:**

The backend handles bad file types but it's good practice to also have the frontend just prevent the user from uploading

**Link to JIRA Ticket:**

[DEV-6086](https://federal-spending-transparency.atlassian.net/browse/DEV-6086)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [ ] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Design review completed
- [ ] Frontend review completed