### PR TITLE
[DEV-15408] webpack devtool to 'source-map' for prod

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -24,7 +24,7 @@ module.exports = {
         splitChunks: { chunks: 'all' },
         moduleIds: 'deterministic' // so that file hashes don't change unexpectedly
     },
-    devtool: "source-map",
+    devtool: "eval-cheap-source-map",
     module: {
         rules: [
             {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -24,7 +24,7 @@ module.exports = {
         splitChunks: { chunks: 'all' },
         moduleIds: 'deterministic' // so that file hashes don't change unexpectedly
     },
-    devtool: "eval-cheap-source-map",
+    devtool: "source-map",
     module: {
         rules: [
             {

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -35,6 +35,7 @@ module.exports = merge(common, {
             }
         }
     },
+    devtool: "source-map",
     module: {
         rules: [
             {


### PR DESCRIPTION
**High level description:**

Updating webpack.common.js's `devtool` from `eval-cheap-source-map` to just `source-map`.

**Technical details:**

May affect non-local deploys performance but will be more secure.

**Link to JIRA Ticket:**

[DEV-15408](https://federal-spending-transparency.atlassian.net/browse/DEV-15408)

**Mockup**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [x] Frontend review completed

[DEV-15408]: https://federal-spending-transparency.atlassian.net/browse/DEV-15408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ