### PR TITLE
DEV-6222/6223: Expiring submission warnings

### DIFF
--- a/src/_scss/pages/addData/_content.scss
+++ b/src/_scss/pages/addData/_content.scss
@@ -30,8 +30,16 @@
 
                 label {
                     font-weight: bold;
+                    line-height: rem(18);
                     .subtype-description {
                         font-weight: normal;
+
+                        &.test-submission-note {
+                            margin-top: rem(7.5);
+                            b {
+                                color: $color-gray;
+                            }
+                        }
                     }
                 }
             }

--- a/src/js/components/addData/SubmissionGuideContent.jsx
+++ b/src/js/components/addData/SubmissionGuideContent.jsx
@@ -72,6 +72,12 @@ export default class SubmissionGuideContent extends React.Component {
                                             creating. This information includes the name of your agency and the
                                             reporting period.
                                         </p>
+                                        <p>
+                                            <b>
+                                                Test submissions are automatically deleted if they remain unedited for
+                                                a period of 6 months.
+                                            </b>
+                                        </p>
                                     </div>
                                 </div>
                             </div>

--- a/src/js/components/addData/metadata/SubmissionTypeField.jsx
+++ b/src/js/components/addData/metadata/SubmissionTypeField.jsx
@@ -92,6 +92,10 @@ export default class SubmissionTypeField extends React.Component {
                                     Test submissions cannot be published or certified, but they can be used to validate
                                     your data.
                                 </div>
+                                <div className="subtype-description test-submission-note">
+                                    <b>Note:</b> Test submissions are automatically deleted if they remain unedited for
+                                    a period of 6 months.
+                                </div>
                             </label>
                         </div>
 


### PR DESCRIPTION
**High level description:**

Adding warnings about test submissions expiring before creating the submission

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-6222](https://federal-spending-transparency.atlassian.net/browse/DEV-6222)
[DEV-6223](https://federal-spending-transparency.atlassian.net/browse/DEV-6223)

**Mockup**
https://bahdigital.invisionapp.com/share/7TIAF69AWB3#/screens
https://bahdigital.invisionapp.com/share/6CIAF6A7FBZ#/screens

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed