### PR TITLE
DEV-6154: Staged cross files

### DIFF
--- a/src/js/components/crossFile/components/FileWarning.jsx
+++ b/src/js/components/crossFile/components/FileWarning.jsx
@@ -40,7 +40,7 @@ export default class FileWarning extends React.Component {
             this.props.submission.crossFileStaging)) {
             this.prepareData();
         }
-        // Have to do this because the callback in prepareData isn't triggering with a new state for some reason
+        // Have to do this because the callback in prepareData isn't triggering with a new state
         if (!_.isEqual(prevState.causedBy, this.state.causedBy) || !_.isEqual(prevState.affectedPairs,
             this.state.affectedPairs)) {
             this.generateMessages();

--- a/src/js/components/crossFile/components/FileWarning.jsx
+++ b/src/js/components/crossFile/components/FileWarning.jsx
@@ -35,10 +35,15 @@ export default class FileWarning extends React.Component {
         this.prepareData();
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps, prevState) {
         if (!_.isEqual(prevProps.files, this.props.files) || !_.isEqual(prevProps.submission.crossFileStaging,
             this.props.submission.crossFileStaging)) {
             this.prepareData();
+        }
+        // Have to do this because the callback in prepareData isn't triggering with a new state for some reason
+        if (!_.isEqual(prevState.causedBy, this.state.causedBy) || !_.isEqual(prevState.affectedPairs,
+            this.state.affectedPairs)) {
+            this.generateMessages();
         }
     }
 
@@ -56,8 +61,6 @@ export default class FileWarning extends React.Component {
         this.setState({
             affectedPairs,
             causedBy
-        }, () => {
-            this.generateMessages();
         });
     }
 


### PR DESCRIPTION
**High level description:**

Allows users to successfully stage 2 files in the same error/warning cross-file box without breaking the page.

**Technical details:**

Swapping to a check on componentDidUpdate because the callback wasn't happening at the right time

**Link to JIRA Ticket:**

[DEV-6154](https://federal-spending-transparency.atlassian.net/browse/DEV-6154)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed