### PR TITLE
Fix: Remove react prompt

### DIFF
--- a/src/js/components/reviewData/Narrative/ReviewDataNarrative.jsx
+++ b/src/js/components/reviewData/Narrative/ReviewDataNarrative.jsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import { Prompt } from 'react-router';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -157,15 +156,10 @@ export default class ReviewDataNarrative extends React.Component {
         }
         if (this.state.commentsCollapsed) {
             return (
-                <React.Fragment>
-                    <Prompt
-                        when={!isEqual(this.state.initialNarrative, this.state.currentNarrative)}
-                        message="You have unsaved comments, these comments will be deleted if you leave this page." />
-                    <ReviewDataNarrativeCollapsed
-                        toggleCommentBox={this.toggleCommentBox}
-                        initialNarrative={this.state.initialNarrative}
-                        unsavedCommentsMessage={unsavedCommentsMessage} />
-                </React.Fragment>
+                <ReviewDataNarrativeCollapsed
+                    toggleCommentBox={this.toggleCommentBox}
+                    initialNarrative={this.state.initialNarrative}
+                    unsavedCommentsMessage={unsavedCommentsMessage} />
             );
         }
         const hasSavedComments = Object.values(this.state.initialNarrative).some((x) => x !== '');
@@ -195,9 +189,6 @@ export default class ReviewDataNarrative extends React.Component {
         }
         return (
             <React.Fragment>
-                <Prompt
-                    when={!isEqual(this.state.initialNarrative, this.state.currentNarrative)}
-                    message="You have unsaved comments, these comments will be deleted if you leave this page." />
                 <div className="row comments-header">
                     <div className="col-md-6">
                         <h5>Agency Comments <span className="not-bold">(optional)</span></h5>


### PR DESCRIPTION
**High level description:**

Removing React Prompt from the comments section

**Technical details:**

The React Prompt component has a bug where it doesn't change the URL back to the current page if the user hits "cancel."

**Link to JIRA Ticket:**

N/A

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed