### PR TITLE
DEV-8158: File reupload box updates

### DIFF
--- a/src/js/containers/validateData/ValidationOverlayContainer.jsx
+++ b/src/js/containers/validateData/ValidationOverlayContainer.jsx
@@ -76,7 +76,8 @@ class ValidationOverlayContainer extends React.Component {
         for (const key in this.props.submission.validation) {
             if (Object.prototype.hasOwnProperty.call(this.props.submission.validation, key)) {
                 const value = this.props.submission.validation[key];
-                if (value.error_data.length > 0) {
+                // checking if error_data even exists because of the file upload props reset
+                if (value.error_data && value.error_data.length > 0) {
                     requiredKeys.push(key);
                 }
             }

--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -43,21 +43,21 @@ const prepareFilesExistingSub = (fileDict) => {
     const req = Request.post(`${kGlobalConstants.API}upload_dabs_files/`);
     if (fileDict.appropriations) {
         req.attach('appropriations', fileDict.appropriations);
-        validationStates['appropriations'] = {
+        validationStates.appropriations = {
             job_status: "running",
             file_status: "incomplete"
         };
     }
     if (fileDict.program_activity) {
         req.attach('program_activity', fileDict.program_activity);
-        validationStates['program_activity'] = {
+        validationStates.program_activity = {
             job_status: "running",
             file_status: "incomplete"
         };
     }
     if (fileDict.award_financial) {
         req.attach('award_financial', fileDict.award_financial);
-        validationStates['award_financial'] = {
+        validationStates.award_financial = {
             job_status: "running",
             file_status: "incomplete"
         };

--- a/src/js/helpers/uploadHelper.js
+++ b/src/js/helpers/uploadHelper.js
@@ -36,16 +36,31 @@ const prepareFilesNewSub = (fileDict) => {
 
 const prepareFilesExistingSub = (fileDict) => {
     const deferred = Q.defer();
+    const store = new StoreSingleton().store;
+    // need to update the validation states to make sure the validation boxes get updated
+    const validationStates = Object.assign({}, store.getState().submission.validation);
 
     const req = Request.post(`${kGlobalConstants.API}upload_dabs_files/`);
     if (fileDict.appropriations) {
         req.attach('appropriations', fileDict.appropriations);
+        validationStates['appropriations'] = {
+            job_status: "running",
+            file_status: "incomplete"
+        };
     }
     if (fileDict.program_activity) {
         req.attach('program_activity', fileDict.program_activity);
+        validationStates['program_activity'] = {
+            job_status: "running",
+            file_status: "incomplete"
+        };
     }
     if (fileDict.award_financial) {
         req.attach('award_financial', fileDict.award_financial);
+        validationStates['award_financial'] = {
+            job_status: "running",
+            file_status: "incomplete"
+        };
     }
     req.field('existing_submission_id', fileDict.existing_submission_id)
         .end((err, res) => {
@@ -55,6 +70,7 @@ const prepareFilesExistingSub = (fileDict) => {
                 deferred.reject(response);
             }
             else {
+                store.dispatch(uploadActions.setValidation(validationStates));
                 deferred.resolve(res);
             }
         });


### PR DESCRIPTION
**High level description:**

Makes sure that the file boxes update even if the user uploads more than one and the others finish before the frontend checks

**Technical details:**

Reset the status of the validation states when uploading files

**Link to JIRA Ticket:**

[DEV-8158](https://federal-spending-transparency.atlassian.net/browse/DEV-8158)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed