### PR TITLE
DEV-10507: CD Export Blurb

### DIFF
--- a/src/js/components/help/DataSourcesContent.jsx
+++ b/src/js/components/help/DataSourcesContent.jsx
@@ -144,7 +144,10 @@ export default class DataSourcesContent extends React.Component {
                                     In practice, the list of congressional districts only change every ten years on the
                                     first election after a new census. Our table also includes historical congressional
                                     districts from the 2000 census that no longer exist but that are still relevant to open
-                                    awards. The latest Broker file can be downloaded at&nbsp;
+                                    awards. 
+                                </p>
+                                <p>
+                                    The latest Broker file can be downloaded at&nbsp;
                                     <a
                                         target="_blank"
                                         rel="noopener noreferrer"
@@ -152,10 +155,7 @@ export default class DataSourcesContent extends React.Component {
                                             `state_congressional.csv`}>
                                         https://{fileLoc}.usaspending.gov/reference_data/state_congressional.csv
                                     </a>
-                                    .
-                                </p>
-                                <p>
-                                    It includes the code, state code, and the "census_year" column. If the "census_year" column is:
+                                    . It includes the code, state code, and the "census_year" column. If the "census_year" column is:
                                     <ul>
                                         <li>blank, that CD has existed since a previous census and is still active.</li>
                                         <li>before the most recent census (ex. 2000 or 2010), those CDs are no longer active but maintained in the file for older validations.</li>

--- a/src/js/components/help/DataSourcesContent.jsx
+++ b/src/js/components/help/DataSourcesContent.jsx
@@ -137,22 +137,32 @@ export default class DataSourcesContent extends React.Component {
                         description={"A two digit code indicating the congressional district along with associated" +
                             " metadata including the state it is tied to."}
                         source={
-                            <p>
-                                The set of congressional districts is automatically updated based on data from
-                                USPS’s Postal Pro products that we purchase (see ’Zip Code’ entry for more information).
-                                In practice, the list of congressional districts only change every ten years on the
-                                first election after a new census. Our table also includes historical congressional
-                                districts from the 2000 census that no longer exist but that are still relevant to open
-                                awards. The latest Broker file can be downloaded at&nbsp;
-                                <a
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    href={`https://${fileLoc}.usaspending.gov/reference_data/` +
-                                        `state_congressional.csv`}>
-                                    https://{fileLoc}.usaspending.gov/reference_data/state_congressional.csv
-                                </a>
-                                .
-                            </p>}
+                            <div>
+                                <p>
+                                    The set of congressional districts is automatically updated based on data from
+                                    USPS’s Postal Pro products that we purchase (see ’Zip Code’ entry for more information).
+                                    In practice, the list of congressional districts only change every ten years on the
+                                    first election after a new census. Our table also includes historical congressional
+                                    districts from the 2000 census that no longer exist but that are still relevant to open
+                                    awards. The latest Broker file can be downloaded at&nbsp;
+                                    <a
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        href={`https://${fileLoc}.usaspending.gov/reference_data/` +
+                                            `state_congressional.csv`}>
+                                        https://{fileLoc}.usaspending.gov/reference_data/state_congressional.csv
+                                    </a>
+                                    .
+                                </p>
+                                <p>
+                                    It includes the code, state code, and the "census_year" column. If the "census_year" column is:
+                                    <ul>
+                                        <li>blank, that CD has existed since a previous census and is still active.</li>
+                                        <li>before the most recent census (ex. 2000 or 2010), those CDs are no longer active but maintained in the file for older validations.</li>
+                                        <li>the most recent census (ex. 2020), these CDs were added based on the most recent census.</li>
+                                    </ul>
+                                </p>
+                            </div>}
                         updatedAt={this.props.updateDates.congressional_district} />
 
                     <DataSourcesItem

--- a/src/js/components/help/DataSourcesContent.jsx
+++ b/src/js/components/help/DataSourcesContent.jsx
@@ -144,7 +144,7 @@ export default class DataSourcesContent extends React.Component {
                                     In practice, the list of congressional districts only change every ten years on the
                                     first election after a new census. Our table also includes historical congressional
                                     districts from the 2000 census that no longer exist but that are still relevant to open
-                                    awards. 
+                                    awards.
                                 </p>
                                 <p>
                                     The latest Broker file can be downloaded at&nbsp;
@@ -155,7 +155,7 @@ export default class DataSourcesContent extends React.Component {
                                             `state_congressional.csv`}>
                                         https://{fileLoc}.usaspending.gov/reference_data/state_congressional.csv
                                     </a>
-                                    . It includes the code, state code, and the "census_year" column. If the "census_year" column is:
+                                    . It includes the code, state code, and the &#34;census_year&#34; column. If the &#34;census_year&#34; column is:
                                     <ul>
                                         <li>blank, that CD has existed since a previous census and is still active.</li>
                                         <li>before the most recent census (ex. 2000 or 2010), those CDs are no longer active but maintained in the file for older validations.</li>


### PR DESCRIPTION
**High level description:**
Adding a blurb to explain the structure of the CD export.

**Technical details:**
N/A

**Link to JIRA Ticket:**

[DEV-10507](https://federal-spending-transparency.atlassian.net/browse/DEV-10507)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [ ] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [ ] Frontend review completed
- [x] Merged concurrently with [Backend#2529](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2529)