### PR TITLE
[DEV-12933] FABS Revalidation/Reupload Issue

### DIFF
--- a/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
+++ b/src/js/components/uploadFabsFile/UploadFabsFileValidation.jsx
@@ -77,6 +77,9 @@ const UploadFabsFileValidation = (props) => {
         return () => {
             props.resetSubmission();
             setIsUnMounted(true);
+            if (dataTimer.current) {
+                window.clearInterval(dataTimer.current);
+            }
         };
     }, []);
 
@@ -145,10 +148,6 @@ const UploadFabsFileValidation = (props) => {
                 });
         }
     }, [signInProgress]);
-
-    useEffect(() => {
-        return () => window.clearInterval(dataTimer.current);
-    }, []);
 
     const setSubmissionMetadata = (submissionID) => {
         setInFlight(true);


### PR DESCRIPTION
**High level description:**

This resolves an issue with the FABS re-upload, re-validate, publish processes where it wouldn't redraw and `check_status` correctly. 

**Technical details:**

Uses useState for isUnMounted and useRef for dataTimer

**Link to JIRA Ticket:**

[DEV-12933](https://federal-spending-transparency.atlassian.net/browse/DEV-12933)

**Mockup**
N/A

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Tested locally and on sandbox 

Reviewer(s):
- [x] Frontend review completed

[DEV-12933]: https://federal-spending-transparency.atlassian.net/browse/DEV-12933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ