### PR TITLE
DEV-7652: historic dabs tooltip percent

### DIFF
--- a/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
+++ b/src/js/components/dashboard/graph/historical/HistoricalDashboardTooltip.jsx
@@ -25,7 +25,9 @@ export default class HistoricalDashboardTooltip extends React.Component {
                         {warning.description}
                     </td>
                     <td className={highlightCSS}>{formatNumberWithPrecision(warning.value, 0)}</td>
-                    <td className={highlightCSS}>{formatNumberWithPrecision(warning.percent, 0)}%</td>
+                    <td className={highlightCSS}>
+                        {warning.percent < 1 ? '<1' : formatNumberWithPrecision(warning.percent, 0)}%
+                    </td>
                 </tr>
             );
         });
@@ -45,7 +47,7 @@ export default class HistoricalDashboardTooltip extends React.Component {
                         <tr className="last-row">
                             <td className="text-left">Warnings Shown</td>
                             <td>{formatNumberWithPrecision(this.props.shownWarnings, 0)}</td>
-                            <td>{formatNumberWithPrecision(shownPercent, 0)}%</td>
+                            <td>{shownPercent < 1 ? '<1' : formatNumberWithPrecision(shownPercent, 0)}%</td>
                         </tr>
                         <tr className="last-row no-border">
                             <td className="text-left">Submission Total</td>


### PR DESCRIPTION
**High level description:**

Showing percentages less than 0 in the tooltip as `<1%` instead of `0%`

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-7652](https://federal-spending-transparency.atlassian.net/browse/DEV-7652)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed