### PR TITLE
[DEV-10014] Broker Redraw Fix

### DIFF
--- a/src/js/components/SharedComponents/navigation/NavbarTab.jsx
+++ b/src/js/components/SharedComponents/navigation/NavbarTab.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 const propTypes = {
     activeTabClassName: PropTypes.string,
@@ -49,9 +50,9 @@ export default class NavbarTab extends React.Component {
         }
         return (
             <li className={isActiveClass ? 'active' : ''}>
-                <a className="usa-da-header-link" href={link}>{this.props.name}
+                <Link className="usa-da-header-link" to={link}>{this.props.name}
                     <span className={isActiveClass ? 'sr-only' : ''}>{isActiveClass ? '(current)' : ''}</span>
-                </a>
+                </Link>
             </li>
         );
     }

--- a/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
+++ b/src/js/components/SharedComponents/navigation/NavigationComponent.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import * as sessionActions from 'redux/actions/sessionActions';
 import { clearSettings } from 'redux/actions/settingsActions';
 import * as PermissionHelper from 'helpers/permissionsHelper';
@@ -172,7 +173,7 @@ export class Navbar extends React.Component {
                                 <span className="icon-bar" />
                                 <span className="icon-bar" />
                             </button>
-                            <a className="navbar-brand usa-da-header-brand" href="/">DATA Act Broker</a>
+                            <Link className="navbar-brand usa-da-header-brand" to="/">DATA Act Broker</Link>
                         </div>
 
                         <div className="collapse navbar-collapse usa-da-header-links" id="bs-example-navbar-collapse-1">

--- a/src/js/components/addData/AddDataContent.jsx
+++ b/src/js/components/addData/AddDataContent.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Link } from 'react-router-dom';
 import SubmissionComponent from './SubmissionComponent';
 import SubmitButton from '../SharedComponents/SubmitButton';
 
@@ -128,9 +129,9 @@ export default class AddDataContent extends React.Component {
                             {actionArea}
                             {
                                 this.state.submissionID !== 0 ?
-                                    <a className="usa-da-submit-review" href={subLink}>
+                                    <Link className="usa-da-submit-review" to={subLink}>
                                         {subID}
-                                    </a>
+                                    </Link>
                                     : null
                             }
                         </div>

--- a/src/js/components/addData/AddDataMeta.jsx
+++ b/src/js/components/addData/AddDataMeta.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
-import { Redirect } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import * as AgencyHelper from 'helpers/agencyHelper';
@@ -273,7 +273,7 @@ export default class AddDataMeta extends React.Component {
                                 </TransitionGroup>
                             </div>
                             <div className="usa-da-guide-link">
-                                <a href="submissionGuide?force=true">View Submission Guide</a>
+                                <Link to="submissionGuide?force=true">View Submission Guide</Link>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/addData/AddDataMeta.jsx
+++ b/src/js/components/addData/AddDataMeta.jsx
@@ -273,7 +273,7 @@ export default class AddDataMeta extends React.Component {
                                 </TransitionGroup>
                             </div>
                             <div className="usa-da-guide-link">
-                                <Link to="submissionGuide?force=true">View Submission Guide</Link>
+                                <Link to="/submissionGuide?force=true">View Submission Guide</Link>
                             </div>
                         </div>
                     </div>

--- a/src/js/components/addData/SubmissionGuideContent.jsx
+++ b/src/js/components/addData/SubmissionGuideContent.jsx
@@ -5,8 +5,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Banner from '../SharedComponents/Banner';
+import { Link } from 'react-router-dom';
 
+import Banner from '../SharedComponents/Banner';
 import { kGlobalConstants } from '../../GlobalConstants';
 
 const propTypes = {
@@ -177,9 +178,9 @@ export default class SubmissionGuideContent extends React.Component {
                                             All files must be present to perform cross-file validations.
                                         </p>
                                         <p>
-                                            <a href="validations">
+                                            <Link to="validations">
                                                 Find out what validations are currently implemented
-                                            </a>
+                                            </Link>
                                         </p>
                                     </div>
                                 </div>

--- a/src/js/components/dashboard/table/DashboardTable.jsx
+++ b/src/js/components/dashboard/table/DashboardTable.jsx
@@ -119,7 +119,7 @@ export default class DashboardTable extends React.Component {
                         <tr key={`dashboard-table-row-${row.submissionId}-${row.ruleLabel}`}>
                             <td>
                                 <Link
-                                    to={`submission/${row.submissionId}`}
+                                    to={`/submission/${row.submissionId}`}
                                     className="date-link">
                                     {row.submissionId}
                                 </Link>

--- a/src/js/components/dashboard/table/DashboardTable.jsx
+++ b/src/js/components/dashboard/table/DashboardTable.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import DashboardTableHeader from 'components/dashboard/table/DashboardTableHeader';
 import NoResultsMessage from 'components/SharedComponents/NoResultsMessage';
@@ -117,11 +118,11 @@ export default class DashboardTable extends React.Component {
                     return (
                         <tr key={`dashboard-table-row-${row.submissionId}-${row.ruleLabel}`}>
                             <td>
-                                <a
-                                    href={`submission/${row.submissionId}`}
+                                <Link
+                                    to={`submission/${row.submissionId}`}
                                     className="date-link">
                                     {row.submissionId}
-                                </a>
+                                </Link>
                             </td>
                             <td>
                                 {row.period}

--- a/src/js/components/error/ErrorPage.jsx
+++ b/src/js/components/error/ErrorPage.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
 import Navbar from '../SharedComponents/navigation/NavigationComponent';
 
 const propTypes = {
@@ -24,7 +26,7 @@ export default class ErrorPage extends React.Component {
                                 <div className="col-md-7 mt-50 mb-50">
                                     <div className="display-2">Page Not Found</div>
                                     <p>No page exists at this address.</p>
-                                    <p><a href="/">Click here</a> to return home.</p>
+                                    <p><Link to="/">Click here</Link> to return home.</p>
                                 </div>
                             </div>
                         </div>

--- a/src/js/components/generateDetachedFiles/DetachedFileA.jsx
+++ b/src/js/components/generateDetachedFiles/DetachedFileA.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Link } from 'react-router-dom';
 import Banner from 'components/SharedComponents/Banner';
 import Navbar from '../SharedComponents/navigation/NavigationComponent';
 import Footer from '../SharedComponents/FooterComponent';
@@ -118,9 +119,9 @@ export default class DetachedFileA extends React.Component {
         if (this.props.status === 'done') {
             submissionLink = (
                 <div className="submission-link">
-                    <a href="/submissionGuide">
+                    <Link to="/submissionGuide">
                         Start a new submission
-                    </a>
+                    </Link>
                 </div>
             );
         }

--- a/src/js/components/help/helpNav.jsx
+++ b/src/js/components/help/helpNav.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 const propTypes = {
     pageArray: PropTypes.array,
@@ -26,9 +27,9 @@ export default class HelpNav extends React.Component {
             const url = this.props.type === 'fabs' ? fabsUrl : dabsUrl;
 
             if (this.props.selected === page) {
-                return <a href={url} className="selected usa-da-button btn-lg" key={page}>{page}</a>;
+                return <Link to={url} className="selected usa-da-button btn-lg" key={page}>{page}</Link>;
             }
-            return <a href={url} className="usa-da-button btn-lg" key={page}>{page}</a>;
+            return <Link to={url} className="usa-da-button btn-lg" key={page}>{page}</Link>;
         });
 
         return (

--- a/src/js/components/help/helpSidebar.jsx
+++ b/src/js/components/help/helpSidebar.jsx
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
 import HelpSidebarItem from './helpSidebarItem';
 
 const propTypes = {
@@ -41,7 +43,7 @@ export default class HelpSidebar extends React.Component {
         if (this.props.helpOnly) {
             membership = (
                 <li>
-                    <a href="/help?section=agencyAccess">Request Agency Access</a>
+                    <Link to="/help?section=agencyAccess">Request Agency Access</Link>
                 </li>
             );
         }
@@ -77,24 +79,24 @@ export default class HelpSidebar extends React.Component {
                 <ul>
                     {clSectionList}
                     <li>
-                        <a href={history}>Release Notes Archive</a>
+                        <Link to={history}>Release Notes Archive</Link>
                     </li>
                 </ul>
                 <h6>This Release&rsquo;s Technical Notes</h6>
                 <ul>
                     {tSectionList}
                     <li>
-                        <a href={technicalHistory}>Technical Notes Archive</a>
+                        <Link to={technicalHistory}>Technical Notes Archive</Link>
                     </li>
                 </ul>
                 <h6>Getting More Help</h6>
                 <ul>
                     {membership}
                     <li>
-                        <a href={`${help}?section=membership`}>Contact the Service Desk</a>
+                        <Link to={`${help}?section=membership`}>Contact the Service Desk</Link>
                     </li>
                     <li>
-                        <a href={resources}>Resources - DAIMS</a>
+                        <Link to={resources}>Resources - DAIMS</Link>
                     </li>
                 </ul>
                 <div className="usa-da-help-sidebar__signup">

--- a/src/js/components/help/helpSidebarItem.jsx
+++ b/src/js/components/help/helpSidebarItem.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Link } from 'react-router-dom';
+
 const propTypes = {
     sectionId: PropTypes.string,
     sectionName: PropTypes.string,
@@ -23,9 +25,9 @@ export default class HelpSidebarItem extends React.Component {
         const help = this.props.type === 'fabs' ? '/FABShelp' : '/help';
         return (
             <li>
-                <a href={`${help}?section=${this.props.sectionId}`}>
+                <Link to={`${help}?section=${this.props.sectionId}`}>
                     {this.props.sectionName}
-                </a>
+                </Link>
             </li>
         );
     }

--- a/src/js/components/landing/blocks/LandingBlock.jsx
+++ b/src/js/components/landing/blocks/LandingBlock.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 const propTypes = {
     children: PropTypes.object,
@@ -42,12 +43,21 @@ export default class LandingBlock extends React.Component {
                     </div>
                     <div className="usa-da-landing-block-bottom">
                         <div className="usa-da-landing-block-button">
-                            <a
-                                className="usa-da-button btn-primary btn-lg btn-full"
-                                href={this.props.url}
-                                disabled={this.props.disabled}>
-                                {this.props.buttonText}
-                            </a>
+                            {this.props.disabled ?
+                                <span
+                                    className="usa-da-button btn-primary btn-lg btn-full"
+                                    disabled>
+                                    {this.props.buttonText}
+                                </span>
+                                :
+                                <Link
+                                    className="usa-da-button btn-primary btn-lg btn-full"
+                                    to={this.props.url}
+                                    disabled={false}>
+                                    {this.props.buttonText}
+                                </Link>
+                            }
+
                         </div>
                         {this.props.children}
                     </div>

--- a/src/js/components/landing/recentActivity/SubmissionLink.jsx
+++ b/src/js/components/landing/recentActivity/SubmissionLink.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Link } from 'react-router-dom';
+
 const propTypes = {
     submissionId: PropTypes.oneOfType([
         PropTypes.string,
@@ -35,9 +37,9 @@ export default class SubmissionLink extends React.Component {
             link = 'N/A';
         }
 
-        let content = <a href={`submission/${this.props.submissionId}`} className="date-link">{link}</a>;
+        let content = <Link to={`submission/${this.props.submissionId}`} className="date-link">{link}</Link>;
         if (this.props.type === 'fabs') {
-            content = <a href={`FABSAddData/${this.props.submissionId}`} className="date-link">{link}</a>;
+            content = <Link to={`FABSAddData/${this.props.submissionId}`} className="date-link">{link}</Link>;
         }
 
         if (this.props.disabled) {

--- a/src/js/components/login/LoginMaxLoading.jsx
+++ b/src/js/components/login/LoginMaxLoading.jsx
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
 import LoginMaxErrorMessage from './LoginMaxErrorMessage';
 import LoadingBauble from '../SharedComponents/overlays/LoadingBauble';
 
@@ -47,7 +49,7 @@ export default class LoginMaxLoading extends React.Component {
                     <div className="col-md-12">
                         {errorMessageComponent}
                         <div className="back-link">
-                            <a href="/">Back to login page</a>
+                            <Link to="/">Back to login page</Link>
                         </div>
                     </div>
                 </div>

--- a/src/js/components/submissionsTable/HistoryLink.jsx
+++ b/src/js/components/submissionsTable/HistoryLink.jsx
@@ -19,7 +19,7 @@ export default class HistoryLink extends React.Component {
     render() {
         return (
             <div className="usa-da-recent-activity-link">
-                <Link to={`submissionHistory/${this.props.submissionId}`}>
+                <Link to={`/submissionHistory/${this.props.submissionId}`}>
                     <FontAwesomeIcon icon={['far', 'calendar-alt']} title="View" />
                 </Link>
             </div>

--- a/src/js/components/submissionsTable/HistoryLink.jsx
+++ b/src/js/components/submissionsTable/HistoryLink.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Link } from 'react-router-dom';
 
 const propTypes = {
     submissionId: PropTypes.oneOfType([
@@ -18,9 +19,9 @@ export default class HistoryLink extends React.Component {
     render() {
         return (
             <div className="usa-da-recent-activity-link">
-                <a href={`submissionHistory/${this.props.submissionId}`}>
+                <Link to={`submissionHistory/${this.props.submissionId}`}>
                     <FontAwesomeIcon icon={['far', 'calendar-alt']} title="View" />
-                </a>
+                </Link>
             </div>
         );
     }

--- a/src/js/components/validateData/ValidateCancellation.jsx
+++ b/src/js/components/validateData/ValidateCancellation.jsx
@@ -16,7 +16,7 @@ export default class ValidateCancellation extends React.Component {
                 Your submission has been stuck in validation for a while. Would you like to cancel and try again?
                 &nbsp;&nbsp;&nbsp;
                 <Link
-                    to="addData"
+                    to="/addData"
                     className="usa-da-button btn-danger">
                     Cancel Submission
                 </Link>

--- a/src/js/components/validateData/ValidateCancellation.jsx
+++ b/src/js/components/validateData/ValidateCancellation.jsx
@@ -5,6 +5,8 @@
 
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 export default class ValidateCancellation extends React.Component {
     render() {
         return (
@@ -13,11 +15,11 @@ export default class ValidateCancellation extends React.Component {
                 role="alert">
                 Your submission has been stuck in validation for a while. Would you like to cancel and try again?
                 &nbsp;&nbsp;&nbsp;
-                <a
-                    href="addData"
+                <Link
+                    to="addData"
                     className="usa-da-button btn-danger">
                     Cancel Submission
-                </a>
+                </Link>
             </div>
         );
     }


### PR DESCRIPTION
**High level description:**

Fixing a bug where React redraws the whole page for every link instead of reloading only parts of it like it should.

**Technical details:**

Replaces <a>'s with <Link>'s only when applicable.

**Link to JIRA Ticket:**

[DEV-10014](https://federal-spending-transparency.atlassian.net/browse/DEV-10014)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [ ] Linked to this PR in JIRA ticket
- [ ] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [ ] Verified cross-browser compatibility
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [ ] Design review completed
- [ ] Frontend review completed
- [ ] Merged concurrently with [Backend#1234](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1234)