### PR TITLE
DEV-2084: Cross File Failed Overlay

### DIFF
--- a/src/js/components/crossFile/CrossFileContent.jsx
+++ b/src/js/components/crossFile/CrossFileContent.jsx
@@ -89,6 +89,7 @@ export default class CrossFileContent extends React.Component {
             }
             if (this.props.submission.state === 'failed') {
                 overlayMode = 'failed';
+                status = 'failed';
             }
 
             // each pair should have easy top-level access to the pair's occurrence counts

--- a/src/js/components/crossFile/CrossFileContent.jsx
+++ b/src/js/components/crossFile/CrossFileContent.jsx
@@ -28,7 +28,7 @@ export default class CrossFileContent extends React.Component {
     constructor(props) {
         super(props);
 
-        this.allowableStates = ['crossFile', 'uploading', 'prepare', 'failed'];
+        this.allowableStates = ['finished', 'uploading', 'prepare', 'failed'];
 
         this.state = {
             crossFileItems: [],
@@ -86,6 +86,9 @@ export default class CrossFileContent extends React.Component {
                 if (overlayMode === 'loading') {
                     overlayMode = 'success';
                 }
+            }
+            if (this.props.submission.state === 'failed') {
+                overlayMode = 'failed';
             }
 
             // each pair should have easy top-level access to the pair's occurrence counts

--- a/src/js/components/crossFile/CrossFileOverlay.jsx
+++ b/src/js/components/crossFile/CrossFileOverlay.jsx
@@ -170,6 +170,17 @@ export default class CrossFileOverlay extends React.Component {
             overlay.nextButtonClass = ' btn-primary';
             overlay.nextButtonDisabled = false;
         }
+        else if (this.props.mode === 'failed') {
+            // loading finished, show warnings
+            overlay.icon = <Icons.ExclamationCircle />;
+            overlay.iconClass = 'usa-da-errorRed';
+            overlay.message = 'An error has occurred while cross-validating your files.';
+            overlay.detail = 'Contact the Service Desk for assistance. Provide this URL when describing the issue.';
+            overlay.uploadButtonDisabled = true;
+            overlay.uploadButtonClass = '-disabled';
+            overlay.nextButtonClass = '-disabled';
+            overlay.nextButtonDisabled = true;
+        }
 
         // handle uploading events
         if (this.props.submission.state === 'uploading') {

--- a/src/js/containers/crossFile/CrossFileContentContainer.jsx
+++ b/src/js/containers/crossFile/CrossFileContentContainer.jsx
@@ -158,7 +158,7 @@ class CrossFileContentContainer extends React.Component {
                                 errors: ReviewHelper.getCrossFileData(response.jobs[0], 'errors'),
                                 warnings: ReviewHelper.getCrossFileData(response.jobs[0], 'warnings')
                             };
-                            this.props.setSubmissionState('crossFile');
+                            this.props.setSubmissionState(crossInfo.status);
                             this.props.setCrossFile(crossFile);
                         });
 


### PR DESCRIPTION
**High level description:**

Simply adds a blocking error overlay when the cross-file job has failed (copied from the first page's error overlay)

**Technical details:**

* Like other error overlays, the status is unchanged such that the user can restart the job if they reupload a file.

**Link to JIRA Ticket:**

[DEV-2084](https://federal-spending-transparency.atlassian.net/browse/DEV-2084)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [ ] Frontend review completed