### PR TITLE
DEV-9220: Info banner on all pages

### DIFF
--- a/src/js/components/dashboard/DashboardPage.jsx
+++ b/src/js/components/dashboard/DashboardPage.jsx
@@ -139,7 +139,7 @@ export default class DashboardPage extends React.Component {
                                 </div>
                             </div>
                         </div>
-                        <Banner />
+                        <Banner type="dabs" />
                         <div className="dashboard-page">
                             <div className="dashboard-page__wrapper">
                                 <div className="dashboard-page__filters">

--- a/src/js/components/generateDetachedFiles/DetachedFileA.jsx
+++ b/src/js/components/generateDetachedFiles/DetachedFileA.jsx
@@ -141,7 +141,7 @@ export default class DetachedFileA extends React.Component {
                                 </div>
                             </div>
                         </div>
-                        <Banner type="all" />
+                        <Banner type="dabs" />
 
                         <div className="container center-block">
                             <div className="row text-center usa-da-select-agency">

--- a/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
+++ b/src/js/components/generateDetachedFiles/GenerateDetachedFilesPage.jsx
@@ -354,7 +354,7 @@ export default class GenerateDetachedFilesPage extends React.Component {
                                 </div>
                             </div>
                         </div>
-                        <Banner type="all" />
+                        <Banner type="dabs" />
 
                         <div className="container center-block">
                             <div className="row text-center usa-da-select-agency">


### PR DESCRIPTION
**High level description:**

Making sure banners related to DABS submissions show up on the detached file A and D generation pages and on the DABS dashboard

**Technical details:**

Changing all the types on the relevant pages to "dabs" instead of "all".

**Link to JIRA Ticket:**

[DEV-9220](https://federal-spending-transparency.atlassian.net/browse/DEV-9220)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed