### PR TITLE
DEV-10922: vendor test submission only fabs

### DIFF
--- a/src/_scss/pages/uploadFabsFile/uploadFabsFile.scss
+++ b/src/_scss/pages/uploadFabsFile/uploadFabsFile.scss
@@ -123,6 +123,9 @@
                 .subtype-description {
                     font-style: italic;
                 }
+                .disabled {
+                    color: $color-gray-light;
+                }
 
                 label {
                     font-weight: bold;
@@ -137,6 +140,33 @@
                             }
                         }
                     }
+                }
+            }
+            .alert-warning {
+                @import "../../components/alerts/_alerts";
+                @include warningAlert;
+                border-color: rgb(243,199,77);
+                margin: 0;
+                padding: rem(7.5) 0;
+                h3 {
+                    margin: 0;
+                    font-weight: bold;
+                    font-size: rem(15);
+                }
+                p {
+                    margin: 0;
+                    margin-top: rem(5);
+                    font-size: rem(14);
+                    line-height: rem(18);
+                }
+                .fa-exclamation-triangle {
+                    font-size: rem(18);
+                    color: $color-gold-dark;
+                    float: right;
+                }
+
+                .col-xs-11 {
+                    padding-left: 0;
                 }
             }
         }

--- a/src/js/components/addData/metadata/SubmissionTypeField.jsx
+++ b/src/js/components/addData/metadata/SubmissionTypeField.jsx
@@ -15,7 +15,8 @@ const propTypes = {
     publishedSubmissions: PropTypes.array,
     endDate: PropTypes.string,
     dateType: PropTypes.string,
-    isDabs: PropTypes.bool
+    isDabs: PropTypes.bool,
+    selectedAgency: PropTypes.string
 };
 
 const defaultProps = {
@@ -24,7 +25,8 @@ const defaultProps = {
     publishedSubmissions: [],
     endDate: '',
     dateType: '',
-    isDabs: true
+    isDabs: true,
+    selectedAgency: ''
 };
 
 export default class SubmissionTypeField extends React.Component {
@@ -97,6 +99,22 @@ export default class SubmissionTypeField extends React.Component {
                 certifiableCSS = 'disabled';
                 disabled = true;
             }
+        }
+
+        if (this.props.selectedAgency === 'TFVA') {
+            warningBanner = (
+                <div className="alert alert-warning text-left row" role="alert">
+                    <div className="col-xs-1">
+                        <FontAwesomeIcon icon="exclamation-triangle" />
+                    </div>
+                    <div className="col-xs-11">
+                        <h3>This agency cannot create publishable submissions.</h3>
+                        <p>This agency is only used to create test FABS submissions.</p>
+                    </div>
+                </div>
+            );
+            certifiableCSS = 'disabled';
+            disabled = true;
         }
 
         const testSubText = this.props.isDabs ? 'published or certified' : 'published';

--- a/src/js/components/uploadFabsFile/UploadFabsFileMeta.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileMeta.jsx
@@ -305,7 +305,8 @@ export default class UploadFabsFileMeta extends React.Component {
                                             <SubmissionTypeField
                                                 onChange={this.handleSubmissionTypeChange}
                                                 value={this.state.submissionType}
-                                                isDabs={false} />
+                                                isDabs={false}
+                                                selectedAgency={this.state.agency} />
                                         </CSSTransition>
                                     )}
                                 </TransitionGroup>


### PR DESCRIPTION
**High level description:**

Preventing upload of publishable FABS for sub tier agency TFVA

**Technical details:**

The backend also prevents this subtier from making publishable submissions but this is a better user experience overall and adds another layer of security.

**Link to JIRA Ticket:**

[DEV-10922](https://federal-spending-transparency.atlassian.net/browse/DEV-10922)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed