### PR TITLE
DEV-4102: generate files defaults

### DIFF
--- a/src/js/containers/generateFiles/GenerateFilesContainer.jsx
+++ b/src/js/containers/generateFiles/GenerateFilesContainer.jsx
@@ -155,20 +155,28 @@ export class GenerateFilesContainer extends React.Component {
                     this.loadSubmissionData();
                 }
                 else {
-                    // files have been requested before, load the dates
+                    // files have been requested before, load the dates and types
                     const d1Start = moment(allResponses[0].value.start, 'MM/DD/YYYY');
                     const d1End = moment(allResponses[0].value.end, 'MM/DD/YYYY');
                     const d2Start = moment(allResponses[1].value.start, 'MM/DD/YYYY');
                     const d2End = moment(allResponses[1].value.end, 'MM/DD/YYYY');
+                    const d1FileType = allResponses[0].value.url.includes('.txt') ? 'txt' : 'csv';
+                    const d2FileType = allResponses[1].value.url.includes('.txt') ? 'txt' : 'csv';
+                    const d1AgencyType = allResponses[0].value.url.includes('funding') ? 'funding' : 'awarding';
+                    const d2AgencyType = allResponses[1].value.url.includes('funding') ? 'funding' : 'awarding';
 
                     // load them into React state
                     const d1 = Object.assign({}, this.state.d1);
                     d1.startDate = d1Start;
                     d1.endDate = d1End;
+                    d1.fileFormat = d1FileType;
+                    d1.agencyType = d1AgencyType;
 
                     const d2 = Object.assign({}, this.state.d2);
                     d2.startDate = d2Start;
                     d2.endDate = d2End;
+                    d2.fileFormat = d2FileType;
+                    d2.agencyType = d2AgencyType;
 
                     this.setState({
                         d1,


### PR DESCRIPTION
**High level description:**

Default the generate D files selections to what the user generated last.

**Technical details:**

Uses the URL to determine awarding/funding and csv/txt so files from before those were in the name default to awarding/csv but I believe that is still accurate to what they were.

**Link to JIRA Ticket:**

[DEV-4102](https://federal-spending-transparency.atlassian.net/browse/DEV-4102)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed