### PR TITLE
Update Broker frontend Dockerfile to prevent deploy failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV NODE_VERSION=${node_version_arg}
 
 # install node version manager
 RUN yum update -y
-RUN yum install -y wget
+RUN yum install -y wget git
 RUN wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz
 RUN mkdir -p /usr/local/lib/nodejs
 RUN tar -xJvf node-v$NODE_VERSION-linux-x64.tar.xz -C /usr/local/lib/nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV NODE_VERSION=${node_version_arg}
 
 # install node version manager
 RUN yum install -y git make 
-RUN curl -L -k https://git.io/n-install --output n-install
+RUN curl -k -L https://git.io/n-install --output n-install
 RUN chmod +x n-install
 RUN yes y | ./n-install
 RUN $HOME/n/bin/n $NODE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_VERSION=${node_version_arg}
 RUN yum install -y git make 
 RUN curl -k -L https://git.io/n-install --output n-install
 RUN chmod +x n-install
-RUN yes y | ./n-install
+RUN yes y | bash ./n-install
 RUN $HOME/n/bin/n $NODE_VERSION
 RUN yum clean all
 RUN echo "PATH=$PATH:$HOME/n/bin/n" >> /etc/environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM centos:centos7.9.2009
-
 ARG node_version_arg=10.16.0
+ARG base_container=frontend_base
+
+FROM centos:centos7.9.2009 as frontend_base
 
 ENV NODE_VERSION=${node_version_arg}
 
@@ -14,17 +15,13 @@ RUN chown -R root /usr/local/lib/nodejs
 RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/node /bin/node
 RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npm /bin/npm
 RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npx /bin/npx
-
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 
 COPY package-lock.json /node-workspace
-
 WORKDIR /node-workspace
-
 RUN npm ci
-
-COPY . /node-workspace
-
-VOLUME /node-workspace
-
 RUN mkdir /test-results
+
+FROM ${base_container}
+WORKDIR /node-workspace
+COPY . /node-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG BASE_CONTAINER=frontend_base
-
 # Base Container
 FROM centos:centos7.9.2009 as frontend_base
 ARG NODE_VERSION_ARG=10.16.0
@@ -21,6 +19,6 @@ RUN npm ci
 RUN mkdir /test-results
 
 # Add frontend code to container
-FROM $BASE_CONTAINER as frontend_code
+FROM frontend_base
 WORKDIR /node-workspace
 COPY . /node-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-FROM centos:7.9.2009
+FROM centos:centos7.9.2009
 
 ARG node_version_arg=10.16.0
 
 ENV NODE_VERSION=${node_version_arg}
 
 # install node version manager
-RUN yum install -y git make 
-RUN curl -k -L https://git.io/n-install --output n-install
-RUN chmod +x n-install
-RUN yes y | bash ./n-install
-RUN $HOME/n/bin/n $NODE_VERSION
-RUN yum clean all
-RUN echo "PATH=$PATH:$HOME/n/bin/n" >> /etc/environment
+RUN yum update -y
+RUN yum install -y wget
+RUN wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz
+RUN mkdir -p /usr/local/lib/nodejs
+RUN tar -xJvf node-v$NODE_VERSION-linux-x64.tar.xz -C /usr/local/lib/nodejs
+RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/node /bin/node
+RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npm /bin/npm
+RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npx /bin/npx
 
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM node:10.16.0
+FROM centos:7.9.2009
+
+ARG node_version_arg=10.16.0
+
+ENV NODE_VERSION=${node_version_arg}
+
+# install node version manager
+RUN yum install -y git make 
+RUN curl -L https://git.io/n-install --output n-install
+RUN chmod +x n-install
+RUN yes y | ./n-install
+RUN $HOME/n/bin/n $NODE_VERSION
+RUN yum clean all
+RUN echo "PATH=$PATH:$HOME/n/bin/n" >> /etc/environment
 
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
-ARG node_version_arg=10.16.0
-ARG base_container=frontend_base
+ARG BASE_CONTAINER=frontend_base
 
+# Base Container
 FROM centos:centos7.9.2009 as frontend_base
-
-ENV NODE_VERSION=${node_version_arg}
-
+ARG NODE_VERSION_ARG=10.16.0
 # install node version manager
 RUN yum update -y
 RUN yum install -y wget git
-RUN wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz
+RUN wget https://nodejs.org/dist/v$NODE_VERSION_ARG/node-v$NODE_VERSION_ARG-linux-x64.tar.xz
 RUN mkdir -p /usr/local/lib/nodejs
-RUN tar -xJvf node-v$NODE_VERSION-linux-x64.tar.xz -C /usr/local/lib/nodejs
+RUN tar -xJvf node-v$NODE_VERSION_ARG-linux-x64.tar.xz -C /usr/local/lib/nodejs
 RUN chown -R root /usr/local/lib/nodejs
-RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/node /bin/node
-RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npm /bin/npm
-RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npx /bin/npx
+RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION_ARG-linux-x64/bin/node /bin/node
+RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION_ARG-linux-x64/bin/npm /bin/npm
+RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION_ARG-linux-x64/bin/npx /bin/npx
 RUN mkdir /node-workspace
 COPY package.json /node-workspace 
 COPY package-lock.json /node-workspace
@@ -22,6 +20,7 @@ WORKDIR /node-workspace
 RUN npm ci
 RUN mkdir /test-results
 
-FROM ${base_container}
+# Add frontend code to container
+FROM $BASE_CONTAINER
 WORKDIR /node-workspace
 COPY . /node-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ RUN npm ci
 RUN mkdir /test-results
 
 # Add frontend code to container
-FROM $BASE_CONTAINER
+FROM $BASE_CONTAINER as frontend_code
 WORKDIR /node-workspace
 COPY . /node-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y wget git
 RUN wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz
 RUN mkdir -p /usr/local/lib/nodejs
 RUN tar -xJvf node-v$NODE_VERSION-linux-x64.tar.xz -C /usr/local/lib/nodejs
+RUN chown -R root /usr/local/lib/nodejs
 RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/node /bin/node
 RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npm /bin/npm
 RUN ln -s /usr/local/lib/nodejs/node-v$NODE_VERSION-linux-x64/bin/npx /bin/npx

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV NODE_VERSION=${node_version_arg}
 
 # install node version manager
 RUN yum install -y git make 
-RUN curl -L https://git.io/n-install --output n-install
+RUN curl -L -k https://git.io/n-install --output n-install
 RUN chmod +x n-install
 RUN yes y | ./n-install
 RUN $HOME/n/bin/n $NODE_VERSION


### PR DESCRIPTION
**High level description:**

The Broker frontend deploys occasionally fail after Jenkins nodes are patched due to the Broker frontend container taking longer than 3 minutes to initialize. The previous docker image was 2 years old has never been updated. 

**Technical details:**

This change separates the building of dependencies from the frontend code and does not affect the docker-compose scripts that are used to run the app locally. Run as usual to build the container that pulls the code into it or add the `--target frontend_base` to build dependencies only. This is blocking the work in updating the work in moving the broker frontend deploy to use ECR. 

Jenkins test run: http://jenkins-master-8ca0e1e199b2c8fc.elb.us-gov-west-1.amazonaws.com:8080/job/z-broker-frontend-nonprod-deploy/9/console

**Link to JIRA Ticket:**

[OPS-2070](https://federal-spending-transparency.atlassian.net/browse/OPS-2070)


The following are ALL required for the PR to be merged:

Author: 
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Design review completed
- [ ] Frontend review completed
- [ ] Merged concurrently with [Backend#1234](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1234)