### PR TITLE
DEV-11912: Remove Oudated Sample File Links

### DIFF
--- a/src/js/components/addData/SubmissionGuideContent.jsx
+++ b/src/js/components/addData/SubmissionGuideContent.jsx
@@ -95,33 +95,9 @@ export default class SubmissionGuideContent extends React.Component {
                                         .txt UTF-8 file formats.
                                         </p>
                                         <ul>
-                                            <li>File A: Appropriation Account data.
-                                                <a
-                                                    href={`${kGlobalConstants.PUBLIC_FILES}appropValid.csv`}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    data-reactid=".0.0.1.0.0.0.1.1.1.0">
-                                                    (Sample file)
-                                                </a>
-                                            </li>
-                                            <li>File B: Object Class and Program Activity.
-                                                <a
-                                                    href={`${kGlobalConstants.PUBLIC_FILES}programActivityValid.csv`}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    data-reactid=".0.0.1.0.0.0.1.2.1.0">
-                                                    (Sample file)
-                                                </a>
-                                            </li>
-                                            <li>File C: Award Financial data.
-                                                <a
-                                                    href={`${kGlobalConstants.PUBLIC_FILES}awardFinancialValid.csv`}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    data-reactid=".0.0.1.0.0.0.1.3.1.0">
-                                                    (Sample file)
-                                                </a>
-                                            </li>
+                                            <li>File A: Appropriation Account data.</li>
+                                            <li>File B: Object Class and Program Activity.</li>
+                                            <li>File C: Award Financial data.</li>
                                         </ul>
                                         <p>
                                             <strong>
@@ -130,15 +106,7 @@ export default class SubmissionGuideContent extends React.Component {
                                         </p>
                                         <ul>
                                             <li>File D1: Award and Awardee Attributes (Procurement Award) data.</li>
-                                            <li>File D2: Award and Awardee Attributes (Financial Assistance) data.
-                                                <a
-                                                    href={`${kGlobalConstants.PUBLIC_FILES}awardValid.csv`}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    data-reactid=".0.0.1.0.0.0.1.4.1.0">
-                                                    (Sample file)
-                                                </a>
-                                            </li>
+                                            <li>File D2: Award and Awardee Attributes (Financial Assistance) data.</li>
                                             <li>File E: Additional Awardee Attributes data.</li>
                                             <li>File F: Sub-award Attributes data.</li>
                                         </ul>


### PR DESCRIPTION
**High level description:**

Instead of updating the outdated sample file links, we are removing them instead given the GSDM link below includes all the updated sample files.

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-11912](https://federal-spending-transparency.atlassian.net/browse/DEV-11912)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [ ] Frontend review completed