### PR TITLE
DEV-7299: historic dashboard graph endpoint

### DIFF
--- a/src/_scss/pages/dashboard/graph/_dashboardGraph.scss
+++ b/src/_scss/pages/dashboard/graph/_dashboardGraph.scss
@@ -77,6 +77,10 @@
                                 padding-left: rem(15);
                                 padding-top: rem(5);
                             }
+                            &.no-border {
+                                border-top: none;
+                                padding-top: 0;
+                            }
                         }
                         &.highlighted {
                             background-color: $color-gray-lighter;

--- a/src/_scss/pages/dashboard/graph/_dashboardGraph.scss
+++ b/src/_scss/pages/dashboard/graph/_dashboardGraph.scss
@@ -79,7 +79,6 @@
                             }
                             &.no-border {
                                 border-top: none;
-                                padding-top: 0;
                             }
                         }
                         &.highlighted {
@@ -105,7 +104,7 @@
                         }
                         .text-left {
                             text-align: left;
-                            width: 40%;
+                            width: 45%;
                         }
                     }
                 }

--- a/src/js/components/dashboard/graph/DashboardGraph.jsx
+++ b/src/js/components/dashboard/graph/DashboardGraph.jsx
@@ -20,7 +20,7 @@ import ActiveDashboardTooltip from './active/ActiveDashboardTooltip';
 const propTypes = {
     xSeries: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     ySeries: PropTypes.arrayOf(PropTypes.object),
-    allY: PropTypes.arrayOf(PropTypes.number),
+    allY: PropTypes.object,
     loading: PropTypes.bool,
     error: PropTypes.bool,
     type: PropTypes.oneOf(['historical', 'active']),

--- a/src/js/components/dashboard/graph/DashboardGraphTooltip.jsx
+++ b/src/js/components/dashboard/graph/DashboardGraphTooltip.jsx
@@ -100,7 +100,7 @@ export default class DashboardGraphTooltip extends React.Component {
         let hr = <hr />;
         if (this.props.shape === 'bar') {
             headerType = ' historic';
-            title = this.props.xValue;
+            title = `${this.props.xValue.slice(0, 3)} 20${this.props.xValue.slice(3)}`;
             hr = null;
         }
         return (

--- a/src/js/components/dashboard/graph/active/SignificanceGraph.jsx
+++ b/src/js/components/dashboard/graph/active/SignificanceGraph.jsx
@@ -18,7 +18,7 @@ import SignificanceCircle from './SignificanceCircle';
 const propTypes = {
     xSeries: PropTypes.arrayOf(PropTypes.number),
     ySeries: PropTypes.arrayOf(PropTypes.object),
-    allY: PropTypes.arrayOf(PropTypes.number),
+    allY: PropTypes.object,
     height: PropTypes.number,
     width: PropTypes.number,
     padding: PropTypes.object,

--- a/src/js/components/dashboard/graph/historical/BarChartStacked.jsx
+++ b/src/js/components/dashboard/graph/historical/BarChartStacked.jsx
@@ -20,7 +20,7 @@ import StackedBarGroup from './StackedBarGroup';
 const propTypes = {
     xSeries: PropTypes.arrayOf(PropTypes.string),
     ySeries: PropTypes.arrayOf(PropTypes.object),
-    allY: PropTypes.arrayOf(PropTypes.number),
+    allY: PropTypes.object,
     height: PropTypes.number,
     width: PropTypes.number,
     padding: PropTypes.object,
@@ -84,8 +84,8 @@ export default class BarChartStacked extends React.Component {
         // when we actually draw the chart, we won't need to do any more calculations
 
         // calculate the Y axis range
-        const yRange = [0, max(values.allY)];
-        if (values.allY.length === 1) {
+        const yRange = [0, max(values.allY.shownWarnings)];
+        if (values.allY.shownWarnings.length === 1) {
             yRange[0] = 0;
         }
 

--- a/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
+++ b/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
@@ -11,7 +11,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 const propTypes = {
     label: PropTypes.string,
     warnings: PropTypes.array,
-    totalWarnings: PropTypes.number
+    totalWarnings: PropTypes.number,
+    shownWarnings: PropTypes.number
 };
 
 export default class HistoricalDashboardTooltip extends React.Component {
@@ -28,6 +29,7 @@ export default class HistoricalDashboardTooltip extends React.Component {
                 </tr>
             );
         });
+        const shownPercent = this.props.shownWarnings / this.props.totalWarnings * 100;
         return (
             <React.Fragment>
                 <table className="tooltip__historic-dashboard-table">
@@ -41,6 +43,11 @@ export default class HistoricalDashboardTooltip extends React.Component {
                     <tbody>
                         {warnings}
                         <tr className="last-row">
+                            <td className="text-left">Displayed Total</td>
+                            <td>{formatNumberWithPrecision(this.props.shownWarnings, 0)}</td>
+                            <td>{formatNumberWithPrecision(shownPercent, 0)}%</td>
+                        </tr>
+                        <tr className="last-row no-border">
                             <td className="text-left">Total</td>
                             <td>{formatNumberWithPrecision(this.props.totalWarnings, 0)}</td>
                             <td>100%</td>

--- a/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
+++ b/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
@@ -29,7 +29,7 @@ export default class HistoricalDashboardTooltip extends React.Component {
                 </tr>
             );
         });
-        const shownPercent = this.props.shownWarnings / this.props.totalWarnings * 100;
+        const shownPercent = (this.props.shownWarnings / this.props.totalWarnings) * 100;
         return (
             <React.Fragment>
                 <table className="tooltip__historic-dashboard-table">

--- a/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
+++ b/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
@@ -37,18 +37,18 @@ export default class HistoricalDashboardTooltip extends React.Component {
                         <tr>
                             <th className="text-left">Warning</th>
                             <th>Count</th>
-                            <th>% of Total</th>
+                            <th>% Total</th>
                         </tr>
                     </thead>
                     <tbody>
                         {warnings}
                         <tr className="last-row">
-                            <td className="text-left">Displayed Total</td>
+                            <td className="text-left">Warnings Shown</td>
                             <td>{formatNumberWithPrecision(this.props.shownWarnings, 0)}</td>
                             <td>{formatNumberWithPrecision(shownPercent, 0)}%</td>
                         </tr>
                         <tr className="last-row no-border">
-                            <td className="text-left">Total</td>
+                            <td className="text-left">Submission Total</td>
                             <td>{formatNumberWithPrecision(this.props.totalWarnings, 0)}</td>
                             <td>100%</td>
                         </tr>

--- a/src/js/components/dashboard/graph/historical/StackedBarGroup.jsx
+++ b/src/js/components/dashboard/graph/historical/StackedBarGroup.jsx
@@ -95,7 +95,7 @@ export default class StackedBarGroup extends React.Component {
                     x={0}
                     y={0}
                     width={hitZoneWidth}
-                    height={this.props.height}
+                    height={this.props.height - 50}
                     onMouseEnter={this.hoveredAbove}
                     onMouseLeave={this.props.hideTooltip}
                     onTouchStart={this.barTouched} />

--- a/src/js/components/dashboard/graph/historical/StackedBarGroup.jsx
+++ b/src/js/components/dashboard/graph/historical/StackedBarGroup.jsx
@@ -43,7 +43,8 @@ export default class StackedBarGroup extends React.Component {
                 xValue,
                 warnings,
                 position,
-                totalWarnings: this.props.stack[0].tooltipData.totalWarnings
+                totalWarnings: this.props.stack[0].tooltipData.totalWarnings,
+                shownWarnings: this.props.stack[0].tooltipData.shownWarnings
             });
         }
         else {
@@ -52,7 +53,8 @@ export default class StackedBarGroup extends React.Component {
                 xValue,
                 warnings,
                 position,
-                totalWarnings: this.props.stack[0].tooltipData.totalWarnings
+                totalWarnings: this.props.stack[0].tooltipData.totalWarnings,
+                shownWarnings: this.props.stack[0].tooltipData.shownWarnings
             });
         }
     }

--- a/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
@@ -114,13 +114,11 @@ export default class WarningsInfoGraphContainer extends React.Component {
 
         // Sort the results into chronologic order
         const compare = (a, b) => {
-            const timePeriodA = `${a.fy} ${a.quarter}`;
-            const timePeriodB = `${b.fy} ${b.quarter}`;
             let comparison = 0;
-            if (timePeriodA > timePeriodB) {
+            if (a.fy > b.fy || (a.fy === b.fy && a.period > b.period)) {
                 comparison = 1;
             }
-            else if (timePeriodA < timePeriodB) {
+            else if (a.fy < b.fy || (a.fy === b.fy && a.period < b.period)) {
                 comparison = -1;
             }
             return comparison;
@@ -128,7 +126,11 @@ export default class WarningsInfoGraphContainer extends React.Component {
         file.sort(compare);
 
         file.forEach((submission) => {
-            const timePeriodLabel = `FY ${submission.fy.toString(10).substring(2)} / Q${submission.quarter}`;
+            let period = `Q${submission.period / 3}`;
+            if (submission.is_quarter) {
+                period = submission.period === 2 ? 'P01/P02' : `P${submission.period.toString().padStart(2, '0')}`;
+            }
+            const timePeriodLabel = `FY ${submission.fy.toString(10).substring(2)} / ${period}`;
             xSeries.push(timePeriodLabel);
             yData.push(submission.warnings);
             allY.totalWarnings.push(submission.total_warnings);

--- a/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
@@ -127,7 +127,7 @@ export default class WarningsInfoGraphContainer extends React.Component {
 
         file.forEach((submission) => {
             let period = `Q${submission.period / 3}`;
-            if (submission.is_quarter) {
+            if (!submission.is_quarter) {
                 period = submission.period === 2 ? 'P01-P02' : `P${submission.period.toString().padStart(2, '0')}`;
             }
             const timePeriodLabel = `FY ${submission.fy.toString(10).substring(2)} / ${period}`;

--- a/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
@@ -128,7 +128,7 @@ export default class WarningsInfoGraphContainer extends React.Component {
         file.forEach((submission) => {
             let period = `Q${submission.period / 3}`;
             if (submission.is_quarter) {
-                period = submission.period === 2 ? 'P01/P02' : `P${submission.period.toString().padStart(2, '0')}`;
+                period = submission.period === 2 ? 'P01-P02' : `P${submission.period.toString().padStart(2, '0')}`;
             }
             const timePeriodLabel = `FY ${submission.fy.toString(10).substring(2)} / ${period}`;
             xSeries.push(timePeriodLabel);

--- a/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
+++ b/src/js/containers/dashboard/graph/WarningsInfoGraphContainer.jsx
@@ -24,7 +24,10 @@ export default class WarningsInfoGraphContainer extends React.Component {
             error: false,
             xSeries: [],
             ySeries: [],
-            allY: [],
+            allY: {
+                totalWarnings: [],
+                shownWarnings: []
+            },
             legend: []
         };
     }
@@ -89,7 +92,8 @@ export default class WarningsInfoGraphContainer extends React.Component {
                     top: bottom + rule.instances,
                     description: rule.label,
                     percent: rule.percent_total,
-                    totalWarnings: allY[index]
+                    totalWarnings: allY.totalWarnings[index],
+                    shownWarnings: allY.shownWarnings[index]
                 };
                 bottom += rule.instances;
             });
@@ -100,7 +104,10 @@ export default class WarningsInfoGraphContainer extends React.Component {
     parseData(data) {
         const xSeries = []; // Fiscal Quarter labels
         const yData = []; // Warnings by rule for each submission
-        const allY = []; // Total warnings values
+        const allY = {
+            totalWarnings: [],
+            shownWarnings: []
+        }; // Total warnings values
 
         // For now, only one file at a time
         const file = data[this.props.appliedFilters.file];
@@ -124,7 +131,8 @@ export default class WarningsInfoGraphContainer extends React.Component {
             const timePeriodLabel = `FY ${submission.fy.toString(10).substring(2)} / Q${submission.quarter}`;
             xSeries.push(timePeriodLabel);
             yData.push(submission.warnings);
-            allY.push(submission.total_warnings);
+            allY.totalWarnings.push(submission.total_warnings);
+            allY.shownWarnings.push(submission.filtered_warnings);
         });
 
         const legend = this.generateLegend(yData);

--- a/tests/containers/dashboard/graph/WarningsInfoGraphContainer-test.jsx
+++ b/tests/containers/dashboard/graph/WarningsInfoGraphContainer-test.jsx
@@ -112,7 +112,7 @@ describe('WarningsInfoGraphContainer', () => {
             container.setProps({ ...newProps });
 
             container.instance().parseData(mockData);
-            expect(container.instance().state.xSeries).toEqual(['FY 98 / Q3', 'FY 99 / Q2']);
+            expect(container.instance().state.xSeries).toEqual(['FY 98 / P09', 'FY 99 / Q2']);
         });
         it('should parse the warnings data (in chronologic order)', () => {
             const container = shallow(<WarningsInfoGraphContainer
@@ -135,7 +135,8 @@ describe('WarningsInfoGraphContainer', () => {
                         bottom: 0,
                         top: 400,
                         description: 'C23.2',
-                        totalWarnings: 800
+                        totalWarnings: 800,
+                        shownWarnings: 800
                     },
                     C12: {
                         percent: 25,
@@ -143,7 +144,8 @@ describe('WarningsInfoGraphContainer', () => {
                         bottom: 400,
                         top: 600,
                         description: 'C12',
-                        totalWarnings: 800
+                        totalWarnings: 800,
+                        shownWarnings: 800
                     },
                     C11: {
                         percent: 25,
@@ -151,7 +153,8 @@ describe('WarningsInfoGraphContainer', () => {
                         bottom: 600,
                         top: 800,
                         description: 'C11',
-                        totalWarnings: 800
+                        totalWarnings: 800,
+                        shownWarnings: 800
                     }
                 },
                 {
@@ -161,7 +164,8 @@ describe('WarningsInfoGraphContainer', () => {
                         bottom: 0,
                         top: 500,
                         description: 'C23.1',
-                        totalWarnings: 1000
+                        totalWarnings: 1000,
+                        shownWarnings: 1000
                     },
                     C12: {
                         percent: 10,
@@ -169,7 +173,8 @@ describe('WarningsInfoGraphContainer', () => {
                         bottom: 500,
                         top: 600,
                         description: 'C12',
-                        totalWarnings: 1000
+                        totalWarnings: 1000,
+                        shownWarnings: 1000
                     },
                     C11: {
                         percent: 40,
@@ -177,7 +182,8 @@ describe('WarningsInfoGraphContainer', () => {
                         bottom: 600,
                         top: 1000,
                         description: 'C11',
-                        totalWarnings: 1000
+                        totalWarnings: 1000,
+                        shownWarnings: 1000
                     }
                 }
             ];
@@ -196,7 +202,8 @@ describe('WarningsInfoGraphContainer', () => {
             container.setProps({ ...newProps });
 
             container.instance().parseData(mockData);
-            expect(container.instance().state.allY).toEqual([800, 1000]);
+            expect(container.instance().state.allY).toEqual(
+                {"shownWarnings": [800, 1000], "totalWarnings": [800, 1000]});
         });
     });
 });

--- a/tests/containers/dashboard/graph/mockData.js
+++ b/tests/containers/dashboard/graph/mockData.js
@@ -9,6 +9,7 @@ export const mockData = {
         {
             submission_id: 123,
             total_warnings: 1000,
+            filtered_warnings: 1000,
             agency: {
                 code: '020',
                 name: 'Department of the Treasury (TREAS)'
@@ -31,11 +32,13 @@ export const mockData = {
                     percent_total: 40
                 }
             ],
-            quarter: 2
+            period: 6,
+            is_quarter: true
         },
         {
             submission_id: 124,
             total_warnings: 800,
+            filtered_warnings: 800,
             agency: {
                 code: '020',
                 name: 'Department of the Treasury (TREAS)'
@@ -58,7 +61,8 @@ export const mockData = {
                     percent_total: 25
                 }
             ],
-            quarter: 3
+            period: 9,
+            is_quarter: false
         }
     ]
 };


### PR DESCRIPTION
**High level description:**

Updating basic labels on graph and using periods and `is_quarter` instead of quarters. Also updating tooltip slightly to adjust for new design.

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-7299](https://federal-spending-transparency.atlassian.net/browse/DEV-7299)

**Mockup**
https://bahdigital.invisionapp.com/share/8UIAH0B9YD7#/screens/296059063

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed
- [ ] Merged concurrently with [Backend#2124](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2124)