### PR TITLE
[DEV-13135] Logging In Screen Confusion Bug

### DIFF
--- a/src/js/containers/AppContainer.jsx
+++ b/src/js/containers/AppContainer.jsx
@@ -64,7 +64,7 @@ export default class AppContainer extends React.Component {
                         appReady: true
                     });
                 });
-        };
+        }
     }
 
     checkCookies() {


### PR DESCRIPTION
**High level description:**

The logging-in screen after CAIA flips back to the login page for a second confusing the user while it should be saying "logging in". This resolves that and reinstates the "logging in" prompt for a second before redirected to home page.

**Technical details:**

This is due to `v1/active_user` being called on every page *in addition to the page that's logging in causing the user to be 'logged out' for a brief moment while the `/v1/caia_login` endpoint is logging them in successfully*. The solution simply prevents `/v1/active_user` being called on the `auth` page in addition to the one being called upon a successful login.

**Link to JIRA Ticket:**

[DEV-13135](https://federal-spending-transparency.atlassian.net/browse/DEV-13135)

**Mockup**
N/A

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)
- [x] Tested locally and on sandbox with slow 3G and no throttling

Reviewer(s):
- [x] Design review completed
- [ ] Frontend review completed

[DEV-13135]: https://federal-spending-transparency.atlassian.net/browse/DEV-13135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ