### PR TITLE
DEV-6869: Review Page USAS Submission Links Open in New Tabs

### DIFF
--- a/src/js/components/reviewData/ReviewDataContent.jsx
+++ b/src/js/components/reviewData/ReviewDataContent.jsx
@@ -301,10 +301,10 @@ export default class ReviewDataContent extends React.Component {
                         <div className="col-md-6">
                             <b>Note:</b> After a submission is published all of the associated comments will be made
                             available on USAspending.gov in the&nbsp;
-                            {/* <a href="https://www.usaspending.gov/submission-statistics/">
+                            {/* <a href="https://www.usaspending.gov/submission-statistics/" target="_blank" rel="noopener noreferrer">
                                 Agency Submission Statistics section
                             </a> and the&nbsp;*/}
-                            <a href="https://files.usaspending.gov/agency_submissions/">
+                            <a href="https://files.usaspending.gov/agency_submissions/" target="_blank" rel="noopener noreferrer">
                                 Agency Submission Files section
                             </a>.
                         </div>


### PR DESCRIPTION
**High level description:**

Updating the links on the review page to USAS to open as new tabs. Note: only the agency submission file link is still available at this point though the other has been primed to open as a new tab once it's uncommented.   

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-6869](https://federal-spending-transparency.atlassian.net/browse/DEV-6869)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed