### PR TITLE
DEV-7091: Submission History Zip

### DIFF
--- a/src/_scss/pages/history/history.scss
+++ b/src/_scss/pages/history/history.scss
@@ -90,5 +90,25 @@
         min-height: rem(300);
         margin-top: rem(30);
         overflow: scroll;
+
+        .usa-da-download {
+            @import "/../../components/buttons/_optional";
+            @include optionalButton;
+            padding: rem(10) 0;
+    
+            background-color: transparent;
+            color: $color-primary;
+            font-weight: 600;
+            font-size: rem(14);
+    
+            &:hover {
+                color: $color-primary-darker;
+                & .usa-da-icon.usa-da-download-report {
+                    & svg {
+                        fill: $color-primary-darker;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/js/components/history/HistoryTable.jsx
+++ b/src/js/components/history/HistoryTable.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import * as SubmissionListHelper from 'helpers/submissionListHelper';
 import * as UtilHelper from 'helpers/util';
@@ -30,7 +31,8 @@ export default class HistoryTable extends React.Component {
                 body: ''
             }
         };
-        this.getSignedUrl = this.getSignedUrl.bind(this);
+        this.getSignedUrlFile = this.getSignedUrlFile.bind(this);
+        this.getSignedUrlZip = this.getSignedUrlZip.bind(this);
         this.handlePublishedSelect = this.handlePublishedSelect.bind(this);
         this.handleCertifiedSelect = this.handleCertifiedSelect.bind(this);
         this.setActiveSubmission = this.setActiveSubmission.bind(this);
@@ -48,7 +50,7 @@ export default class HistoryTable extends React.Component {
             });
     }
 
-    getSignedUrl(index) {
+    getSignedUrlFile(index) {
         let urlFile = null;
         if (this.state.activeType === 'certification') {
             urlFile = this.state.certifications[this.state.active].certified_files[index];
@@ -66,6 +68,44 @@ export default class HistoryTable extends React.Component {
         });
         SubmissionListHelper.getSubmissionFile(this.props.submissionID, urlFile.published_files_history_id,
             urlFile.is_warning)
+            .then((response) => {
+                window.open(response.url);
+                this.setState({
+                    warning: {
+                        active: false
+                    }
+                });
+            })
+            .catch((err) => {
+                console.error(err);
+                this.setState({
+                    warning: {
+                        active: true,
+                        type: 'danger',
+                        header: 'History Error',
+                        body: err.message
+                    }
+                });
+            });
+    }
+    
+    getSignedUrlZip() {
+        let historyId = null;
+        if (this.state.activeType === 'certification') {
+            historyId = this.state.certifications[this.state.active].certify_history_id;
+        }
+        else {
+            historyId = this.state.publications[this.state.active].publish_history_id;
+        }
+        this.setState({
+            warning: {
+                active: true,
+                type: 'warning',
+                header: 'Zipping File. Please Wait',
+                body: 'Zipping files and retreiving zip from server. Please wait.'
+            }
+        });
+        SubmissionListHelper.getSubmissionZip(this.props.submissionID, historyId, this.state.activeType)
             .then((response) => {
                 window.open(response.url);
                 this.setState({
@@ -116,14 +156,14 @@ export default class HistoryTable extends React.Component {
         }
         const list = [];
         for (let i = 0; i < activeSubmissionsFiles.length; i++) {
-            const onKeyDownHandler = UtilHelper.createOnKeyDownHandler(this.getSignedUrl, [i]);
+            const onKeyDownHandler = UtilHelper.createOnKeyDownHandler(this.getSignedUrlFile, [i]);
             list.push(
                 <div
                     role="button"
                     tabIndex={0}
                     className="file-link"
                     onKeyDown={onKeyDownHandler}
-                    onClick={this.getSignedUrl.bind(this, i)}
+                    onClick={this.getSignedUrlFile.bind(this, i)}
                     key={i}>
                     {activeSubmissionsFiles[i].filename}
                 </div>);
@@ -222,6 +262,17 @@ export default class HistoryTable extends React.Component {
             );
         }
 
+        let downloadButton = null;
+        if (fileList != null && fileList.length > 0) {
+            downloadButton = (
+                <button
+                    className="usa-da-download"
+                    onClick={this.getSignedUrlZip.bind(this, this.state.active)}>
+                    <FontAwesomeIcon icon="cloud-download-alt" /> Download All Files (.zip)
+                </button>
+            );
+        }
+
         return (
             <div className="container">
                 <div className="row">
@@ -249,6 +300,7 @@ export default class HistoryTable extends React.Component {
                     <div className="col-md-6 download-box">
                         <h2>Download Files: {current}</h2>
                         {fileList}
+                        {downloadButton}
                     </div>
                 </div>
             </div>

--- a/src/js/components/history/HistoryTable.jsx
+++ b/src/js/components/history/HistoryTable.jsx
@@ -88,7 +88,7 @@ export default class HistoryTable extends React.Component {
                 });
             });
     }
-    
+
     getSignedUrlZip() {
         let historyId = null;
         if (this.state.activeType === 'certification') {

--- a/src/js/helpers/submissionListHelper.js
+++ b/src/js/helpers/submissionListHelper.js
@@ -107,11 +107,30 @@ export const loadSubmissionHistory = (submissionID) => {
     return deferred.promise;
 };
 
-export const getSubmissionFile = (submissionID, certifiedFilesHistory, isWarning) => {
+export const getSubmissionFile = (submissionID, publishedFilesHistory, isWarning) => {
     const deferred = Q.defer();
 
     Request.get(`${kGlobalConstants.API}get_certified_file/?submission_id=${submissionID}&` +
-                `published_files_history_id=${certifiedFilesHistory}&is_warning=${isWarning}`)
+                `published_files_history_id=${publishedFilesHistory}&is_warning=${isWarning}`)
+        .send()
+        .end((err, res) => {
+            if (err) {
+                deferred.reject(err);
+            }
+            else {
+                deferred.resolve(res.body);
+            }
+        });
+
+    return deferred.promise;
+};
+
+export const getSubmissionZip = (submissionID, historyId, activeType) => {
+    const deferred = Q.defer();
+
+    const historyType = (activeType === 'publication') ? 'publish' : 'certify';
+    Request.get(`${kGlobalConstants.API}get_submission_zip/?submission_id=${submissionID}&` +
+                `${historyType}_history_id=${historyId}`)
         .send()
         .end((err, res) => {
             if (err) {


### PR DESCRIPTION
**High level description:**

Adds a button on the Submission History page to download all the files in a zip.

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-7091](https://federal-spending-transparency.atlassian.net/browse/DEV-7091)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Frontend review completed
- [ ] Merged after [Backend#2331](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2231)
