### PR TITLE
DEV-7295: Historical Dashboard Graph X-Axis Cleanup

### DIFF
--- a/src/js/components/dashboard/graph/BarChartXAxis.jsx
+++ b/src/js/components/dashboard/graph/BarChartXAxis.jsx
@@ -19,10 +19,33 @@ const propTypes = {
 
 export default class BarChartXAxis extends React.Component {
     render() {
-        const labels = this.props.items.map((item) => (
+        const timePeriodLabels = [];
+        this.props.items.forEach((yearItem) => {
+            yearItem.timePeriodItems.forEach((periodItem) => (
+                timePeriodLabels.push(
+                    <BarChartXAxisItem
+                        key={`${yearItem.value} ${periodItem.value}`}
+                        label={periodItem.label}
+                        x={periodItem.x}
+                        y={periodItem.y} />
+                )
+            ));
+        });
+        const yearLines = this.props.items.map((item) => (
+            <line
+                key={item.value}
+                className="x-axis"
+                x1={item.startX}
+                x2={item.endX}
+                y1={40}
+                y2={40} />
+        ));
+        const yearLabels = this.props.items.map((yearItem) => (
             <BarChartXAxisItem
-                {...item}
-                key={item.value} />
+                key={yearItem.value}
+                label={`FY ${yearItem.label}`}
+                x={yearItem.x}
+                y={yearItem.y} />
         ));
 
         return (
@@ -40,7 +63,15 @@ export default class BarChartXAxis extends React.Component {
                 <g
                     className="axis-labels"
                     transform={`translate(${this.props.labelGroup.x},${this.props.labelGroup.y})`}>
-                    {labels}
+                    {timePeriodLabels}
+                </g>
+                <g transform={`translate(${this.props.lineGroup.x}, ${this.props.lineGroup.y})`}>
+                    {yearLines}
+                </g>
+                <g
+                    className="axis-labels"
+                    transform={`translate(${this.props.labelGroup.x},${this.props.labelGroup.y})`}>
+                    {yearLabels}
                 </g>
             </g>
         );

--- a/src/js/components/dashboard/graph/DashboardGraphTooltip.jsx
+++ b/src/js/components/dashboard/graph/DashboardGraphTooltip.jsx
@@ -71,7 +71,7 @@ export default class DashboardGraphTooltip extends React.Component {
         let direction = 'left';
         // if we are too close to the right edge, the arrow should point right (bc the
         // tooltip will be on the left of the bar)
-        if (shape === 'bar' && distanceFromRight <= 55) {
+        if (shape === 'bar' && distanceFromRight <= 120) {
             direction = 'right';
         }
         else if (shape === 'circle' && distanceFromRight <= 120) {


### PR DESCRIPTION
**High level description:**

Updating the Historical Dashboard Graph's X-axis to be much cleaner by
1. moving years to a separate line below
2. grouping period marks to quarter marks (they still are properly marked in the tooltip)

**Technical details:**

* Added to the threshold that determines if a tooltip is on the left or right side as some of the tooltips are unviewable on the right side.

**Link to JIRA Ticket:**

[DEV-7295](https://federal-spending-transparency.atlassian.net/browse/DEV-7295)

**Mockup**
https://bahdigital.invisionapp.com/share/8UIAH0B9YD7#/screens/296059058

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed