### PR TITLE
DEV-6155/6156: Deprecate old endpoints

### DIFF
--- a/src/js/helpers/generateFilesHelper.js
+++ b/src/js/helpers/generateFilesHelper.js
@@ -99,8 +99,8 @@ export const fetchDetachedFileUrl = (jobId) => {
 export const getFabsMeta = (submissionId) => {
     const deferred = Q.defer();
 
-    Request.post(`${kGlobalConstants.API}get_fabs_meta/`)
-        .send({ submission_id: submissionId })
+    Request.get(`${kGlobalConstants.API}get_fabs_meta/?submission_id=${submissionId}`)
+        .send()
         .end((errFile, res) => {
             if (errFile) {
                 deferred.reject(errFile);

--- a/src/js/helpers/reviewHelper.js
+++ b/src/js/helpers/reviewHelper.js
@@ -345,7 +345,7 @@ export const fetchObligations = (submissionId) => {
 
 export const submissionReport = (submissionId, warning, fileType, crossType) => {
     const deferred = Q.defer();
-    const params = [];
+    const params = [`submission_id=${submissionId}`];
     if (warning) {
         params.push('warning=true');
     }
@@ -359,7 +359,7 @@ export const submissionReport = (submissionId, warning, fileType, crossType) => 
         params.push(`cross_type=${crossType}`);
     }
 
-    Request.get(`${kGlobalConstants.API}submission/${submissionId}/report_url?${params.join('&')}`)
+    Request.get(`${kGlobalConstants.API}report_url/?${params.join('&')}`)
         .end((errFile, res) => {
             if (errFile) {
                 deferred.reject(errFile, res);

--- a/src/js/helpers/submissionListHelper.js
+++ b/src/js/helpers/submissionListHelper.js
@@ -110,12 +110,9 @@ export const loadSubmissionHistory = (submissionID) => {
 export const getSubmissionFile = (submissionID, certifiedFilesHistory, isWarning) => {
     const deferred = Q.defer();
 
-    Request.post(`${kGlobalConstants.API}get_certified_file/`)
-        .send({
-            submission_id: submissionID,
-            published_files_history_id: certifiedFilesHistory,
-            is_warning: isWarning
-        })
+    Request.get(`${kGlobalConstants.API}get_certified_file/?submission_id=${submissionID}&` +
+                `published_files_history_id=${certifiedFilesHistory}&is_warning=${isWarning}`)
+        .send()
         .end((err, res) => {
             if (err) {
                 deferred.reject(err);


### PR DESCRIPTION
**High level description:**

Updating to use the new versions of the deprecated endpoints

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-6155](https://federal-spending-transparency.atlassian.net/browse/DEV-6155)
[DEV-6156](https://federal-spending-transparency.atlassian.net/browse/DEV-6156)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed
- [ ] Merged after or concurrently with [Backend#1974](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1974)