### PR TITLE
DEV-7887: agency comments raw files

### DIFF
--- a/src/js/components/help/RawFilesItem.jsx
+++ b/src/js/components/help/RawFilesItem.jsx
@@ -26,7 +26,8 @@ export default class RawFilesItem extends React.Component {
     }
 
     itemAction() {
-        this.props.itemAction(this.props.currentLevel, this.props.item.id, this.props.item.label);
+        this.props.itemAction(this.props.currentLevel, this.props.item.id, this.props.item.label,
+            this.props.item.filetype);
     }
 
     render() {

--- a/src/js/components/help/RawFilesPage.jsx
+++ b/src/js/components/help/RawFilesPage.jsx
@@ -68,8 +68,8 @@ export default class RawFilesPage extends React.Component {
                     });
             }
             else {
-                const urlType = kGlobalConstants.PROD ? '' : 'non';
-                window.open(`https://files-${urlType}prod.usaspending.gov/agency_submissions/${label}`);
+                const urlType = kGlobalConstants.PROD ? '' : '-nonprod';
+                window.open(`https://files${urlType}.usaspending.gov/agency_submissions/${label}`);
             }
         }
         else {

--- a/src/js/components/help/RawFilesPage.jsx
+++ b/src/js/components/help/RawFilesPage.jsx
@@ -12,6 +12,7 @@ import Banner from 'components/SharedComponents/Banner';
 import Footer from 'components/SharedComponents/FooterComponent';
 import RawFilesContent from 'components/help/RawFilesContent';
 import HelpNav from './helpNav';
+import { kGlobalConstants } from '../../GlobalConstants';
 
 const propTypes = {
     type: PropTypes.oneOf(['dabs', 'fabs']),
@@ -55,15 +56,21 @@ export default class RawFilesPage extends React.Component {
             });
     }
 
-    itemAction(level, id, label) {
+    itemAction(level, id, label, fileType) {
         if (level === 'download') {
-            HelpHelper.downloadPublishedFile(id)
-                .then((result) => {
-                    window.open(result.url);
-                })
-                .catch((error) => {
-                    console.error(error);
-                });
+            if (fileType !== 'comments') {
+                HelpHelper.downloadPublishedFile(id)
+                    .then((result) => {
+                        window.open(result.url);
+                    })
+                    .catch((error) => {
+                        console.error(error);
+                    });
+            }
+            else {
+                const urlType = kGlobalConstants.PROD ? '' : 'non';
+                window.open(`https://files-${urlType}prod.usaspending.gov/agency_submissions/${label}`);
+            }
         }
         else {
             const tmpState = Object.assign({}, this.state);


### PR DESCRIPTION
**High level description:**

Adding a special download for agency comments on the raw files page because those are hosted elsewhere and don't have a publish ID

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-7887](https://federal-spending-transparency.atlassian.net/browse/DEV-7887)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed
- [x] Merged concurrently with [Backend#2181](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2181)