### PR TITLE
DEV-7486: file a generation date picker correct quarters

### DIFF
--- a/src/js/components/generateDetachedFiles/DetachedFileA.jsx
+++ b/src/js/components/generateDetachedFiles/DetachedFileA.jsx
@@ -207,13 +207,15 @@ export default class DetachedFileA extends React.Component {
                                                     Bureau of the Fiscal Service.
                                                 </p>
                                                 <p>
-                                                    Note: Because there is no Period 01 (October) reporting window in
-                                                    GTAS, a generated File A for a new Fiscal Year is not available
-                                                    until the Period 02 GTAS reporting window.
+                                                    Note: Periods are available to generate the day after they end.
+                                                    However, if the GTAS window for that period is not complete File A
+                                                    Data is subject to change and may need to be regenerated in order to
+                                                    reflect the final state of GTAS data once the window closes.
 
                                                     While Period 01 data is automatically included with data from
                                                     later periods (because File A Data is cumulative within the Fiscal
-                                                    year), it is not selectable on its own.
+                                                    year), it is not selectable on its own and therefore will not be
+                                                    visible until Dec 1 with Period 02.
                                                 </p>
                                             </div>
                                         </div>

--- a/src/js/components/generateDetachedFiles/DetachedFileA.jsx
+++ b/src/js/components/generateDetachedFiles/DetachedFileA.jsx
@@ -19,7 +19,7 @@ import DownloadFile from './DownloadFile';
 import FYPicker from './FYPicker';
 import PeriodPicker from './PeriodPicker';
 
-const initialPeriod = defaultPeriods();
+const initialPeriod = defaultPeriods(true);
 
 const propTypes = {
     type: PropTypes.oneOf(['dabs', 'fabs']),
@@ -82,7 +82,7 @@ export default class DetachedFileA extends React.Component {
     }
 
     pickedYear(fy) {
-        const fyAvailablePeriods = availablePeriodsInFY(fy);
+        const fyAvailablePeriods = availablePeriodsInFY(fy, true);
         this.setState({
             periodArray: fyAvailablePeriods.periodArray,
             period: fyAvailablePeriods.period,
@@ -97,7 +97,8 @@ export default class DetachedFileA extends React.Component {
     }
 
     generate() {
-        const minPeriod = utils.getPeriodTextFromValue(this.state.periodArray[0]);
+        // it's not possible to not start with October so we will always have the first period be 1
+        const minPeriod = utils.getPeriodTextFromValue(1);
         const maxPeriod = utils.getPeriodTextFromValue(this.state.period);
 
         this.setState({

--- a/src/js/components/generateDetachedFiles/PeriodButton.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButton.jsx
@@ -57,7 +57,17 @@ const PeriodButton = (props) => {
                 </span>
             );
         }
-        buttonText = <React.Fragment>{utils.getPeriodTextFromValue(props.period)}{quarterIndicator}</React.Fragment>;
+        // if we're in period 2, we need to make a special piece of text for the dropdown
+        if (props.period === 2) {
+            buttonText = '01/02 - October/November';
+        }
+        else {
+            buttonText = (
+                <React.Fragment>
+                    {utils.getPeriodTextFromValue(props.period)}{quarterIndicator}
+                </React.Fragment>
+            );
+        }
     }
     else if (typeof props.period === 'string') {
         buttonText = props.period;

--- a/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodButtonWithTooltip.jsx
@@ -89,7 +89,7 @@ export default class PeriodButtonWithTooltip extends React.Component {
             }
             else {
                 tooltip = (
-                    <WarningTooltip message={`The submission period has yet to open. Please seearch for a ` +
+                    <WarningTooltip message={`The submission period has yet to open. Please search for a ` +
                         `submission period that has opened.`} />
                 );
             }

--- a/src/js/components/generateDetachedFiles/PeriodPicker.jsx
+++ b/src/js/components/generateDetachedFiles/PeriodPicker.jsx
@@ -104,13 +104,15 @@ export default class PeriodPicker extends React.Component {
     render() {
         let currentSelection = 'Select a reporting period';
         if (this.props.type === 'fileA') {
-            const minPeriod = utils.getPeriodTextFromValue(this.props.periodArray[0]);
+            // in file A we always select period 1 first
+            const minPeriod = utils.getPeriodTextFromValue(1);
             const maxPeriod = utils.getPeriodTextFromValue(this.props.period);
             currentSelection = `${minPeriod} - ${maxPeriod}`;
         }
         const periods = this.props.periodArray.map((period, index) => {
-            // if it's the file A generation, highlight the hovered period and everything before it
-            let active = index + 1 <= this.state.hoveredPeriod;
+            // if it's the file A generation, highlight the hovered period and everything before it. We start on
+            // period 2 so we have to add 2 to the index, not 1
+            let active = index + 2 <= this.state.hoveredPeriod;
             let disabledReason = '';
 
             // if it's the historic dashboard, highlight the hovered item or the periods that make up the quarter

--- a/src/js/helpers/periodPickerHelper.js
+++ b/src/js/helpers/periodPickerHelper.js
@@ -17,44 +17,15 @@ export const mostRecentPeriod = () => {
     // get the latest period for which GTAS data is available
     const now = moment();
     let year = now.year();
-
-    let period = 12;
-
-    if (now.isBetween(moment(`12/18/${year}`, 'MM-DD-YYYY'), moment(`12/31/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        // Period 2 before Jan 1
-        period = 2;
+    // moment.month is 0-indexed
+    let period = (now.month() + 3) % 12;
+    // if we're in October/November, we only want to show the previous year's P12
+    if ( period === 0 || period === 1 ) {
+        period = 12;
+    }
+    // if we're in December we want to see FY22 P02 but the current year is still 2021 so we need to add 1
+    if ( period === 2 ) {
         year += 1;
-    }
-    else if (now.isBetween(moment(`01/01/${year}`, 'MM-DD-YYYY'), moment(`01/17/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        // Period 2 after Jan 1
-        period = 2;
-    }
-    else if (now.isBetween(moment(`01/18/${year}`, 'MM-DD-YYYY'), moment(`02/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 3;
-    }
-    else if (now.isBetween(moment(`02/19/${year}`, 'MM-DD-YYYY'), moment(`03/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 4;
-    }
-    else if (now.isBetween(moment(`03/19/${year}`, 'MM-DD-YYYY'), moment(`04/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 5;
-    }
-    else if (now.isBetween(moment(`04/19/${year}`, 'MM-DD-YYYY'), moment(`05/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 6;
-    }
-    else if (now.isBetween(moment(`05/19/${year}`, 'MM-DD-YYYY'), moment(`06/17/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 7;
-    }
-    else if (now.isBetween(moment(`06/18/${year}`, 'MM-DD-YYYY'), moment(`07/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 8;
-    }
-    else if (now.isBetween(moment(`07/19/${year}`, 'MM-DD-YYYY'), moment(`08/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 9;
-    }
-    else if (now.isBetween(moment(`08/19/${year}`, 'MM-DD-YYYY'), moment(`09/16/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 10;
-    }
-    else if (now.isBetween(moment(`09/17/${year}`, 'MM-DD-YYYY'), moment(`10/18/${year}`, 'MM-DD-YYYY'), null, '[]')) {
-        period = 11;
     }
 
     return {

--- a/src/js/helpers/periodPickerHelper.js
+++ b/src/js/helpers/periodPickerHelper.js
@@ -20,11 +20,11 @@ export const mostRecentPeriod = () => {
     // moment.month is 0-indexed
     let period = (now.month() + 3) % 12;
     // if we're in October/November, we only want to show the previous year's P12
-    if ( period === 0 || period === 1 ) {
+    if (period === 0 || period === 1) {
         period = 12;
     }
     // if we're in December we want to see FY22 P02 but the current year is still 2021 so we need to add 1
-    if ( period === 2 ) {
+    if (period === 2) {
         year += 1;
     }
 
@@ -52,22 +52,24 @@ export const lastCompletedPeriodInFY = (fy) => {
     return current;
 };
 
-export const availablePeriodsInFY = (fy) => {
+export const availablePeriodsInFY = (fy, ignoreOne = false) => {
+    // if we want to ignore one from the array (for certain picker purposes) ignoreOne should be true
     const sanitizedFY = handlePotentialStrings(fy);
     // get the most recent available period and year
     const lastPeriod = lastCompletedPeriodInFY(sanitizedFY);
 
     if (lastPeriod.year > sanitizedFY) {
+        const periodArray = ignoreOne ? [2] : [1, 2];
         // FY is in the future
         return {
-            periodArray: [1, 2],
+            periodArray,
             period: 2,
             year: sanitizedFY
         };
     }
 
     const available = [];
-    const firstPeriod = 1;
+    const firstPeriod = ignoreOne ? 2 : 1;
 
     for (let i = firstPeriod; i <= lastPeriod.period; i++) {
         if (sanitizedFY >= utils.earliestFileAYear) {
@@ -82,9 +84,9 @@ export const availablePeriodsInFY = (fy) => {
     };
 };
 
-export const defaultPeriods = () => {
+export const defaultPeriods = (ignoreOne = false) => {
     const current = mostRecentPeriod();
-    return availablePeriodsInFY(current.year);
+    return availablePeriodsInFY(current.year, ignoreOne);
 };
 
 export const defaultFiscalYear = () => {

--- a/tests/helpers/periodPickerHelper-test.js
+++ b/tests/helpers/periodPickerHelper-test.js
@@ -36,22 +36,14 @@ describe('periodPickerHelper', () => {
         it('should return the most recently completed period', () => {
             mockDate('1912-06-01');
             const output = periodPickerHelper.mostRecentPeriod();
-            expect(output.period).toEqual(7);
+            expect(output.period).toEqual(8);
         });
         it('should return the fiscal year of the most recently completed period', () => {
             mockDate('1912-06-01');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output.year).toEqual(1912);
         });
-        it('if GTAS data is not available, it should return the period before that', () => {
-            mockDate('1912-04-01');
-            const output = periodPickerHelper.mostRecentPeriod();
-            expect(output).toEqual({
-                period: 5,
-                year: 1912
-            });
-        });
-        it('if GTAS data is not available for period 2, then it should return period 12 of the previous fiscal year)', () => {
+        it('if period 2 isnt over yet, then it should return period 12 of the previous fiscal year)', () => {
             mockDate('2018-11-19');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output).toEqual({
@@ -59,32 +51,8 @@ describe('periodPickerHelper', () => {
                 year: 2018
             });
         });
-        it('if GTAS data is not available for this date (June), then it should return the previous period (May)', () => {
-            mockDate('1912-06-01');
-            const output = periodPickerHelper.mostRecentPeriod();
-            expect(output).toEqual({
-                period: 7,
-                year: 1912
-            });
-        });
-        it('if GTAS data is available for this date (June), then it should return the current period (June)', () => {
-            mockDate('1912-06-19');
-            const output = periodPickerHelper.mostRecentPeriod();
-            expect(output).toEqual({
-                period: 8,
-                year: 1912
-            });
-        });
-        it('if GTAS data is available for this year, then it should return the next year for this specific window', () => {
+        it('if period 2 is over for this year, then it should return the next year for this specific window', () => {
             mockDate('1912-12-19');
-            const output = periodPickerHelper.mostRecentPeriod();
-            expect(output).toEqual({
-                period: 2,
-                year: 1913
-            });
-        });
-        it('should return the next calendar year from when period 2 becomes available until Dec 31st', () => {
-            mockDate('1912-12-31');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output).toEqual({
                 period: 2,
@@ -95,7 +63,7 @@ describe('periodPickerHelper', () => {
             mockDate('1913-01-01');
             const output = periodPickerHelper.mostRecentPeriod();
             expect(output).toEqual({
-                period: 2,
+                period: 3,
                 year: 1913
             });
         });
@@ -114,19 +82,11 @@ describe('periodPickerHelper', () => {
             mockDate('1912-06-01');
             const output = periodPickerHelper.lastCompletedPeriodInFY('1912');
             expect(output).toEqual({
-                period: 7,
+                period: 8,
                 year: 1912
             });
         });
-        it('if GTAS data is not available for period 2 of the specified FY, it should return the latest period of the previous FY', () => {
-            mockDate('1912-10-19');
-            const output = periodPickerHelper.lastCompletedPeriodInFY('1912');
-            expect(output).toEqual({
-                period: 12,
-                year: 1912
-            });
-        });
-        it('if GTAS data is available for period 2 of the specified FY, it should return the current period of the FY', () => {
+        it('if period 2 of the specified FY is complete, it should return the next calendar year for the FY', () => {
             mockDate('1912-12-19');
             const output = periodPickerHelper.lastCompletedPeriodInFY('1913');
             expect(output).toEqual({
@@ -154,12 +114,12 @@ describe('periodPickerHelper', () => {
                 year: 2019
             });
         });
-        it('for the current post-2017 fiscal year, it should return a period before the periods that have been closed for at least 45 days to date', () => {
+        it('for the current post-2017 fiscal year, it should return a period before the periods that have finished', () => {
             mockDate('2020-06-01');
             const output = periodPickerHelper.availablePeriodsInFY(2020);
             expect(output).toEqual({
-                period: 7,
-                periodArray: [1, 2, 3, 4, 5, 6, 7],
+                period: 8,
+                periodArray: [1, 2, 3, 4, 5, 6, 7, 8],
                 year: 2020
             });
         });
@@ -172,7 +132,7 @@ describe('periodPickerHelper', () => {
                 year: 2017
             });
         });
-        it('if the system clock returns a date within FY 2017, it should return a period that have GTAS data available, in addition to periods starting in October', () => {
+        it('if the system clock returns a date within FY 2017, it should return all completed periods, in addition to periods starting in October', () => {
             mockDate('2017-08-30');
             const output = periodPickerHelper.availablePeriodsInFY(2017);
             expect(output).toEqual({
@@ -205,8 +165,8 @@ describe('periodPickerHelper', () => {
             mockDate('2020-06-01');
             const output = periodPickerHelper.defaultPeriods();
             expect(output).toEqual({
-                period: 7,
-                periodArray: [1, 2, 3, 4, 5, 6, 7],
+                period: 8,
+                periodArray: [1, 2, 3, 4, 5, 6, 7, 8],
                 year: 2020
             });
         });
@@ -219,7 +179,7 @@ describe('periodPickerHelper', () => {
                 year: 2020
             });
         });
-        it('should return the available period in the current fiscal year if GTAS data is available', () => {
+        it('should return the available period in the current fiscal year if period 2 is done, also one year ahead if its period 3', () => {
             mockDate('2020-12-20');
             const output = periodPickerHelper.defaultPeriods();
             expect(output).toEqual({


### PR DESCRIPTION
**High level description:**

Periods in the Detached file A period picker will now show up the day after the month ends.
- Each period shows up the first day of the next month (eg. P03 will appear Jan 1st, P02 will appear Dec 1st, etc)
- Detached file A period dropdown now combines P1/P2 as a selection

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-7486](https://federal-spending-transparency.atlassian.net/browse/DEV-7486)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed