### PR TITLE
[DEV-15409] DOMPurify, Sanitize Typeaheads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "d3-scale": "^4.0.2",
         "data-transparency-ui": "git+https://github.com/fedspendingtransparency/data-transparency-ui#v7.0.6",
         "date-fns": "^4.1.0",
+        "dompurify": "3.4.11",
         "ent": "^2.2.0",
         "file-loader": "^6.2.0",
         "git-revision-webpack-plugin": "^5.0.0",
@@ -8187,6 +8188,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -12733,6 +12741,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "d3-scale": "^4.0.2",
     "data-transparency-ui": "git+https://github.com/fedspendingtransparency/data-transparency-ui#v7.0.6",
     "date-fns": "^4.1.0",
+    "dompurify": "3.4.11",
     "ent": "^2.2.0",
     "file-loader": "^6.2.0",
     "git-revision-webpack-plugin": "^5.0.0",

--- a/src/js/components/SharedComponents/DropdownTypeahead.jsx
+++ b/src/js/components/SharedComponents/DropdownTypeahead.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Awesomplete from 'awesomplete';
+import DOMPurify from 'dompurify';
 import { keyCodes } from 'dataMapping/keyMappings';
 import DropdownTypeaheadCheckbox from './DropdownTypeaheadCheckbox';
 
@@ -148,8 +149,20 @@ export default class DropdownTypeahead extends React.Component {
 
     mountAwesomeplete() {
         const target = this.awesomplete;
+        const awesomepleteSettings = {
+            item: function (text, input) {
+                // Awesomplete expects it wrapped in a li
+                var li = document.createElement("li");
+                console.log('SANITIZING');
+                
+                var cleanHtml = DOMPurify.sanitize(text.label);
+                li.innerHTML = cleanHtml;
+            
+                return li;
+            }
+        }
         if (this.props.prioritySort) {
-            this.typeahead = new Awesomplete(target, {
+            awesomepleteSettings['sort'] = {
                 sort: (a, b) => {
                     if (a.value.priority > b.value.priority) {
                         return 1;
@@ -158,12 +171,10 @@ export default class DropdownTypeahead extends React.Component {
                         return -1;
                     }
                     return 0;
-                }
-            });
+                },
+            };
         }
-        else {
-            this.typeahead = new Awesomplete(target);
-        }
+        this.typeahead = new Awesomplete(target, awesomepleteSettings);
         this.typeahead.autoFirst = true;
 
         if (this.props.formatter) {

--- a/src/js/components/SharedComponents/DropdownTypeahead.jsx
+++ b/src/js/components/SharedComponents/DropdownTypeahead.jsx
@@ -153,7 +153,6 @@ export default class DropdownTypeahead extends React.Component {
             item: function (text, input) {
                 // Awesomplete expects it wrapped in a li
                 var li = document.createElement("li");
-                console.log('SANITIZING');
                 
                 var cleanHtml = DOMPurify.sanitize(text.label);
                 li.innerHTML = cleanHtml;

--- a/src/js/components/SharedComponents/DropdownTypeahead.jsx
+++ b/src/js/components/SharedComponents/DropdownTypeahead.jsx
@@ -159,7 +159,7 @@ export default class DropdownTypeahead extends React.Component {
             
                 return li;
             }
-        }
+        };
         if (this.props.prioritySort) {
             awesomepleteSettings['sort'] = {
                 sort: (a, b) => {
@@ -170,7 +170,7 @@ export default class DropdownTypeahead extends React.Component {
                         return -1;
                     }
                     return 0;
-                },
+                }
             };
         }
         this.typeahead = new Awesomplete(target, awesomepleteSettings);

--- a/src/js/components/SharedComponents/Typeahead.jsx
+++ b/src/js/components/SharedComponents/Typeahead.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Awesomplete from 'awesomplete';
+import DOMPurify from 'dompurify';
 import { keyCodes } from 'dataMapping/keyMappings';
 
 import TypeaheadWarning from './TypeaheadWarning';
@@ -84,8 +85,20 @@ export default class Typeahead extends React.Component {
 
     mountAwesomeplete() {
         const target = this.awesomplete;
+        const awesomepleteSettings = {
+            item: function (text, input) {
+                // Awesomplete expects it wrapped in a li
+                var li = document.createElement("li");
+                console.log('SANITIZING');
+                
+                var cleanHtml = DOMPurify.sanitize(text.label);
+                li.innerHTML = cleanHtml;
+            
+                return li;
+            }
+        }
         if (this.props.prioritySort) {
-            this.typeahead = new Awesomplete(target, {
+            awesomepleteSettings['sort'] = {
                 sort: (a, b) => {
                     if (a.value.priority > b.value.priority) {
                         return 1;
@@ -94,12 +107,10 @@ export default class Typeahead extends React.Component {
                         return -1;
                     }
                     return 0;
-                }
-            });
+                },
+            };
         }
-        else {
-            this.typeahead = new Awesomplete(target);
-        }
+        this.typeahead = new Awesomplete(target, awesomepleteSettings);
         this.typeahead.autoFirst = true;
 
         if (this.props.formatter) {

--- a/src/js/components/SharedComponents/Typeahead.jsx
+++ b/src/js/components/SharedComponents/Typeahead.jsx
@@ -89,7 +89,6 @@ export default class Typeahead extends React.Component {
             item: function (text, input) {
                 // Awesomplete expects it wrapped in a li
                 var li = document.createElement("li");
-                console.log('SANITIZING');
                 
                 var cleanHtml = DOMPurify.sanitize(text.label);
                 li.innerHTML = cleanHtml;

--- a/src/js/components/SharedComponents/Typeahead.jsx
+++ b/src/js/components/SharedComponents/Typeahead.jsx
@@ -95,7 +95,7 @@ export default class Typeahead extends React.Component {
             
                 return li;
             }
-        }
+        };
         if (this.props.prioritySort) {
             awesomepleteSettings['sort'] = {
                 sort: (a, b) => {
@@ -106,7 +106,7 @@ export default class Typeahead extends React.Component {
                         return -1;
                     }
                     return 0;
-                },
+                }
             };
         }
         this.typeahead = new Awesomplete(target, awesomepleteSettings);


### PR DESCRIPTION
**High level description:**

Sanitizing the typeahead values/labels before injecting into innerHTML to prevent issues.

**Technical details:**

N/A

**Link to JIRA Ticket:**

[DEV-15409](https://federal-spending-transparency.atlassian.net/browse/DEV-15409)

**Mockup**
https://invis.io/RYA3XN5WP#/273832670_Homepage_2-2_E

The following are ALL required for the PR to be merged:

Author: 
- [x] Linked to this PR in JIRA ticket
- [x] Scheduled Demo including Design/Testing/Front-end OR Provided Instructions for Local Testing above and in JIRA
- [x] Verified cross-browser compatibility
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome extension)

Reviewer(s):
- [x] Design review completed
- [ ] Frontend review completed

[DEV-15409]: https://federal-spending-transparency.atlassian.net/browse/DEV-15409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ