### PR TITLE
DEV-8396: default dabs period

### DIFF
--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -87,6 +87,26 @@ export const fyStartDate = () => {
     return quarterToMonth(1, year, 'start');
 };
 
+export const periodToMonth = (period) => {
+    // Returns the month that the period corresponds to in MM format.
+    // Period 4 = January, month 01, etc.
+    const monthDictionary = {
+        4: "01",
+        5: "02",
+        6: "03",
+        7: "04",
+        8: "05",
+        9: "06",
+        10: "07",
+        11: "08",
+        12: "09",
+        1: "10",
+        2: "11",
+        3: "12"
+    };
+    return monthDictionary[period];
+};
+
 
 export const validUploadFileChecker = (rawFile) => {
     if (rawFile.file) {

--- a/tests/helpers/util-test.js
+++ b/tests/helpers/util-test.js
@@ -69,6 +69,12 @@ describe("util helper functions", () => {
             moment.now = () => new Date();
         });
     });
+    describe("periodToMonth", () => {
+        it("should return the correct month when provided with a period", () => {
+            const month = utilHelper.periodToMonth(4);
+            expect(month).toEqual("01");
+        });
+    });
     describe("fyStartDate", () => {
         it("should return the start date of the current fiscal year", () => {
             const mockedDate = moment("2015-04-01", "YYYY-MM-DD").toDate();


### PR DESCRIPTION
**High level description:**

Defaulting DABS monthly submissions to current period until it closes, at which point it starts defaulting to the next period.

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-8396](https://federal-spending-transparency.atlassian.net/browse/DEV-8396)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed
- [ ] Merged concurrently with or after [Backend#2270](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2270)