### PR TITLE
DEV-11275: Default date picker

### DIFF
--- a/src/js/components/generateFiles/components/DatePicker.jsx
+++ b/src/js/components/generateFiles/components/DatePicker.jsx
@@ -39,6 +39,7 @@ export default class DatePicker extends React.Component {
 
         this.state = {
             inputValue: '',
+            calendarMonth: moment().toDate(),
             showDatePicker: false
         };
 
@@ -46,6 +47,7 @@ export default class DatePicker extends React.Component {
         this.handleTypedDate = this.handleTypedDate.bind(this);
         this.handleDateBlur = this.handleDateBlur.bind(this);
         this.handleDateFocus = this.handleDateFocus.bind(this);
+        this.handleMonthChange = this.handleMonthChange.bind(this);
     }
 
     componentDidMount() {
@@ -62,10 +64,18 @@ export default class DatePicker extends React.Component {
     // convert the date to something typeable
         if (this.props.value !== null) {
             const inputValue = this.props.value.format('MM/DD/YYYY');
+            const calendarMonth = this.props.value.toDate();
             this.setState({
-                inputValue
+                inputValue,
+                calendarMonth
             });
         }
+    }
+
+    handleMonthChange(newMonth) {
+        this.setState({
+            calendarMonth: newMonth
+        });
     }
 
     toggleDatePicker(e) {
@@ -234,11 +244,12 @@ export default class DatePicker extends React.Component {
                         this.datepicker = c;
                     }}>
                     <DayPicker
-                        initialMonth={pickedDay}
+                        month={this.state.calendarMonth}
                         disabled={disabledDays}
                         selected={pickedDay}
                         mode="single"
                         onDayClick={this.handleDatePick}
+                        onMonthChange={this.handleMonthChange}
                         onFocus={this.handleDateFocus}
                         onBlur={this.handleDateBlur} />
                 </div>


### PR DESCRIPTION
**High level description:**

Fixing the month that shows up in the picker

**Technical details:**

The default month sticks after the first instantiation even if the prop changes so we have to use a function and the month prop instead.

**Link to JIRA Ticket:**

[DEV-11275](https://federal-spending-transparency.atlassian.net/browse/DEV-11275)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- Verified cross-browser compatibility
- Verified mobile/tablet/desktop/monitor responsiveness
- Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- Design review completed
- [x] Frontend review completed