### PR TITLE
Day Picker Fixes

### DIFF
--- a/src/_scss/components/datepicker/_calendar-range-datepicker.scss
+++ b/src/_scss/components/datepicker/_calendar-range-datepicker.scss
@@ -15,6 +15,7 @@
             .rdp-months {
                 justify-content: space-between;
                 max-width: 100%;
+                gap: 0;
 
                 .rdp-nav {
                     width: 100%;

--- a/src/js/components/SharedComponents/CalendarRangeDatePicker.jsx
+++ b/src/js/components/SharedComponents/CalendarRangeDatePicker.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { DayPicker, addToRange } from 'react-day-picker';
 
-import Moment from 'moment';
 import moment from 'moment';
 
 const propTypes = {
@@ -72,8 +71,8 @@ export default class CalendarRangeDatePicker extends React.Component {
     sendToFilters() {
         if (this.state.range.to) {
             const dates = {
-                startDate: Moment(this.state.range.from).format('MM/DD/YYYY'),
-                endDate: Moment(this.state.range.to).format('MM/DD/YYYY')
+                startDate: moment(this.state.range.from).format('MM/DD/YYYY'),
+                endDate: moment(this.state.range.to).format('MM/DD/YYYY')
             };
             this.props.onSelect(dates);
             this.setState({

--- a/src/js/components/SharedComponents/CalendarRangeDatePicker.jsx
+++ b/src/js/components/SharedComponents/CalendarRangeDatePicker.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { DayPicker, addToRange } from 'react-day-picker';
 
 import Moment from 'moment';
+import moment from 'moment';
 
 const propTypes = {
     numberOfMonths: PropTypes.number,
@@ -91,8 +92,7 @@ export default class CalendarRangeDatePicker extends React.Component {
     drawDatePicker() {
         const { minDate, maxDate } = this.props.minmaxDates;
         const disabledDays = { before: minDate, after: maxDate };
-        const defaultMonth = new Date();
-        defaultMonth.setMonth(defaultMonth.getMonth() - 1);
+        const defaultMonth = moment().subtract(1, 'months').toDate();
         if (this.props.minmaxDates.maxDate && this.props.minmaxDates.minDate) {
             return (<DayPicker
                 showOutsideDays


### PR DESCRIPTION
**High level description:**

Fixing a visual issue in Chrome and the default date when months aren't exactly 30 days

**Technical details:**

Using Moment instead of the built-in Date month subtraction because that actually works

**Link to JIRA Ticket:**

[DEV-11018](https://federal-spending-transparency.atlassian.net/browse/DEV-11018)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [ ] Frontend review completed